### PR TITLE
🔧 Restructure CI: typecheck → test → build, split publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Typecheck
+        run: yarn turbo run typecheck
+
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    needs: typecheck
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build
+        run: yarn turbo run build
+
+      - name: Test with coverage
+        run: yarn jest --coverage
+        env:
+          NODE_OPTIONS: '--experimental-vm-modules'
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Typecheck
         run: yarn turbo run typecheck
 
-  build-and-test:
-    name: Build & Test
+  test:
+    name: Test
     runs-on: ubuntu-latest
     needs: typecheck
     steps:
@@ -45,9 +45,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Build
-        run: yarn turbo run build
-
       - name: Test with coverage
         run: yarn jest --coverage
         env:
@@ -58,3 +55,24 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage/lcov.info
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build
+        run: yarn turbo run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Build devtools (tests import from dist)
+        run: yarn turbo run build --filter=@umpire/devtools
+
       - name: Test with coverage
         run: yarn jest --coverage
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,44 +1,14 @@
-name: Build, Test & Publish
+name: Publish
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
 
 jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Build
-        run: yarn turbo run build
-
-      - name: Test with coverage
-        run: yarn jest --coverage
-        env:
-          NODE_OPTIONS: '--experimental-vm-modules'
-
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coverage/lcov.info
-
   detect-version-changes:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       any_changed: ${{ steps.versions.outputs.any_changed }}
@@ -120,8 +90,8 @@ jobs:
           NODE
 
   publish:
-    needs: [build-and-test, detect-version-changes]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.detect-version-changes.outputs.any_changed == 'true'
+    needs: [detect-version-changes]
+    if: needs.detect-version-changes.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Splits and reorders the CI pipeline for clearer separation and faster feedback.

## Changes

- **New `ci.yml`** — runs on every PR and push to main
  - `typecheck` fast-fail — blocks the rest if types are broken
  - `test` job: builds `@umpire/devtools` first (its tests import from dist due to preact/react tsconfig conflict), then runs full jest suite with coverage + Coveralls
  - `build` job: full `turbo build` after tests pass
- **Renamed `publish.yml`** (was "Build, Test & Publish") — main-only, triggered via `workflow_run` on CI success so tests gate publishing