### PR TITLE
✅ Core Validation & Zod Integration Improvements

### DIFF
--- a/docs/src/components/SignupDemo.tsx
+++ b/docs/src/components/SignupDemo.tsx
@@ -55,7 +55,6 @@ const fieldSchemas = z.object({
 
 const signupValidation = createZodValidation({
   schemas: fieldSchemas.shape,
-  zod: z,
   build(baseSchema) {
     // Keep the schema-level refinement too: Umpire owns availability and
     // blocked-submit reasons, while this remains an optional final parse-time

--- a/docs/src/components/SignupDemo.tsx
+++ b/docs/src/components/SignupDemo.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { z } from 'zod'
 import { anyOf, check, disables, enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
+import type { FieldValues } from '@umpire/core'
 // useUmpireWithDevtools powers the named instance in the optional panel on this page.
 // Swap back to: import { useUmpire } from '@umpire/react'  (remove leading id arg)
 import { useUmpireWithDevtools } from '@umpire/devtools/react'
@@ -70,16 +71,14 @@ const hasValidEmail = check('email', fieldSchemas.shape.email)
 const hasStrongPassword = check('password', fieldSchemas.shape.password)
 const hasNumericCompanySize = check('companySize', fieldSchemas.shape.companySize)
 
-function allowWhenSsoOr<F extends Record<string, unknown>>(
-  predicate: (values: F, conditions: SignupConditions) => boolean,
-) {
-  return (values: F, conditions: SignupConditions) => conditions.sso || predicate(values, conditions)
+type SignupPredicate = (values: FieldValues<typeof signupFields>, conditions: SignupConditions) => boolean
+
+function allowWhenSsoOr(predicate: SignupPredicate): SignupPredicate {
+  return (values, conditions) => conditions.sso || predicate(values, conditions)
 }
 
-function allowWhenNotBusiness<F extends Record<string, unknown>>(
-  predicate: (values: F, conditions: SignupConditions) => boolean,
-) {
-  return (values: F, conditions: SignupConditions) => conditions.plan !== 'business' || predicate(values, conditions)
+function allowWhenNotBusiness(predicate: SignupPredicate): SignupPredicate {
+  return (values, conditions) => conditions.plan !== 'business' || predicate(values, conditions)
 }
 
 const signupUmp = umpire<typeof signupFields, SignupConditions>({

--- a/docs/src/components/SignupDemo.tsx
+++ b/docs/src/components/SignupDemo.tsx
@@ -1,10 +1,10 @@
-import { useState, useMemo } from 'react'
+import { useState } from 'react'
 import { z } from 'zod'
-import { anyOf, check, disables, enabledWhen, requires, umpire } from '@umpire/core'
+import { anyOf, check, disables, enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
 // useUmpireWithDevtools powers the named instance in the optional panel on this page.
 // Swap back to: import { useUmpire } from '@umpire/react'  (remove leading id arg)
 import { useUmpireWithDevtools } from '@umpire/devtools/react'
-import { activeSchema, activeErrors, zodErrors } from '@umpire/zod'
+import { createZodValidation } from '@umpire/zod'
 import { zodValidationExtension } from '@umpire/zod/devtools'
 
 // ── Known SSO domains ─────────────────────────────────────────────────────────
@@ -39,12 +39,59 @@ const signupFields = {
 type SignupConditions = { plan: 'personal' | 'business'; sso: boolean }
 type SignupField = keyof typeof signupFields
 
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+// ── Zod: per-field validation schemas ────────────────────────────────────────
+// These are the "correctness" checks. Umpire handles "should this field be
+// in play?" — Zod handles "is this value well-formed?"
+
+const fieldSchemas = z.object({
+  email: z.string().email('Enter a valid email'),
+  password: z.string().min(8, 'At least 8 characters'),
+  confirmPassword: z.string(),
+  referralCode: z.string(),
+  companyName: z.string(),
+  companySize: z.string().regex(/^\d+$/, 'Must be a number'),
+})
+
+const signupValidation = createZodValidation({
+  schemas: fieldSchemas.shape,
+  zod: z,
+  build(baseSchema) {
+    // Keep the schema-level refinement too: Umpire owns availability and
+    // blocked-submit reasons, while this remains an optional final parse-time
+    // correctness check for submit handlers and tooling.
+    return baseSchema.refine(
+      (data) => !data.confirmPassword || !data.password || data.confirmPassword === data.password,
+      { message: 'Passwords do not match', path: ['confirmPassword'] },
+    )
+  },
+})
+
+const hasValidEmail = check('email', fieldSchemas.shape.email)
+const hasStrongPassword = check('password', fieldSchemas.shape.password)
+const hasNumericCompanySize = check('companySize', fieldSchemas.shape.companySize)
+
+function allowWhenSsoOr<F extends Record<string, unknown>>(
+  predicate: (values: F, conditions: SignupConditions) => boolean,
+) {
+  return (values: F, conditions: SignupConditions) => conditions.sso || predicate(values, conditions)
+}
+
+function allowWhenNotBusiness<F extends Record<string, unknown>>(
+  predicate: (values: F, conditions: SignupConditions) => boolean,
+) {
+  return (values: F, conditions: SignupConditions) => conditions.plan !== 'business' || predicate(values, conditions)
+}
 
 const signupUmp = umpire<typeof signupFields, SignupConditions>({
   fields: signupFields,
   rules: [
     requires('confirmPassword', 'password'),
+    // Model the password/confirmation relationship structurally so Umpire can
+    // see it for fair/foul state and downstream dependency chains, independent
+    // of whether the Zod object-level refine runs on a given pass.
+    fairWhen('confirmPassword', (confirmPassword, values) => confirmPassword === values.password, {
+      reason: 'Match your password exactly',
+    }),
     enabledWhen('companyName', (_v, c) => c.plan === 'business', {
       reason: 'business plan required',
     }),
@@ -63,7 +110,7 @@ const signupUmp = umpire<typeof signupFields, SignupConditions>({
     //   Path B — SSO: the domain is a known SSO provider
     // anyOf enables submit when at least one path is satisfied.
     anyOf(
-      enabledWhen('submit', check('email', emailRegex), {
+      enabledWhen('submit', hasValidEmail, {
         reason: 'Enter a valid email address',
       }),
       enabledWhen('submit', (_v, c) => c.sso, {
@@ -71,49 +118,35 @@ const signupUmp = umpire<typeof signupFields, SignupConditions>({
       }),
     ),
 
-    // Path A also requires a password — SSO bypasses this
-    enabledWhen('submit', (v, c) => c.sso || !!v.password, {
+    // `oneOf()` does not fit here because it switches field branches, not
+    // predicate branches. These helpers keep the submit-path split readable.
+    enabledWhen('submit', allowWhenSsoOr((v) => !!v.password), {
       reason: 'Enter a password',
     }),
+    enabledWhen('submit', allowWhenSsoOr(hasStrongPassword), {
+      reason: 'Use at least 8 password characters',
+    }),
+    enabledWhen('submit', allowWhenSsoOr((v) => !!v.confirmPassword), {
+      reason: 'Confirm your password',
+    }),
+    enabledWhen('submit', allowWhenSsoOr((v) => v.confirmPassword === v.password), {
+      reason: 'Passwords must match',
+    }),
+
+    enabledWhen('submit', allowWhenNotBusiness((v) => !!v.companyName), {
+      reason: 'Enter a company name',
+    }),
+    enabledWhen('submit', allowWhenNotBusiness((v) => !!v.companySize), {
+      reason: 'Enter company size',
+    }),
+    enabledWhen('submit', allowWhenNotBusiness(hasNumericCompanySize), {
+      reason: 'Company size must be a number',
+    }),
   ],
-})
-
-// ── Zod: per-field validation schemas ────────────────────────────────────────
-// These are the "correctness" checks. Umpire handles "should this field be
-// in play?" — Zod handles "is this value well-formed?"
-
-const fieldSchemas = z.object({
-  email: z.string().email('Enter a valid email'),
-  password: z.string().min(8, 'At least 8 characters'),
-  confirmPassword: z.string().min(1, 'Confirm your password'),
-  referralCode: z.string(),
-  companyName: z.string().min(1, 'Company name is required'),
-  companySize: z.string().min(1, 'Company size is required').regex(/^\d+$/, 'Must be a number'),
+  validators: signupValidation.validators,
 })
 
 type SignupValues = ReturnType<typeof signupUmp.init>
-type SignupAvailability = ReturnType<typeof signupUmp.check>
-
-function buildSignupValidation(
-  availability: SignupAvailability,
-  values: SignupValues,
-) {
-  const baseSchema = activeSchema(availability, fieldSchemas.shape, z)
-  const schema = baseSchema
-    .refine(
-      (data) => !data.confirmPassword || !data.password || data.confirmPassword === data.password,
-      { message: 'Passwords do not match', path: ['confirmPassword'] },
-    )
-  const result = schema.safeParse(values)
-
-  return {
-    result,
-    schemaFields: Object.keys(baseSchema.shape),
-    validationErrors: result.success
-      ? {}
-      : activeErrors(availability, zodErrors(result.error)),
-  }
-}
 
 // ── Field metadata ───────────────────────────────────────────────────────────
 
@@ -154,6 +187,7 @@ export default function SignupDemo() {
   const [values, setValues] = useState(() => signupUmp.init())
   const [plan, setPlan] = useState<'personal' | 'business'>('personal')
   const [touched, setTouched] = useState<Set<string>>(new Set())
+  const [submissionIssues, setSubmissionIssues] = useState<Array<{ field: string; message: string }>>([])
 
   // SSO is derived from the email — no extra state needed
   const emailDomain = domainFromEmail(String(values.email ?? ''))
@@ -165,22 +199,15 @@ export default function SignupDemo() {
     extensions: [
       zodValidationExtension({
         resolve({ scorecard, values }) {
-          const validation = buildSignupValidation(scorecard.check, values)
-
-          return {
-            result: validation.result,
-            schemaFields: validation.schemaFields,
-          }
+          return signupValidation.run(scorecard.check, values)
         },
       }),
     ],
   })
-  const validationErrors = useMemo(
-    () => buildSignupValidation(availability, values).validationErrors,
-    [availability, values],
-  )
 
   function updateValue(field: SignupField, nextValue: string) {
+    setSubmissionIssues([])
+
     if (field === 'email') {
       const domain = domainFromEmail(nextValue)
       const company = domain ? (knownDomains[domain] ?? null) : null
@@ -205,6 +232,7 @@ export default function SignupDemo() {
   }
 
   function applyResets() {
+    setSubmissionIssues([])
     setValues((current) => {
       const next = { ...current }
       for (const foul of fouls) {
@@ -212,6 +240,11 @@ export default function SignupDemo() {
       }
       return next
     })
+  }
+
+  function submit() {
+    const result = signupValidation.run(availability, values)
+    setSubmissionIssues(result.normalizedErrors)
   }
 
   const canSubmit = availability.submit.enabled
@@ -266,7 +299,10 @@ export default function SignupDemo() {
                     'umpire-demo__plan-option',
                     plan === option.value && 'umpire-demo__plan-option--active',
                   )}
-                  onClick={() => setPlan(option.value)}
+                  onClick={() => {
+                    setSubmissionIssues([])
+                    setPlan(option.value)
+                  }}
                 >
                   {option.label}
                 </button>
@@ -278,7 +314,9 @@ export default function SignupDemo() {
                 const meta = fieldMeta[field]
                 const av = availability[field]
                 const isEnabled = av.enabled
-                const error = touched.has(field) ? validationErrors[field] : undefined
+                const error = isEnabled && touched.has(field)
+                  ? av.error ?? (av.fair === false ? av.reason : undefined)
+                  : undefined
 
                 return (
                   <div
@@ -318,14 +356,18 @@ export default function SignupDemo() {
 
             <button
               type="button"
+              disabled={!canSubmit}
               className={cls(
                 'signup-demo__submit',
                 canSubmit ? 'signup-demo__submit--ready' : 'signup-demo__submit--blocked',
               )}
-              disabled={!canSubmit}
+              onClick={submit}
             >
               {sso ? `Continue with SSO` : `Create account`}
             </button>
+            {!canSubmit && availability.submit.reason && (
+              <div className="signup-demo__reason">{availability.submit.reason}</div>
+            )}
           </div>
         </section>
 
@@ -354,7 +396,9 @@ export default function SignupDemo() {
                 <tbody>
                   {tableOrder.map((field) => {
                     const av = availability[field]
-                    const error = field !== 'submit' ? validationErrors[field] : undefined
+                    const error = field !== 'submit' && av.enabled
+                      ? av.error ?? (av.fair === false ? av.reason : undefined)
+                      : undefined
 
                     return (
                       <tr key={field} className={field === 'submit' ? 'signup-demo__table-row--submit' : undefined}>
@@ -405,6 +449,24 @@ export default function SignupDemo() {
           </div>
         </section>
       </div>
+
+      {submissionIssues.length > 0 && (
+        <div className="umpire-demo__fouls">
+          <div className="umpire-demo__fouls-copy">
+            <div className="umpire-demo__fouls-kicker">Submit validation</div>
+            <div className="umpire-demo__fouls-list">
+              {submissionIssues.map((issue) => (
+                <div key={`${issue.field}:${issue.message}`} className="umpire-demo__foul">
+                  <span className="umpire-demo__foul-field">
+                    {fieldMeta[issue.field as SignupField]?.label ?? issue.field}
+                  </span>
+                  <span className="umpire-demo__foul-reason">{issue.message}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/docs/src/content/docs/adapters/zod.md
+++ b/docs/src/content/docs/adapters/zod.md
@@ -15,7 +15,7 @@ yarn add @umpire/core @umpire/zod zod
 
 ## API
 
-### `activeSchema(availability, shape, z)`
+### `activeSchema(availability, shape)`
 
 Builds a `z.object()` from the availability map:
 
@@ -34,7 +34,7 @@ const fieldSchemas = {
 }
 
 const availability = ump.check(values, conditions)
-const schema = activeSchema(availability, fieldSchemas, z)
+const schema = activeSchema(availability, fieldSchemas)
 const result = schema.safeParse(values)
 ```
 
@@ -47,10 +47,10 @@ const myFormSchema = z.object({
 })
 
 // ✗ Wrong — activeSchema expects a shape, not a z.object()
-activeSchema(availability, myFormSchema, z)
+activeSchema(availability, myFormSchema)
 
 // ✓ Correct
-activeSchema(availability, myFormSchema.shape, z)
+activeSchema(availability, myFormSchema.shape)
 ```
 
 `activeSchema` throws a descriptive error if it detects a Zod object was passed instead of its shape.
@@ -82,7 +82,7 @@ const errors = activeErrors(availability, zodErrors(result.error))
 Cross-field refinements chain normally on the result of `activeSchema`:
 
 ```ts
-const schema = activeSchema(availability, fieldSchemas, z)
+const schema = activeSchema(availability, fieldSchemas)
   .refine(
     (data) => !data.confirmPassword || !data.password
       || data.confirmPassword === data.password,

--- a/docs/src/content/docs/adapters/zod.md
+++ b/docs/src/content/docs/adapters/zod.md
@@ -77,6 +77,32 @@ const errors = activeErrors(availability, zodErrors(result.error))
 // companyName omitted if disabled on the current plan
 ```
 
+## Blank strings and `isEmpty`
+
+`@umpire/zod` follows Umpire's satisfaction rules. By default, only `null` and
+`undefined` count as empty. So if a field does not define `isEmpty`, an empty
+string is still considered satisfied and can surface `valid: false` from
+`validators` immediately.
+
+For form-style string inputs, use an explicit empty-state helper:
+
+```ts
+import { isEmptyString, umpire } from '@umpire/core'
+
+const ump = umpire({
+  fields: {
+    email: { required: true, isEmpty: isEmptyString },
+  },
+  rules: [],
+  validators: createZodValidation({
+    schemas: { email: z.string().email('Enter a valid email') },
+  }).validators,
+})
+```
+
+That keeps blank strings in the "not yet validateable" lane until the field is
+actually satisfied under your chosen emptiness rule.
+
 ## Chaining refinements
 
 Cross-field refinements chain normally on the result of `activeSchema`:

--- a/docs/src/content/docs/api/check.md
+++ b/docs/src/content/docs/api/check.md
@@ -30,6 +30,8 @@ type FieldStatus = {
   required: boolean
   reason: string | null
   reasons: string[]
+  valid?: boolean
+  error?: string
 }
 
 type AvailabilityMap<F extends Record<string, FieldDef>> = {

--- a/docs/src/content/docs/api/scorecard.md
+++ b/docs/src/content/docs/api/scorecard.md
@@ -59,6 +59,8 @@ type ScorecardField<F> = {
   required: boolean
   reason: string | null
   reasons: string[]
+  valid?: boolean
+  error?: string
 
   // Transition
   changed: boolean       // this field's value differs from before

--- a/docs/src/content/docs/concepts/validation.md
+++ b/docs/src/content/docs/concepts/validation.md
@@ -18,6 +18,27 @@ This page shows how to compose Umpire with validation libraries like Zod, Yup, o
 
 The handoff point is `check()`. It wraps a validator into something Umpire can use as a rule source, without Umpire taking ownership of validation logic.
 
+Validation still follows Umpire's satisfaction semantics. By default, only
+`null` and `undefined` are treated as empty. That means `''` is considered
+present and satisfied unless the field defines `isEmpty`.
+
+If you want blank strings to behave like "not yet validateable" form input, give
+the field an explicit empty-state rule:
+
+```ts
+import { isEmptyString } from '@umpire/core'
+
+const ump = umpire({
+  fields: {
+    email: { required: true, isEmpty: isEmptyString },
+  },
+  rules: [],
+})
+```
+
+Without that, a field can be `satisfied: true` and `valid: false` at the same
+time, which is often the right result for non-empty invalid input.
+
 ## `check()` is the bridge
 
 `check(field, validator)` creates a predicate that Umpire can use inside `requires()`, `enabledWhen()`, or `disables()`. The validator runs against the field's current value and returns a boolean.

--- a/docs/src/content/docs/examples/signup.mdx
+++ b/docs/src/content/docs/examples/signup.mdx
@@ -151,7 +151,7 @@ const availability = signupUmp.check(values, { plan, sso })
 // Build a Zod schema that only validates enabled fields.
 // Enabled + required → base schema. Enabled + optional → .optional().
 // Disabled → excluded entirely.
-const schema = activeSchema(availability, fieldSchemas.shape, z)
+const schema = activeSchema(availability, fieldSchemas.shape)
   .refine(
     (data) => !data.confirmPassword || !data.password
       || data.confirmPassword === data.password,

--- a/docs/src/content/docs/examples/signup.mdx
+++ b/docs/src/content/docs/examples/signup.mdx
@@ -11,14 +11,28 @@ import SignupDemo from '../../../components/SignupDemo.tsx'
   <SignupDemo client:load />
 </div>
 
-This demo composes two layers: **Umpire** decides which fields are available (enabled, required, or due for cleanup), and **Zod** validates the enabled ones. The two layers are authored independently — Umpire rules don't reference Zod, and Zod schemas don't reference Umpire. They compose at the call site through [`@umpire/zod`](/umpire/adapters/zod/), a thin adapter that builds a dynamic Zod schema from the availability map.
+This demo composes two layers: **Umpire** decides which fields are available, required, fair, or due for cleanup, and **Zod** handles value correctness for the fields that are in play. The button state and the primary user-facing reasons come from Umpire's relationship model; a submit handler can still run a final Zod pass in userland when you want a schema issue summary.
 
 Try typing `bob@acme.com` — the form recognizes the domain as an SSO provider, flips to the business plan, fills in the company name, and disables the password fields entirely.
 
 ## The Availability Rules
 
+Assume the `fieldSchemas` object from the validation section below is already defined. The submit rules reuse those same field schemas through `check()` anywhere the logic is just “is this value well-formed?”
+
 ```ts
-import { anyOf, check, disables, enabledWhen, requires, umpire } from '@umpire/core'
+import { anyOf, check, disables, enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
+
+const hasValidEmail = check('email', fieldSchemas.shape.email)
+const hasStrongPassword = check('password', fieldSchemas.shape.password)
+const hasNumericCompanySize = check('companySize', fieldSchemas.shape.companySize)
+
+function allowWhenSsoOr(predicate) {
+  return (values, conditions) => conditions.sso || predicate(values, conditions)
+}
+
+function allowWhenNotBusiness(predicate) {
+  return (values, conditions) => conditions.plan !== 'business' || predicate(values, conditions)
+}
 
 const signupUmp = umpire({
   fields: {
@@ -32,6 +46,9 @@ const signupUmp = umpire({
   },
   rules: [
     requires('confirmPassword', 'password'),
+    fairWhen('confirmPassword', (confirmPassword, values) => confirmPassword === values.password, {
+      reason: 'Match your password exactly',
+    }),
     enabledWhen('companyName', (_v, c) => c.plan === 'business', {
       reason: 'business plan required',
     }),
@@ -47,7 +64,7 @@ const signupUmp = umpire({
 
     // Submit is available via EITHER path — anyOf enables it when at least one passes
     anyOf(
-      enabledWhen('submit', check('email', /^[^\s@]+@[^\s@]+\.[^\s@]+$/), {
+      enabledWhen('submit', hasValidEmail, {
         reason: 'Enter a valid email address',
       }),
       enabledWhen('submit', (_v, c) => c.sso, {
@@ -55,17 +72,37 @@ const signupUmp = umpire({
       }),
     ),
 
-    // Path A (standard auth) also requires a password — SSO bypasses this
-    enabledWhen('submit', (v, c) => c.sso || !!v.password, {
+    // `oneOf()` is not the right fit here because it selects field branches,
+    // not predicate branches. These helpers keep the path gating readable.
+    enabledWhen('submit', allowWhenSsoOr((v) => !!v.password), {
       reason: 'Enter a password',
+    }),
+    enabledWhen('submit', allowWhenSsoOr(hasStrongPassword), {
+      reason: 'Use at least 8 password characters',
+    }),
+    enabledWhen('submit', allowWhenSsoOr((v) => !!v.confirmPassword), {
+      reason: 'Confirm your password',
+    }),
+    enabledWhen('submit', allowWhenSsoOr((v) => v.confirmPassword === v.password), {
+      reason: 'Passwords must match',
+    }),
+
+    enabledWhen('submit', allowWhenNotBusiness((v) => !!v.companyName), {
+      reason: 'Enter a company name',
+    }),
+    enabledWhen('submit', allowWhenNotBusiness((v) => !!v.companySize), {
+      reason: 'Enter company size',
+    }),
+    enabledWhen('submit', allowWhenNotBusiness(hasNumericCompanySize), {
+      reason: 'Company size must be a number',
     }),
   ],
 })
 ```
 
-`confirmPassword` waits for `password`. Company fields gate on the business plan. Company size waits for company name. When a field is disabled, Umpire suppresses `required` to `false` — a validation library should never complain about a field that isn't in play.
+`confirmPassword` waits for `password`, and `fairWhen()` gives it a direct mismatch reason without disabling it. Company fields gate on the business plan. Company size waits for company name. The value-shape checks for email, password strength, and numeric company size are reused directly from the Zod field schemas instead of being rewritten by hand. When a field is disabled, Umpire suppresses `required` to `false` — a validation library should never complain about a field that isn't in play.
 
-The `submit` field ties the paths together. `anyOf` expresses OR-logic: submit is available if the standard auth path OR the SSO path is satisfied. The separate `enabledWhen` for password applies to both — but because it guards on `c.sso || !!v.password`, it passes on the SSO path without needing a password.
+The `submit` field ties the paths together. `anyOf` expresses OR-logic: submit is available if the standard auth path OR the SSO path is satisfied. The extra `enabledWhen` rules keep submit blocked until the active path has everything it needs, including password confirmation and business-only fields.
 
 ## The SSO Conditions
 
@@ -95,14 +132,14 @@ import { z } from 'zod'
 const fieldSchemas = z.object({
   email: z.string().email('Enter a valid email'),
   password: z.string().min(8, 'At least 8 characters'),
-  confirmPassword: z.string().min(1, 'Confirm your password'),
+  confirmPassword: z.string(),
   referralCode: z.string(),
-  companyName: z.string().min(1, 'Company name is required'),
-  companySize: z.string().min(1, 'Company size is required').regex(/^\d+$/, 'Must be a number'),
+  companyName: z.string(),
+  companySize: z.string().regex(/^\d+$/, 'Must be a number'),
 })
 ```
 
-These are pure correctness checks — is the email well-formed, is the password long enough, is company size a number. They say nothing about whether a field should be visible or required. That's Umpire's job. `submit` is not in this schema — it has no value to validate, only availability.
+These are value-shape checks — is the email well-formed, is the password long enough, is company size numeric. They do not own requiredness or submit availability. That's Umpire's job. `submit` is not in this schema — it has no value to validate, only availability.
 
 ## Composing Them
 
@@ -146,7 +183,9 @@ The entire form is one loop. No branching per field, no special cases for SSO, n
 ```tsx
 {fieldOrder.map((field) => {
   const av = availability[field]
-  const error = touched.has(field) ? validationErrors[field] : undefined
+  const error = av.enabled && touched.has(field)
+    ? av.error ?? (av.fair === false ? av.reason : undefined)
+    : undefined
 
   return (
     <div className={cls('field', !av.enabled && 'field--disabled')}>
@@ -169,19 +208,22 @@ The entire form is one loop. No branching per field, no special cases for SSO, n
 <button disabled={!availability.submit.enabled}>
   {sso ? 'Continue with SSO' : 'Create account'}
 </button>
+{!availability.submit.enabled && availability.submit.reason && (
+  <div className="reason">{availability.submit.reason}</div>
+)}
 ```
 
-Availability, validation, required markers, disabled states, inline errors — all derived from two objects (`availability` and `validationErrors`) that update together. The SSO condition changes the availability map, and the render loop reads it without knowing about SSO directly.
+Availability, required markers, disabled states, inline feedback, and blocked-submit reasons all come from `availability`. Zod just fills `FieldStatus.error` when a field-local validator runs, while structural feedback like password mismatch comes from Umpire's own `reason`.
 
 ## What Happens When You Interact
 
 **Personal plan** — company fields are disabled by Umpire. Zod never sees them. No validation errors for fields that aren't in play.
 
-**Business plan** — company fields enable. `companyName` becomes required, and Zod validates it's non-empty. `companySize` must be digits only.
+**Business plan** — company fields enable. Umpire keeps submit blocked until the company fields are filled, and Zod still checks that `companySize` is digits only.
 
 **Type a known domain** (e.g. `bob@acme.com`) — SSO condition activates. Plan flips to business. Company name fills automatically. Password fields disable via `disables()`. `anyOf` switches to the SSO path — submit no longer needs a password, just an email.
 
-**Switch plans with stale values** — `play()` recommends clearing company fields. Apply resets and the validation errors disappear with the values.
+**Switch plans with stale values** — `play()` recommends clearing company fields. Apply resets and any stale submit or validation issues disappear with the values.
 
 **Typed a password before SSO kicked in** — `play()` flags the now-disabled password fields as fouls and recommends clearing them.
 
@@ -193,6 +235,6 @@ Availability, validation, required markers, disabled states, inline errors — a
 | Which submit path is valid? | Umpire `anyOf` | Password auth OR SSO — whichever path satisfies |
 | Is this value well-formed? | Zod | `email` must match a pattern |
 | What should reset after a transition? | Umpire `play()` | Password fields flagged when SSO activates |
-| Should we show this validation error? | `@umpire/zod` | Only for enabled fields |
+| Do we want a final submit-time schema pass? | Userland | Run Zod on button click and show a summary if desired |
 
 See [Composing with Validation](/umpire/concepts/validation/) for the full patterns, including dynamic schema building and the `check()` bridge for gating availability on validity.

--- a/packages/core/__tests__/rules.test.ts
+++ b/packages/core/__tests__/rules.test.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals'
 import { field } from '../src/field.js'
+import { isNamedCheck } from '../src/validation.js'
 import {
   anyOf,
   check,
@@ -10,7 +11,6 @@ import {
   getNamedCheckMetadata,
   inspectPredicate,
   inspectRule,
-  isNamedCheck,
   oneOf,
   requires,
 } from '../src/rules.js'

--- a/packages/core/__tests__/validation.test.ts
+++ b/packages/core/__tests__/validation.test.ts
@@ -1,0 +1,219 @@
+import { enabledWhen } from '../src/rules.js'
+import { umpire } from '../src/umpire.js'
+
+describe('surface validation metadata', () => {
+  test.each([
+    [
+      'function',
+      (value: string) => value === 'ok',
+    ],
+    [
+      'named check',
+      {
+        __check: 'equalsOk',
+        validate: (value: string) => value === 'ok',
+      },
+    ],
+    [
+      'safeParse',
+      {
+        safeParse: (value: unknown) => ({ success: value === 'ok' }),
+      },
+    ],
+    [
+      'test',
+      {
+        test: (value: string) => value === 'ok',
+      },
+    ],
+  ])('supports %s validator shapes in validators config', (_label, validator) => {
+    const ump = umpire({
+      fields: {
+        alpha: { required: true, isEmpty: (value: unknown) => !value },
+      },
+      rules: [],
+      validators: {
+        alpha: validator,
+      },
+    })
+
+    expect(ump.check({ alpha: 'ok' }).alpha).toMatchObject({
+      enabled: true,
+      fair: true,
+      required: true,
+      valid: true,
+    })
+
+    expect(ump.check({ alpha: 'nope' }).alpha).toMatchObject({
+      enabled: true,
+      fair: true,
+      required: true,
+      valid: false,
+    })
+    expect(ump.check({ alpha: 'nope' }).alpha.error).toBeUndefined()
+  })
+
+  test('surfaces configured validation errors for failing validators', () => {
+    const ump = umpire({
+      fields: {
+        email: { required: true, isEmpty: (value: unknown) => !value },
+      },
+      rules: [],
+      validators: {
+        email: {
+          validator: {
+            safeParse: (value: unknown) => ({ success: value === 'ok@example.com' }),
+          },
+          error: 'Must be a valid email address',
+        },
+      },
+    })
+
+    expect(ump.check({ email: 'bad' }).email).toMatchObject({
+      enabled: true,
+      fair: true,
+      required: true,
+      valid: false,
+      error: 'Must be a valid email address',
+    })
+    expect(ump.check({ email: 'ok@example.com' }).email).toMatchObject({
+      valid: true,
+    })
+    expect(ump.check({ email: 'ok@example.com' }).email.error).toBeUndefined()
+  })
+
+  test('skips validation metadata for disabled fields', () => {
+    const ump = umpire({
+      fields: {
+        companyName: { required: true, isEmpty: (value: unknown) => !value },
+      },
+      rules: [
+        enabledWhen('companyName', (_values, conditions: { plan?: string }) => conditions.plan === 'business', {
+          reason: 'business plan required',
+        }),
+      ],
+      validators: {
+        companyName: {
+          validator: (value: string) => value.length > 0,
+          error: 'Company name is required',
+        },
+      },
+    })
+
+    const result = ump.check({ companyName: 'Acme' }, { plan: 'personal' })
+
+    expect(result.companyName).toMatchObject({
+      enabled: false,
+      fair: true,
+      required: false,
+      reason: 'business plan required',
+    })
+    expect(result.companyName.valid).toBeUndefined()
+    expect(result.companyName.error).toBeUndefined()
+  })
+
+  test('skips validation metadata until a field has a satisfied value', () => {
+    const ump = umpire({
+      fields: {
+        password: { required: true, isEmpty: (value: unknown) => !value },
+      },
+      rules: [],
+      validators: {
+        password: {
+          validator: (value: string) => value.length >= 8,
+          error: 'At least 8 characters',
+        },
+      },
+    })
+
+    const result = ump.check({ password: '' })
+
+    expect(result.password).toMatchObject({
+      enabled: true,
+      fair: true,
+      required: true,
+    })
+    expect(result.password.valid).toBeUndefined()
+    expect(result.password.error).toBeUndefined()
+  })
+
+  test('treats string-test validators as invalid for non-string values', () => {
+    const ump = umpire({
+      fields: {
+        age: {},
+      },
+      rules: [],
+      validators: {
+        age: {
+          test: (value: string) => value.length > 0,
+        },
+      },
+    })
+
+    expect(ump.check({ age: 42 }).age).toMatchObject({
+      enabled: true,
+      fair: true,
+      required: false,
+      valid: false,
+    })
+    expect(ump.check({ age: 42 }).age.error).toBeUndefined()
+  })
+
+  test('mirrors validation metadata into scorecard fields', () => {
+    const ump = umpire({
+      fields: {
+        email: { required: true, isEmpty: (value: unknown) => !value },
+      },
+      rules: [],
+      validators: {
+        email: {
+          validator: {
+            safeParse: (value: unknown) => ({ success: value === 'ok@example.com' }),
+          },
+          error: 'Must be a valid email address',
+        },
+      },
+    })
+
+    const card = ump.scorecard({
+      values: {
+        email: 'bad',
+      },
+    })
+
+    expect(card.check.email).toMatchObject({
+      valid: false,
+      error: 'Must be a valid email address',
+    })
+    expect(card.fields.email).toMatchObject({
+      valid: false,
+      error: 'Must be a valid email address',
+    })
+  })
+
+  test('throws for validator config that references an unknown field', () => {
+    expect(() => umpire({
+      fields: {
+        alpha: {},
+      },
+      rules: [],
+      validators: {
+        beta: (value: unknown) => value === 'ok',
+      } as never,
+    })).toThrow('[umpire] Unknown field "beta" referenced by validators')
+  })
+
+  test('throws for invalid validator config shapes', () => {
+    expect(() => umpire({
+      fields: {
+        alpha: {},
+      },
+      rules: [],
+      validators: {
+        alpha: {
+          validator: { nope: true },
+        },
+      } as never,
+    })).toThrow('[umpire] Invalid validator configured for field "alpha"')
+  })
+})

--- a/packages/core/__tests__/validation.test.ts
+++ b/packages/core/__tests__/validation.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals'
 import { enabledWhen } from '../src/rules.js'
 import { umpire } from '../src/umpire.js'
 
@@ -80,6 +81,71 @@ describe('surface validation metadata', () => {
       valid: true,
     })
     expect(ump.check({ email: 'ok@example.com' }).email.error).toBeUndefined()
+  })
+
+  test('supports validators that return normalized validation results', () => {
+    const ump = umpire({
+      fields: {
+        username: { required: true, isEmpty: (value: unknown) => !value },
+      },
+      rules: [],
+      validators: {
+        username: (value: string) => value === 'doug'
+          ? { valid: true }
+          : { valid: false, error: 'Username is taken' },
+      },
+    })
+
+    expect(ump.check({ username: 'doug' }).username).toMatchObject({
+      valid: true,
+    })
+    expect(ump.check({ username: 'alice' }).username).toMatchObject({
+      valid: false,
+      error: 'Username is taken',
+    })
+  })
+
+  test('uses wrapped validation errors as a fallback for normalized validator results', () => {
+    const ump = umpire({
+      fields: {
+        username: { required: true, isEmpty: (value: unknown) => !value },
+      },
+      rules: [],
+      validators: {
+        username: {
+          validator: (value: string) => ({ valid: value === 'doug' }),
+          error: 'Username is invalid',
+        },
+      },
+    })
+
+    expect(ump.check({ username: 'alice' }).username).toMatchObject({
+      valid: false,
+      error: 'Username is invalid',
+    })
+  })
+
+  test('warns in development when a validation function returns an unsupported result', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const ump = umpire({
+        fields: {
+          username: { required: true, isEmpty: (value: unknown) => !value },
+        },
+        rules: [],
+        validators: {
+          username: (() => undefined) as never,
+        },
+      })
+
+      expect(ump.check({ username: 'doug' }).username).toMatchObject({
+        valid: false,
+      })
+      expect(warn).toHaveBeenCalledTimes(1)
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   test('skips validation metadata for disabled fields', () => {

--- a/packages/core/src/dev.ts
+++ b/packages/core/src/dev.ts
@@ -1,0 +1,4 @@
+export function shouldWarnInDev(): boolean {
+  const processLike = globalThis as { process?: { env?: Record<string, string | undefined> } }
+  return processLike.process?.env?.NODE_ENV !== 'production'
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,9 @@ export type {
   JsonPrimitive,
   NamedCheck,
   NamedCheckMetadata,
+  FieldValidator,
+  ValidationEntry,
+  ValidationMap,
 } from './types.js'
 export type { FieldBuilder, FieldInput, FieldRef, NormalizeField, NormalizeFields } from './field.js'
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,10 @@ export type {
   NamedCheck,
   NamedCheckMetadata,
   FieldValidator,
+  ValidationFunction,
+  ValidationOutcome,
+  ValidationResult,
+  ValidationValidator,
   ValidationEntry,
   ValidationMap,
 } from './types.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export { isEmptyArray, isEmptyObject, isEmptyPresent, isEmptyString } from './em
 export { field } from './field.js'
 export { foulMap } from './foul-map.js'
 export { isSatisfied } from './satisfaction.js'
+export { isNamedCheck } from './validation.js'
 export {
   defineRule,
   enabledWhen,
@@ -59,7 +60,6 @@ export {
   getNamedCheckMetadata,
   inspectPredicate,
   inspectRule,
-  isNamedCheck,
 } from './rules.js'
 export { scorecard } from './scorecard.js'
 export { umpire } from './umpire.js'

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -1,9 +1,10 @@
 import { getFieldBuilderName } from './field.js'
 import { isSatisfied } from './satisfaction.js'
+import { isNamedCheck as isNamedCheckValidator, runFieldValidator } from './validation.js'
 import type {
+  FieldValidator,
   FieldDef,
   FieldValues,
-  NamedCheck,
   NamedCheckMetadata,
   Rule,
   RuleEvaluation,
@@ -155,15 +156,6 @@ type OneOfOptions<
 > = RuleOptions<F, C> & {
   activeBranch?: string | ((values: FieldValues<F>, conditions: C) => string | null | undefined)
 }
-
-type FunctionValidator<V> = (value: V) => boolean
-type SafeParseValidator<V> = { safeParse: (value: V) => { success: boolean } }
-type StringTestValidator = { test: (value: string) => boolean }
-type Validator<V> =
-  | FunctionValidator<V>
-  | NamedCheck<V>
-  | SafeParseValidator<V>
-  | StringTestValidator
 
 export type InternalPredicate<
   F extends Record<string, FieldDef>,
@@ -411,18 +403,7 @@ function cloneNamedCheckMetadata(metadata: NamedCheckMetadata): NamedCheckMetada
   })
 }
 
-export function isNamedCheck<T = unknown>(validator: unknown): validator is NamedCheck<T> {
-  if (typeof validator !== 'object' || validator === null) {
-    return false
-  }
-
-  return (
-    '__check' in validator &&
-    typeof (validator as { __check?: unknown }).__check === 'string' &&
-    'validate' in validator &&
-    typeof (validator as { validate?: unknown }).validate === 'function'
-  )
-}
+export { isNamedCheck } from './validation.js'
 
 function isNamedCheckMetadataCarrier(value: unknown): value is NamedCheckMetadataCarrier {
   return (typeof value === 'function' || typeof value === 'object') && value !== null
@@ -435,7 +416,7 @@ function hasNamedCheckMetadata(
 }
 
 export function getNamedCheckMetadata(value: unknown): NamedCheckMetadata | undefined {
-  if (isNamedCheck(value)) {
+  if (isNamedCheckValidator(value)) {
     return cloneNamedCheckMetadata(value)
   }
 
@@ -1322,10 +1303,10 @@ export function check<
   V = unknown,
 >(
   field: FieldSelector<F, V>,
-  validator: Validator<NonNullable<V>>,
+  validator: FieldValidator<NonNullable<V>>,
 ): Predicate<F, C> {
   const target = getFieldNameOrThrow(field)
-  const namedCheckMetadata = isNamedCheck(validator)
+  const namedCheckMetadata = isNamedCheckValidator(validator)
     ? cloneNamedCheckMetadata(validator)
     : undefined
 
@@ -1336,23 +1317,7 @@ export function check<
       return false
     }
 
-    if (typeof validator === 'function') {
-      return validator(value as NonNullable<V>)
-    }
-
-    if (isNamedCheck(validator)) {
-      return validator.validate(value as NonNullable<V>)
-    }
-
-    if ('safeParse' in validator) {
-      return validator.safeParse(value as NonNullable<V>).success
-    }
-
-    if ('test' in validator) {
-      return typeof value === 'string' && validator.test(value)
-    }
-
-    return false
+    return runFieldValidator(validator, value as NonNullable<V>)
   }) as Predicate<F, C>
 
   predicate._checkField = target

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -404,8 +404,6 @@ function cloneNamedCheckMetadata(metadata: NamedCheckMetadata): NamedCheckMetada
   })
 }
 
-export { isNamedCheck } from './validation.js'
-
 function isNamedCheckMetadataCarrier(value: unknown): value is NamedCheckMetadataCarrier {
   return (typeof value === 'function' || typeof value === 'object') && value !== null
 }

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -1,3 +1,4 @@
+import { shouldWarnInDev } from './dev.js'
 import { getFieldBuilderName } from './field.js'
 import { isSatisfied } from './satisfaction.js'
 import { isNamedCheck as isNamedCheckValidator, runFieldValidator } from './validation.js'
@@ -809,11 +810,6 @@ function branchHasSatisfiedField<F extends Record<string, FieldDef>>(
   }
 
   return branchFields.some((field) => isSatisfied(values[field], fields?.[field]))
-}
-
-function shouldWarnInDev(): boolean {
-  const processLike = globalThis as { process?: { env?: Record<string, string | undefined> } }
-  return processLike.process?.env?.NODE_ENV !== 'production'
 }
 
 function warnAmbiguousOneOf(groupName: string, branchNames: string[]): void {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,12 +15,43 @@ export interface NamedCheck<T = unknown> extends NamedCheckMetadata {
   readonly validate: (value: NonNullable<T>) => boolean
 }
 
+export type FieldValue<T extends FieldDef> = T extends FieldDef<infer V> ? V : unknown
+
+export type FunctionValidator<T = unknown> = (value: NonNullable<T>) => boolean
+
+export type SafeParseValidator<T = unknown> = {
+  safeParse(value: NonNullable<T>): { success: boolean }
+}
+
+export type StringTestValidator = {
+  test(value: string): boolean
+}
+
+export type FieldValidator<T = unknown> =
+  | FunctionValidator<T>
+  | NamedCheck<T>
+  | SafeParseValidator<T>
+  | StringTestValidator
+
+export type ValidationEntry<T = unknown> =
+  | FieldValidator<T>
+  | {
+      validator: FieldValidator<T>
+      error?: string
+    }
+
+export type ValidationMap<F extends Record<string, FieldDef>> = Partial<{
+  [K in keyof F & string]: ValidationEntry<FieldValue<F[K]>>
+}>
+
 export type FieldStatus = {
   enabled: boolean
   fair: boolean
   required: boolean
   reason: string | null
   reasons: string[]
+  valid?: boolean
+  error?: string
 }
 
 export type FieldAvailability = FieldStatus
@@ -28,8 +59,6 @@ export type FieldAvailability = FieldStatus
 export type AvailabilityMap<F extends Record<string, FieldDef>> = {
   [K in keyof F]: FieldStatus
 }
-
-export type FieldValue<T extends FieldDef> = T extends FieldDef<infer V> ? V : unknown
 
 export type FieldValues<F extends Record<string, FieldDef>> = {
   [K in keyof F]?: FieldValue<F[K]>
@@ -135,6 +164,8 @@ export type ScorecardField<F extends Record<string, FieldDef>> = {
   satisfied: boolean
   enabled: boolean
   fair: boolean
+  valid?: boolean
+  error?: string
   required: boolean
   reason: string | null
   reasons: string[]

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -179,11 +179,11 @@ export type ScorecardField<F extends Record<string, FieldDef>> = {
   satisfied: boolean
   enabled: boolean
   fair: boolean
-  valid?: boolean
-  error?: string
   required: boolean
   reason: string | null
   reasons: string[]
+  valid?: boolean
+  error?: string
   changed: boolean
   cascaded: boolean
   foul: Foul<F> | null

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,10 +33,25 @@ export type FieldValidator<T = unknown> =
   | SafeParseValidator<T>
   | StringTestValidator
 
+export type ValidationResult = {
+  valid: boolean
+  error?: string
+}
+
+export type ValidationOutcome = boolean | ValidationResult
+
+export type ValidationFunction<T = unknown> = (value: NonNullable<T>) => ValidationOutcome
+
+export type ValidationValidator<T = unknown> =
+  | ValidationFunction<T>
+  | NamedCheck<T>
+  | SafeParseValidator<T>
+  | StringTestValidator
+
 export type ValidationEntry<T = unknown> =
-  | FieldValidator<T>
+  | ValidationValidator<T>
   | {
-      validator: FieldValidator<T>
+      validator: ValidationValidator<T>
       error?: string
     }
 

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -21,6 +21,11 @@ import {
   resolveOneOfState,
 } from './rules.js'
 import { isSatisfied } from './satisfaction.js'
+import {
+  normalizeValidationEntry,
+  runValidationEntry,
+  type NormalizedValidationEntry,
+} from './validation.js'
 import type {
   AvailabilityMap,
   ChallengeDirectReason,
@@ -37,11 +42,16 @@ import type {
   ScorecardResult,
   Umpire,
   UmpireGraph,
+  ValidationMap,
 } from './types.js'
 
 function createEmptyConditions<C extends Record<string, unknown>>(conditions: C | undefined): C {
   return (conditions ?? ({} as C)) as C
 }
+
+type NormalizedValidationMap<F extends Record<string, FieldDef>> = Partial<{
+  [K in keyof F & string]: NormalizedValidationEntry
+}>
 
 function getChangedFields<
   F extends Record<string, FieldDef>,
@@ -60,6 +70,39 @@ function getChangedFields<
 
 function isPresent(value: unknown) {
   return value !== null && value !== undefined
+}
+
+function normalizeValidators<F extends Record<string, FieldDef>>(
+  fields: F,
+  validators: ValidationMap<F> | undefined,
+): NormalizedValidationMap<F> {
+  const normalized = {} as NormalizedValidationMap<F>
+
+  if (!validators) {
+    return normalized
+  }
+
+  const fieldNames = new Set(Object.keys(fields))
+
+  for (const [field, entry] of Object.entries(validators) as Array<[keyof F & string, unknown]>) {
+    if (entry === undefined) {
+      continue
+    }
+
+    if (!fieldNames.has(field)) {
+      throw new Error(`[umpire] Unknown field "${field}" referenced by validators`)
+    }
+
+    const normalizedEntry = normalizeValidationEntry(entry)
+
+    if (!normalizedEntry) {
+      throw new Error(`[umpire] Invalid validator configured for field "${field}"`)
+    }
+
+    normalized[field] = normalizedEntry
+  }
+
+  return normalized
 }
 
 function buildFieldEdgeLookup<F extends Record<string, FieldDef>>(
@@ -758,9 +801,12 @@ export function umpire<
 >(config: {
   fields: FInput
   rules: Rule<NormalizeFields<FInput>, C>[]
+  validators?: ValidationMap<NormalizeFields<FInput>>
 }): Umpire<NormalizeFields<FInput>, C> {
   const { fields, rules } = normalizeConfig(config.fields, config.rules)
   const fieldNames = Object.keys(fields) as Array<keyof NormalizeFields<FInput> & string>
+  const validators = normalizeValidators(fields, config.validators)
+  const hasValidators = Object.keys(validators).length > 0
 
   validateRules(fields, rules)
 
@@ -792,6 +838,40 @@ export function umpire<
       prev,
       rulesByTarget,
     )
+  }
+
+  function attachValidationMetadata(
+    values: FieldValues<NormalizeFields<FInput>>,
+    availability: AvailabilityMap<NormalizeFields<FInput>>,
+  ): AvailabilityMap<NormalizeFields<FInput>> {
+    if (!hasValidators) {
+      return availability
+    }
+
+    const validated = {} as AvailabilityMap<NormalizeFields<FInput>>
+
+    for (const field of fieldNames) {
+      const status = availability[field]
+      const validator = validators[field]
+
+      // Validation metadata only applies once a field is structurally active
+      // and has a satisfied value to validate.
+      if (!validator || !status.enabled || !isSatisfied(values[field], fields[field])) {
+        validated[field] = status
+        continue
+      }
+
+      const result = runValidationEntry(
+        validator,
+        values[field] as NonNullable<FieldValues<NormalizeFields<FInput>>[typeof field]>,
+      )
+
+      validated[field] = result.error === undefined
+        ? { ...status, valid: result.valid }
+        : { ...status, valid: result.valid, error: result.error }
+    }
+
+    return validated
   }
 
   function recommendFouls(
@@ -940,7 +1020,8 @@ export function umpire<
     const { before, includeChallenge = false } = options
     const typedValues = snapshot.values as FieldValues<NormalizeFields<FInput>>
     const typedPrev = before?.values as FieldValues<NormalizeFields<FInput>> | undefined
-    const check = checkAvailability(typedValues, snapshot.conditions, typedPrev)
+    const structuralCheck = checkAvailability(typedValues, snapshot.conditions, typedPrev)
+    const check = attachValidationMetadata(typedValues, structuralCheck)
     const changedFields = getChangedFields(
       fieldNames,
       before as { values: FieldValues<NormalizeFields<FInput>> } | undefined,
@@ -971,28 +1052,37 @@ export function umpire<
         const value = typedValues[field]
         const present = isPresent(value)
         const satisfied = isSatisfied(value, fields[field])
+        const scorecardField: ScorecardResult<NormalizeFields<FInput>, C>['fields'][typeof field] = {
+          field,
+          value,
+          present,
+          satisfied,
+          enabled: availability.enabled,
+          fair: availability.fair,
+          required: availability.required,
+          reason: availability.reason,
+          reasons: availability.reasons,
+          changed: changedFieldSet.has(field),
+          cascaded: cascadingFieldSet.has(field),
+          foul: foulsByField[field] ?? null,
+          incoming: incomingByField[field],
+          outgoing: outgoingByField[field],
+          trace: includeChallenge
+            ? buildChallenge(field, snapshot.values, snapshot.conditions, before?.values)
+            : undefined,
+        }
+
+        if (availability.valid !== undefined) {
+          scorecardField.valid = availability.valid
+        }
+
+        if (availability.error !== undefined) {
+          scorecardField.error = availability.error
+        }
 
         return [
           field,
-          {
-            field,
-            value,
-            present,
-            satisfied,
-            enabled: availability.enabled,
-            fair: availability.fair,
-            required: availability.required,
-            reason: availability.reason,
-            reasons: availability.reasons,
-            changed: changedFieldSet.has(field),
-            cascaded: cascadingFieldSet.has(field),
-            foul: foulsByField[field] ?? null,
-            incoming: incomingByField[field],
-            outgoing: outgoingByField[field],
-            trace: includeChallenge
-              ? buildChallenge(field, snapshot.values, snapshot.conditions, before?.values)
-              : undefined,
-          },
+          scorecardField,
         ]
       }),
     ) as ScorecardResult<NormalizeFields<FInput>, C>['fields']
@@ -1015,10 +1105,15 @@ export function umpire<
 
   return {
     check(values, conditions, prev) {
-      return checkAvailability(
-        values as FieldValues<NormalizeFields<FInput>>,
-        conditions,
-        prev as FieldValues<NormalizeFields<FInput>> | undefined,
+      const typedValues = values as FieldValues<NormalizeFields<FInput>>
+
+      return attachValidationMetadata(
+        typedValues,
+        checkAvailability(
+          typedValues,
+          conditions,
+          prev as FieldValues<NormalizeFields<FInput>> | undefined,
+        ),
       )
     },
 

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -866,9 +866,13 @@ export function umpire<
         values[field] as NonNullable<FieldValues<NormalizeFields<FInput>>[typeof field]>,
       )
 
-      validated[field] = result.error === undefined
-        ? { ...status, valid: result.valid }
-        : { ...status, valid: result.valid, error: result.error }
+      const nextStatus = { ...status, valid: result.valid }
+
+      if (!result.valid && result.error !== undefined) {
+        nextStatus.error = result.error
+      }
+
+      validated[field] = nextStatus
     }
 
     return validated

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -14,6 +14,10 @@ export type NormalizedValidationEntry<T = unknown> = {
   error?: string
 }
 
+type NormalizedValidationResult =
+  | { valid: true }
+  | { valid: false; error?: string }
+
 // `check()` remains boolean-only at the public API boundary, but the runtime
 // validator shapes are otherwise shared with richer validation entries.
 type SupportedValidator<T = unknown> = FieldValidator<T> | ValidationValidator<T>
@@ -64,7 +68,7 @@ function isValidationEntryObject<T = unknown>(entry: unknown): entry is Validati
 function normalizeValidationResult(
   result: unknown,
   fallbackError?: string,
-): ValidationResult {
+): NormalizedValidationResult {
   if (typeof result === 'boolean') {
     return result
       ? { valid: true }
@@ -153,6 +157,6 @@ export function runFieldValidator<T = unknown>(
 export function runValidationEntry<T = unknown>(
   entry: NormalizedValidationEntry<T>,
   value: NonNullable<T>,
-): ValidationResult {
+): NormalizedValidationResult {
   return normalizeValidationResult(entry.validate(value), entry.error)
 }

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -14,6 +14,10 @@ export type NormalizedValidationEntry<T = unknown> = {
   error?: string
 }
 
+// `check()` remains boolean-only at the public API boundary, but the runtime
+// validator shapes are otherwise shared with richer validation entries.
+type SupportedValidator<T = unknown> = FieldValidator<T> | ValidationValidator<T>
+
 type ValidationEntryObject<T = unknown> = {
   validator: ValidationValidator<T>
   error?: string
@@ -37,14 +41,7 @@ export function isNamedCheck<T = unknown>(validator: unknown): validator is Name
     typeof validator.validate === 'function'
 }
 
-function isFieldValidator<T = unknown>(validator: unknown): validator is FieldValidator<T> {
-  return typeof validator === 'function' ||
-    isNamedCheck<T>(validator) ||
-    isSafeParseValidator<T>(validator) ||
-    isStringTestValidator(validator)
-}
-
-function isValidationValidator<T = unknown>(validator: unknown): validator is ValidationValidator<T> {
+function isSupportedValidator<T = unknown>(validator: unknown): validator is SupportedValidator<T> {
   return typeof validator === 'function' ||
     isNamedCheck<T>(validator) ||
     isSafeParseValidator<T>(validator) ||
@@ -60,7 +57,7 @@ function isValidationResult(result: unknown): result is ValidationResult {
 function isValidationEntryObject<T = unknown>(entry: unknown): entry is ValidationEntryObject<T> {
   return isRecord(entry) &&
     'validator' in entry &&
-    isValidationValidator<T>(entry.validator) &&
+    isSupportedValidator<T>(entry.validator) &&
     (!('error' in entry) || entry.error === undefined || typeof entry.error === 'string')
 }
 
@@ -103,7 +100,7 @@ function normalizeValidationResult(
 }
 
 function toValidationFunction<T = unknown>(
-  validator: ValidationValidator<T>,
+  validator: SupportedValidator<T>,
 ): (value: NonNullable<T>) => ValidationOutcome {
   if (typeof validator === 'function') {
     return validator
@@ -123,7 +120,7 @@ function toValidationFunction<T = unknown>(
 export function normalizeValidationEntry<T = unknown>(
   entry: unknown,
 ): NormalizedValidationEntry<T> | null {
-  if (isValidationValidator<T>(entry)) {
+  if (isSupportedValidator<T>(entry)) {
     return { validate: toValidationFunction(entry) }
   }
 
@@ -146,7 +143,7 @@ export function runFieldValidator<T = unknown>(
   validator: FieldValidator<T>,
   value: NonNullable<T>,
 ): boolean {
-  if (!isFieldValidator<T>(validator)) {
+  if (!isSupportedValidator<T>(validator)) {
     return false
   }
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,0 +1,117 @@
+import type {
+  FieldValidator,
+  NamedCheck,
+  SafeParseValidator,
+  StringTestValidator,
+} from './types.js'
+
+export type NormalizedValidationEntry<T = unknown> = {
+  validate: (value: NonNullable<T>) => boolean
+  error?: string
+}
+
+export type ValidationResult = {
+  valid: boolean
+  error?: string
+}
+
+type ValidationEntryObject<T = unknown> = {
+  validator: FieldValidator<T>
+  error?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isSafeParseValidator<T = unknown>(validator: unknown): validator is SafeParseValidator<T> {
+  return isRecord(validator) && typeof validator.safeParse === 'function'
+}
+
+function isStringTestValidator(validator: unknown): validator is StringTestValidator {
+  return isRecord(validator) && typeof validator.test === 'function'
+}
+
+export function isNamedCheck<T = unknown>(validator: unknown): validator is NamedCheck<T> {
+  return isRecord(validator) &&
+    typeof validator.__check === 'string' &&
+    typeof validator.validate === 'function'
+}
+
+function isFieldValidator<T = unknown>(validator: unknown): validator is FieldValidator<T> {
+  return typeof validator === 'function' ||
+    isNamedCheck<T>(validator) ||
+    isSafeParseValidator<T>(validator) ||
+    isStringTestValidator(validator)
+}
+
+function isValidationEntryObject<T = unknown>(entry: unknown): entry is ValidationEntryObject<T> {
+  return isRecord(entry) &&
+    'validator' in entry &&
+    isFieldValidator<T>(entry.validator) &&
+    (!('error' in entry) || entry.error === undefined || typeof entry.error === 'string')
+}
+
+function toValidationFunction<T = unknown>(
+  validator: FieldValidator<T>,
+): (value: NonNullable<T>) => boolean {
+  if (typeof validator === 'function') {
+    return validator
+  }
+
+  if (isNamedCheck<T>(validator)) {
+    return validator.validate
+  }
+
+  if (isSafeParseValidator<T>(validator)) {
+    return (value) => validator.safeParse(value).success
+  }
+
+  return (value) => typeof value === 'string' && validator.test(value)
+}
+
+export function normalizeValidationEntry<T = unknown>(
+  entry: unknown,
+): NormalizedValidationEntry<T> | null {
+  if (isFieldValidator<T>(entry)) {
+    return { validate: toValidationFunction(entry) }
+  }
+
+  if (!isValidationEntryObject<T>(entry)) {
+    return null
+  }
+
+  const normalized: NormalizedValidationEntry<T> = {
+    validate: toValidationFunction(entry.validator),
+  }
+
+  if (entry.error !== undefined) {
+    normalized.error = entry.error
+  }
+
+  return normalized
+}
+
+export function runFieldValidator<T = unknown>(
+  validator: FieldValidator<T>,
+  value: NonNullable<T>,
+): boolean {
+  if (!isFieldValidator<T>(validator)) {
+    return false
+  }
+
+  return toValidationFunction(validator)(value)
+}
+
+export function runValidationEntry<T = unknown>(
+  entry: NormalizedValidationEntry<T>,
+  value: NonNullable<T>,
+): ValidationResult {
+  const result: ValidationResult = { valid: entry.validate(value) }
+
+  if (!result.valid && entry.error !== undefined) {
+    result.error = entry.error
+  }
+
+  return result
+}

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,22 +1,21 @@
+import { shouldWarnInDev } from './dev.js'
 import type {
   FieldValidator,
   NamedCheck,
   SafeParseValidator,
+  ValidationOutcome,
   StringTestValidator,
+  ValidationResult,
+  ValidationValidator,
 } from './types.js'
 
 export type NormalizedValidationEntry<T = unknown> = {
-  validate: (value: NonNullable<T>) => boolean
-  error?: string
-}
-
-export type ValidationResult = {
-  valid: boolean
+  validate: (value: NonNullable<T>) => ValidationOutcome
   error?: string
 }
 
 type ValidationEntryObject<T = unknown> = {
-  validator: FieldValidator<T>
+  validator: ValidationValidator<T>
   error?: string
 }
 
@@ -45,16 +44,67 @@ function isFieldValidator<T = unknown>(validator: unknown): validator is FieldVa
     isStringTestValidator(validator)
 }
 
+function isValidationValidator<T = unknown>(validator: unknown): validator is ValidationValidator<T> {
+  return typeof validator === 'function' ||
+    isNamedCheck<T>(validator) ||
+    isSafeParseValidator<T>(validator) ||
+    isStringTestValidator(validator)
+}
+
+function isValidationResult(result: unknown): result is ValidationResult {
+  return isRecord(result) &&
+    typeof result.valid === 'boolean' &&
+    (!('error' in result) || result.error === undefined || typeof result.error === 'string')
+}
+
 function isValidationEntryObject<T = unknown>(entry: unknown): entry is ValidationEntryObject<T> {
   return isRecord(entry) &&
     'validator' in entry &&
-    isFieldValidator<T>(entry.validator) &&
+    isValidationValidator<T>(entry.validator) &&
     (!('error' in entry) || entry.error === undefined || typeof entry.error === 'string')
 }
 
+function normalizeValidationResult(
+  result: unknown,
+  fallbackError?: string,
+): ValidationResult {
+  if (typeof result === 'boolean') {
+    return result
+      ? { valid: true }
+      : fallbackError === undefined
+        ? { valid: false }
+        : { valid: false, error: fallbackError }
+  }
+
+  if (!isValidationResult(result)) {
+    if (shouldWarnInDev()) {
+      console.warn(
+        '[umpire] Validation functions must return a boolean or { valid, error? }. ' +
+        'Received an unsupported result and treated it as invalid.',
+      )
+    }
+
+    return fallbackError === undefined
+      ? { valid: false }
+      : { valid: false, error: fallbackError }
+  }
+
+  if (result.valid) {
+    return { valid: true }
+  }
+
+  if (result.error !== undefined) {
+    return { valid: false, error: result.error }
+  }
+
+  return fallbackError === undefined
+    ? { valid: false }
+    : { valid: false, error: fallbackError }
+}
+
 function toValidationFunction<T = unknown>(
-  validator: FieldValidator<T>,
-): (value: NonNullable<T>) => boolean {
+  validator: ValidationValidator<T>,
+): (value: NonNullable<T>) => ValidationOutcome {
   if (typeof validator === 'function') {
     return validator
   }
@@ -73,7 +123,7 @@ function toValidationFunction<T = unknown>(
 export function normalizeValidationEntry<T = unknown>(
   entry: unknown,
 ): NormalizedValidationEntry<T> | null {
-  if (isFieldValidator<T>(entry)) {
+  if (isValidationValidator<T>(entry)) {
     return { validate: toValidationFunction(entry) }
   }
 
@@ -100,18 +150,12 @@ export function runFieldValidator<T = unknown>(
     return false
   }
 
-  return toValidationFunction(validator)(value)
+  return normalizeValidationResult(toValidationFunction(validator)(value)).valid
 }
 
 export function runValidationEntry<T = unknown>(
   entry: NormalizedValidationEntry<T>,
   value: NonNullable<T>,
 ): ValidationResult {
-  const result: ValidationResult = { valid: entry.validate(value) }
-
-  if (!result.valid && entry.error !== undefined) {
-    result.error = entry.error
-  }
-
-  return result
+  return normalizeValidationResult(entry.validate(value), entry.error)
 }

--- a/packages/zod/AGENTS.md
+++ b/packages/zod/AGENTS.md
@@ -1,6 +1,6 @@
 # @umpire/zod
 
-- Use `activeSchema(availability, fieldSchemas, z)` with a field-schema shape, not a `z.object()` instance.
+- Use `activeSchema(availability, fieldSchemas)` with a field-schema shape, not a `z.object()` instance.
 - Disabled fields are excluded from the active schema. Enabled but optional fields get `.optional()`.
 - Normalize parse issues with `zodErrors(error)`, then filter them with `activeErrors(availability, errors)`.
 - This package is availability-aware validation glue; keep availability logic in `@umpire/core`, not inside Zod refinements.

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -41,7 +41,7 @@ const fieldSchemas = {
 // 3. Compose at render time
 const availability = ump.check(values, { plan })
 
-const schema = activeSchema(availability, fieldSchemas, z)
+const schema = activeSchema(availability, fieldSchemas)
 const result = schema.safeParse(values)
 
 if (!result.success) {
@@ -52,7 +52,6 @@ if (!result.success) {
 
 const validation = createZodValidation({
   schemas: fieldSchemas,
-  zod: z,
 })
 
 const umpWithValidation = umpire({
@@ -71,7 +70,7 @@ const umpWithValidation = umpire({
 
 ## API
 
-### `activeSchema(availability, schemas, z)`
+### `activeSchema(availability, schemas)`
 
 Builds a `z.object()` from the availability map:
 - **Disabled fields** are excluded entirely
@@ -90,7 +89,7 @@ Filters normalized field errors to only include enabled fields. Returns `Partial
 
 Normalizes a Zod error's `issues` array into `{ field, message }[]` pairs for use with `activeErrors`.
 
-### `createZodValidation({ schemas, zod, build? })`
+### `createZodValidation({ schemas, build? })`
 
 Creates a convenience adapter with:
 - `validators` for `umpire({ validators })`, surfacing the first field-level Zod issue as `error`
@@ -108,7 +107,6 @@ import { zodValidationExtension } from '@umpire/zod/devtools'
 
 const validation = createZodValidation({
   schemas: fieldSchemas,
-  zod: z,
   build(baseSchema) {
     return baseSchema.refine(
       (data) => !data.confirmPassword || !data.password || data.confirmPassword === data.password,

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -97,6 +97,36 @@ Creates a convenience adapter with:
 
 If you need every issue or deeper control, you can still use `activeSchema()` and `safeParse()` directly.
 
+### Blank strings and `isEmpty`
+
+The generated validators follow Umpire's satisfaction semantics. By default,
+only `null` and `undefined` count as empty. So if a string field does not define
+`isEmpty`, a value like `''` is still considered satisfied and may surface
+`valid: false` immediately.
+
+For form-style inputs, define an explicit empty-state rule:
+
+```ts
+import { isEmptyString, umpire } from '@umpire/core'
+
+const validation = createZodValidation({
+  schemas: {
+    email: z.string().email('Enter a valid email'),
+  },
+})
+
+const ump = umpire({
+  fields: {
+    email: { required: true, isEmpty: isEmptyString },
+  },
+  rules: [],
+  validators: validation.validators,
+})
+```
+
+That keeps blank strings out of the validation path until the field is
+satisfied under your chosen emptiness semantics.
+
 ## Devtools
 
 If you use `@umpire/devtools`, `@umpire/zod/devtools` can expose validation state in a tab. The most ergonomic path is to derive from the current devtools context:

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -17,7 +17,7 @@ npm install @umpire/core @umpire/zod zod
 ```ts
 import { z } from 'zod'
 import { umpire, enabledWhen, requires } from '@umpire/core'
-import { activeSchema, activeErrors, zodErrors } from '@umpire/zod'
+import { activeSchema, activeErrors, createZodValidation, zodErrors } from '@umpire/zod'
 
 // 1. Define availability rules
 const ump = umpire({
@@ -49,6 +49,24 @@ if (!result.success) {
   // errors.email → 'Enter a valid email' (only if email is enabled)
   // errors.companyName → undefined (disabled on personal plan)
 }
+
+const validation = createZodValidation({
+  schemas: fieldSchemas,
+  zod: z,
+})
+
+const umpWithValidation = umpire({
+  fields: {
+    email:       { required: true, isEmpty: (v) => !v },
+    companyName: { required: true, isEmpty: (v) => !v },
+  },
+  rules: [
+    enabledWhen('companyName', (_v, c) => c.plan === 'business', {
+      reason: 'business plan required',
+    }),
+  ],
+  validators: validation.validators,
+})
 ```
 
 ## API
@@ -72,6 +90,14 @@ Filters normalized field errors to only include enabled fields. Returns `Partial
 
 Normalizes a Zod error's `issues` array into `{ field, message }[]` pairs for use with `activeErrors`.
 
+### `createZodValidation({ schemas, zod, build? })`
+
+Creates a convenience adapter with:
+- `validators` for `umpire({ validators })`, surfacing the first field-level Zod issue as `error`
+- `run(availability, values)` for the full `activeSchema() -> safeParse() -> activeErrors()` flow
+
+If you need every issue or deeper control, you can still use `activeSchema()` and `safeParse()` directly.
+
 ## Devtools
 
 If you use `@umpire/devtools`, `@umpire/zod/devtools` can expose validation state in a tab. The most ergonomic path is to derive from the current devtools context:
@@ -80,20 +106,22 @@ If you use `@umpire/devtools`, `@umpire/zod/devtools` can expose validation stat
 import { useUmpireWithDevtools } from '@umpire/devtools/react'
 import { zodValidationExtension } from '@umpire/zod/devtools'
 
+const validation = createZodValidation({
+  schemas: fieldSchemas,
+  zod: z,
+  build(baseSchema) {
+    return baseSchema.refine(
+      (data) => !data.confirmPassword || !data.password || data.confirmPassword === data.password,
+      { message: 'Passwords do not match', path: ['confirmPassword'] },
+    )
+  },
+})
+
 const { check } = useUmpireWithDevtools('signup', ump, values, conditions, {
   extensions: [
     zodValidationExtension({
       resolve({ scorecard, values }) {
-        const baseSchema = activeSchema(scorecard.check, fieldSchemas, z)
-        const schema = baseSchema.refine(
-          (data) => !data.confirmPassword || !data.password || data.confirmPassword === data.password,
-          { message: 'Passwords do not match', path: ['confirmPassword'] },
-        )
-
-        return {
-          result: schema.safeParse(values),
-          schemaFields: Object.keys(baseSchema.shape),
-        }
+        return validation.run(scorecard.check, values)
       },
     }),
   ],

--- a/packages/zod/__tests__/active-schema.test.ts
+++ b/packages/zod/__tests__/active-schema.test.ts
@@ -51,7 +51,6 @@ describe('activeSchema', () => {
         requiredName: z.string(),
         disabledSecret: z.string(),
       },
-      z,
     )
 
     expect(Object.keys(schema.shape)).toEqual(['requiredName'])
@@ -64,7 +63,6 @@ describe('activeSchema', () => {
       {
         requiredName: z.string(),
       },
-      z,
     )
 
     expect(schema.safeParse({}).success).toBe(false)
@@ -77,7 +75,6 @@ describe('activeSchema', () => {
       {
         optionalNickname: z.string(),
       },
-      z,
     )
 
     expect(schema.safeParse({}).success).toBe(true)
@@ -85,7 +82,7 @@ describe('activeSchema', () => {
   })
 
   test('returns an empty object schema for empty availability', () => {
-    const schema = activeSchema({} as AvailabilityMap<EmptyFields>, {}, z)
+    const schema = activeSchema({} as AvailabilityMap<EmptyFields>, {})
 
     expect(Object.keys(schema.shape)).toEqual([])
     expect(schema.safeParse({}).success).toBe(true)
@@ -97,7 +94,6 @@ describe('activeSchema', () => {
       {
         requiredName: z.string(),
       },
-      z,
     )
 
     expect(schema.shape.missingSchema).toBeUndefined()
@@ -110,7 +106,6 @@ describe('activeSchema', () => {
       z.object({
         requiredName: z.string(),
       }) as never,
-      z,
     )).toThrow(
       'activeSchema() expects per-field schemas, not a z.object(). ' +
       'Pass formSchema.shape instead of formSchema.',

--- a/packages/zod/__tests__/active-schema.test.ts
+++ b/packages/zod/__tests__/active-schema.test.ts
@@ -112,7 +112,7 @@ describe('activeSchema', () => {
       }) as never,
       z,
     )).toThrow(
-      '[@umpire/zod] activeSchema() expects per-field schemas, not a z.object(). ' +
+      'activeSchema() expects per-field schemas, not a z.object(). ' +
       'Pass formSchema.shape instead of formSchema.',
     )
   })

--- a/packages/zod/__tests__/devtools.test.ts
+++ b/packages/zod/__tests__/devtools.test.ts
@@ -248,7 +248,7 @@ describe('zodValidationExtension', () => {
         const baseSchema = activeSchema(scorecard.check, {
           email: z.string().email('Enter a valid email'),
           companyName: z.string().min(1, 'Company name is required'),
-        }, z)
+        })
 
         return {
           result: baseSchema.safeParse(values),

--- a/packages/zod/__tests__/validation.test.ts
+++ b/packages/zod/__tests__/validation.test.ts
@@ -8,7 +8,6 @@ describe('createZodValidation', () => {
       schemas: {
         email: z.string().email('Enter a valid email'),
       },
-      zod: z,
     })
 
     const ump = umpire({
@@ -43,7 +42,6 @@ describe('createZodValidation', () => {
         confirmPassword: z.string().min(1, 'Confirm your password'),
         companyName: z.string().min(1, 'Company name is required'),
       },
-      zod: z,
       build(baseSchema) {
         return baseSchema.refine(
           (data) => data.confirmPassword === data.password,
@@ -85,7 +83,6 @@ describe('createZodValidation', () => {
       schemas: z.object({
         email: z.string().email(),
       }) as never,
-      zod: z,
     })).toThrow(
       'createZodValidation() expects per-field schemas, not a z.object(). ' +
       'Pass formSchema.shape instead of formSchema.',
@@ -95,7 +92,6 @@ describe('createZodValidation', () => {
   test('throws if given a non-object instead of per-field schemas', () => {
     expect(() => createZodValidation({
       schemas: undefined as never,
-      zod: z,
     })).toThrow('createZodValidation() expects a per-field schema map object.')
   })
 })

--- a/packages/zod/__tests__/validation.test.ts
+++ b/packages/zod/__tests__/validation.test.ts
@@ -1,0 +1,101 @@
+import { enabledWhen, umpire } from '@umpire/core'
+import { z } from 'zod'
+import { createZodValidation } from '../src/validation.js'
+
+describe('createZodValidation', () => {
+  test('creates core validators that surface the first Zod issue', () => {
+    const validation = createZodValidation({
+      schemas: {
+        email: z.string().email('Enter a valid email'),
+      },
+      zod: z,
+    })
+
+    const ump = umpire({
+      fields: {
+        email: { required: true, isEmpty: (value: unknown) => !value },
+      },
+      rules: [],
+      validators: validation.validators,
+    })
+
+    expect(ump.check({ email: 'bad' }).email).toMatchObject({
+      valid: false,
+      error: 'Enter a valid email',
+    })
+    expect(ump.check({ email: 'ok@example.com' }).email).toMatchObject({
+      valid: true,
+    })
+  })
+
+  test('runs active schema validation and returns filtered field errors', () => {
+    const fields = {
+      email: { required: true, isEmpty: (value: unknown) => !value },
+      password: { required: true, isEmpty: (value: unknown) => !value },
+      confirmPassword: { required: true, isEmpty: (value: unknown) => !value },
+      companyName: { required: true, isEmpty: (value: unknown) => !value },
+    }
+
+    const validation = createZodValidation({
+      schemas: {
+        email: z.string().email('Enter a valid email'),
+        password: z.string().min(8, 'At least 8 characters'),
+        confirmPassword: z.string().min(1, 'Confirm your password'),
+        companyName: z.string().min(1, 'Company name is required'),
+      },
+      zod: z,
+      build(baseSchema) {
+        return baseSchema.refine(
+          (data) => data.confirmPassword === data.password,
+          { message: 'Passwords do not match', path: ['confirmPassword'] },
+        )
+      },
+    })
+
+    const ump = umpire<typeof fields, { plan: 'personal' | 'business' }>({
+      fields,
+      rules: [
+        enabledWhen('companyName', (_values, conditions) => conditions.plan === 'business', {
+          reason: 'business plan required',
+        }),
+      ],
+    })
+
+    const values = {
+      email: 'ok@example.com',
+      password: 'password123',
+      confirmPassword: 'mismatch',
+      companyName: '',
+    }
+    const availability = ump.check(values, { plan: 'personal' })
+    const result = validation.run(availability, values)
+
+    expect(result.schemaFields).toEqual(['email', 'password', 'confirmPassword'])
+    expect(result.errors).toEqual({
+      confirmPassword: 'Passwords do not match',
+    })
+    expect(result.normalizedErrors).toEqual([
+      { field: 'confirmPassword', message: 'Passwords do not match' },
+    ])
+    expect(result.result.success).toBe(false)
+  })
+
+  test('throws if given a z.object instead of per-field schemas', () => {
+    expect(() => createZodValidation({
+      schemas: z.object({
+        email: z.string().email(),
+      }) as never,
+      zod: z,
+    })).toThrow(
+      'createZodValidation() expects per-field schemas, not a z.object(). ' +
+      'Pass formSchema.shape instead of formSchema.',
+    )
+  })
+
+  test('throws if given a non-object instead of per-field schemas', () => {
+    expect(() => createZodValidation({
+      schemas: undefined as never,
+      zod: z,
+    })).toThrow('createZodValidation() expects a per-field schema map object.')
+  })
+})

--- a/packages/zod/src/active-schema.ts
+++ b/packages/zod/src/active-schema.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod'
+import { z } from 'zod'
 import type { AvailabilityMap, FieldDef } from '@umpire/core'
 import { assertFieldSchemas } from './schema-guards.js'
 
@@ -12,18 +12,15 @@ type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
  *
  * ```ts
  * // Per-field
- * activeSchema(availability, { email: z.string().email() }, z)
+ * activeSchema(availability, { email: z.string().email() })
  *
  * // From an existing z.object()
- * activeSchema(availability, formSchema.shape, z)
+ * activeSchema(availability, formSchema.shape)
  * ```
  */
 export function activeSchema<F extends Record<string, FieldDef>>(
   availability: AvailabilityMap<F>,
   schemas: FieldSchemas<F>,
-  zod: {
-    object(shape: Record<string, z.ZodTypeAny>): z.ZodObject<Record<string, z.ZodTypeAny>>
-  },
 ): z.ZodObject<Record<string, z.ZodTypeAny>> {
   assertFieldSchemas(schemas, 'activeSchema')
 
@@ -46,5 +43,5 @@ export function activeSchema<F extends Record<string, FieldDef>>(
     shape[field] = status.required ? base : base.optional()
   }
 
-  return zod.object(shape)
+  return z.object(shape)
 }

--- a/packages/zod/src/active-schema.ts
+++ b/packages/zod/src/active-schema.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 import type { AvailabilityMap, FieldDef } from '@umpire/core'
+import { assertFieldSchemas } from './schema-guards.js'
 
 type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
   Record<keyof F & string, z.ZodTypeAny>
@@ -24,13 +25,7 @@ export function activeSchema<F extends Record<string, FieldDef>>(
     object(shape: Record<string, z.ZodTypeAny>): z.ZodObject<Record<string, z.ZodTypeAny>>
   },
 ): z.ZodObject<Record<string, z.ZodTypeAny>> {
-  // Catch the common mistake of passing a z.object() instead of its .shape
-  if ('_def' in schemas || '_zod' in schemas) {
-    throw new Error(
-      '[@umpire/zod] activeSchema() expects per-field schemas, not a z.object(). ' +
-      'Pass formSchema.shape instead of formSchema.',
-    )
-  }
+  assertFieldSchemas(schemas, 'activeSchema')
 
   const fieldSchemas = schemas
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,3 +1,9 @@
 export { activeSchema } from './active-schema.js'
 export { activeErrors, zodErrors } from './active-errors.js'
 export type { NormalizedFieldError } from './active-errors.js'
+export { createZodValidation } from './validation.js'
+export type {
+  CreateZodValidationOptions,
+  ZodValidationAdapter,
+  ZodValidationRunResult,
+} from './validation.js'

--- a/packages/zod/src/schema-guards.ts
+++ b/packages/zod/src/schema-guards.ts
@@ -1,4 +1,4 @@
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
 

--- a/packages/zod/src/schema-guards.ts
+++ b/packages/zod/src/schema-guards.ts
@@ -1,0 +1,25 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export function isZodObjectSchema(value: unknown): boolean {
+  return isRecord(value) && ('_def' in value || '_zod' in value)
+}
+
+export function assertFieldSchemas(
+  schemas: unknown,
+  caller: 'activeSchema' | 'createZodValidation',
+): asserts schemas is Record<string, unknown> {
+  if (isZodObjectSchema(schemas)) {
+    throw new Error(
+      `[umpire/zod] ${caller}() expects per-field schemas, not a z.object(). ` +
+      'Pass formSchema.shape instead of formSchema.',
+    )
+  }
+
+  if (!isRecord(schemas)) {
+    throw new Error(
+      `[umpire/zod] ${caller}() expects a per-field schema map object.`,
+    )
+  }
+}

--- a/packages/zod/src/validation.ts
+++ b/packages/zod/src/validation.ts
@@ -30,13 +30,8 @@ type ZodSchemaLike = {
   safeParse(value: unknown): ZodSafeParseResultLike
 }
 
-type ZodObjectFactory = {
-  object(shape: Record<string, z.ZodTypeAny>): z.ZodObject<Record<string, z.ZodTypeAny>>
-}
-
 export type CreateZodValidationOptions<F extends Record<string, FieldDef>> = {
   schemas: FieldSchemas<F>
-  zod: ZodObjectFactory
   build?(schema: z.ZodObject<Record<string, z.ZodTypeAny>>): ZodSchemaLike
 }
 
@@ -77,7 +72,6 @@ export function createZodValidation<F extends Record<string, FieldDef>>(
 
   const {
     schemas,
-    zod,
     build,
   } = options
   const validators = {} as ValidationMap<F>
@@ -105,7 +99,7 @@ export function createZodValidation<F extends Record<string, FieldDef>>(
   return {
     validators,
     run(availability, values) {
-      const baseSchema = activeSchema(availability, schemas, zod)
+      const baseSchema = activeSchema(availability, schemas)
       const schema = build ? build(baseSchema) : baseSchema
       const result = schema.safeParse(values)
       const normalizedErrors = isFailedParseResult(result) ? zodErrors(result.error) : []

--- a/packages/zod/src/validation.ts
+++ b/packages/zod/src/validation.ts
@@ -7,7 +7,7 @@ import type {
 import type { z } from 'zod'
 import { activeErrors, zodErrors, type NormalizedFieldError } from './active-errors.js'
 import { activeSchema } from './active-schema.js'
-import { assertFieldSchemas } from './schema-guards.js'
+import { assertFieldSchemas, isRecord } from './schema-guards.js'
 
 type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
   Record<keyof F & string, z.ZodTypeAny>
@@ -48,10 +48,6 @@ export type ZodValidationAdapter<F extends Record<string, FieldDef>> = {
     values: InputValues<F>,
   ): ZodValidationRunResult<F>
   validators: ValidationMap<F>
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
 }
 
 function firstIssueMessage(error: ZodErrorLike): string | undefined {

--- a/packages/zod/src/validation.ts
+++ b/packages/zod/src/validation.ts
@@ -1,0 +1,121 @@
+import type {
+  AvailabilityMap,
+  FieldDef,
+  InputValues,
+  ValidationMap,
+} from '@umpire/core'
+import type { z } from 'zod'
+import { activeErrors, zodErrors, type NormalizedFieldError } from './active-errors.js'
+import { activeSchema } from './active-schema.js'
+import { assertFieldSchemas } from './schema-guards.js'
+
+type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
+  Record<keyof F & string, z.ZodTypeAny>
+>
+
+type ZodIssueLike = {
+  path: readonly (string | number)[]
+  message: string
+}
+
+type ZodErrorLike = {
+  issues: readonly ZodIssueLike[]
+}
+
+type ZodSafeParseResultLike =
+  | { success: true }
+  | { success: false; error: ZodErrorLike }
+
+type ZodSchemaLike = {
+  safeParse(value: unknown): ZodSafeParseResultLike
+}
+
+type ZodObjectFactory = {
+  object(shape: Record<string, z.ZodTypeAny>): z.ZodObject<Record<string, z.ZodTypeAny>>
+}
+
+export type CreateZodValidationOptions<F extends Record<string, FieldDef>> = {
+  schemas: FieldSchemas<F>
+  zod: ZodObjectFactory
+  build?(schema: z.ZodObject<Record<string, z.ZodTypeAny>>): ZodSchemaLike
+}
+
+export type ZodValidationRunResult<F extends Record<string, FieldDef>> = {
+  errors: Partial<Record<keyof F & string, string>>
+  normalizedErrors: NormalizedFieldError[]
+  result: ZodSafeParseResultLike
+  schemaFields: Array<keyof F & string>
+}
+
+export type ZodValidationAdapter<F extends Record<string, FieldDef>> = {
+  run(
+    availability: AvailabilityMap<F>,
+    values: InputValues<F>,
+  ): ZodValidationRunResult<F>
+  validators: ValidationMap<F>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function firstIssueMessage(error: ZodErrorLike): string | undefined {
+  return error.issues[0]?.message
+}
+
+function isFailedParseResult(result: unknown): result is Extract<ZodSafeParseResultLike, { success: false }> {
+  return isRecord(result) &&
+    result.success === false &&
+    isRecord(result.error) &&
+    Array.isArray(result.error.issues)
+}
+
+export function createZodValidation<F extends Record<string, FieldDef>>(
+  options: CreateZodValidationOptions<F>,
+): ZodValidationAdapter<F> {
+  assertFieldSchemas(options.schemas, 'createZodValidation')
+
+  const {
+    schemas,
+    zod,
+    build,
+  } = options
+  const validators = {} as ValidationMap<F>
+
+  for (const [field, schema] of Object.entries(schemas) as Array<[keyof F & string, z.ZodTypeAny | undefined]>) {
+    if (!schema) {
+      continue
+    }
+
+    validators[field] = (value: unknown) => {
+      const result = schema.safeParse(value)
+
+      if (result.success) {
+        return { valid: true }
+      }
+
+      const error = firstIssueMessage(result.error)
+
+      return error === undefined
+        ? { valid: false }
+        : { valid: false, error }
+    }
+  }
+
+  return {
+    validators,
+    run(availability, values) {
+      const baseSchema = activeSchema(availability, schemas, zod)
+      const schema = build ? build(baseSchema) : baseSchema
+      const result = schema.safeParse(values)
+      const normalizedErrors = isFailedParseResult(result) ? zodErrors(result.error) : []
+
+      return {
+        errors: activeErrors(availability, normalizedErrors),
+        normalizedErrors,
+        result,
+        schemaFields: Object.keys(baseSchema.shape) as Array<keyof F & string>,
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Adds first-class validation metadata to `@umpire/core` and introduces a cleaner `@umpire/zod` adapter built around that contract.

This lets Umpire surface field-local validation state through `check()` / `scorecard()` while keeping full-form and cross-field schema validation in adapter or userland flows.

## What Changed

- Added optional `validators` support to `umpire()`
- Added `valid?: boolean` and `error?: string` to `FieldStatus` and `ScorecardField`
- Extracted shared validation normalization/execution into `packages/core/src/validation.ts`
- Kept `check()` stateless and boolean-focused at the public rule API boundary
- Added `createZodValidation()` to `@umpire/zod`
- Removed the extra `zod` factory option from the Zod adapter API
- Added guards for accidentally passing `z.object()` instead of `.shape`
- Updated docs, tests, and the signup example to reflect the new validation model

## Notes

- Validation metadata is only attached when a field has a validator, is enabled, and is satisfied
- Full-form / submit-time validation remains an adapter or userland concern
- Blank strings still follow Umpire satisfaction semantics unless `isEmpty` is defined

## Testing

- `yarn turbo run test --filter=@umpire/core`
- `yarn turbo run typecheck --filter=@umpire/core`
- `yarn turbo run test --filter=@umpire/zod`
- `yarn turbo run typecheck --filter=@umpire/zod`
- `cd docs && npx astro build`
