### PR TITLE
🧹 Json Validation Naming Cleanup

### DIFF
--- a/.changeset/late-cougars-think.md
+++ b/.changeset/late-cougars-think.md
@@ -4,5 +4,6 @@
 
 - `@umpire/json` now supports top-level `validators` in the portable schema for field-local validation metadata.
 - `fromJson()` now returns `{ fields, rules, validators }` so parsed schemas can feed portable validators straight into `umpire()`.
-- `toJson()` now accepts `validators` and serializes portable named checks from `checks.*()` into the JSON `validators` section.
+- `toJson()` now accepts `validators` and serializes portable validators from `namedValidators.*()` into the JSON `validators` section.
+- `@umpire/json` now exposes `namedValidators.*()` and validator-first type names such as `JsonValidatorOp` and `JsonValidatorSpec`.
 - `@umpire/json` keeps `expr.check()` for structural predicates and preserves top-level `"check"` rules as the legacy structural compatibility form.

--- a/.changeset/late-cougars-think.md
+++ b/.changeset/late-cougars-think.md
@@ -1,0 +1,8 @@
+---
+"@umpire/json": patch
+---
+
+- `@umpire/json` now supports top-level `validators` in the portable schema for field-local validation metadata.
+- `fromJson()` now returns `{ fields, rules, validators }` so parsed schemas can feed portable validators straight into `umpire()`.
+- `toJson()` now accepts `validators` and serializes portable named checks from `checks.*()` into the JSON `validators` section.
+- `@umpire/json` keeps `expr.check()` for structural predicates and preserves top-level `"check"` rules as the legacy structural compatibility form.

--- a/docs/src/content/docs/adapters/json/dsl.md
+++ b/docs/src/content/docs/adapters/json/dsl.md
@@ -138,12 +138,12 @@ enabledWhenExpr('holePunch', expr.and(
 })
 ```
 
-### `expr.check(field, checkSpec)`
+### `expr.check(field, validator)`
 
-The field-bound check source. Evaluates to `true` when the named field satisfies a named check:
+The field-bound check source. Evaluates to `true` when the named field satisfies a portable validator:
 
 ```ts
-enabledWhenExpr('submit', expr.check('email', checks.email()), {
+enabledWhenExpr('submit', expr.check('email', namedValidators.email()), {
   reason: 'Enter a valid email address first',
 })
 ```
@@ -175,7 +175,7 @@ This gives three clear tiers:
 | Authored with | `toJson()` output |
 |---|---|
 | Portable builders + `expr.*` | Exact round-trip |
-| Core helpers + `checks.*()` | Usually serializable via introspection |
+| Core helpers + `namedValidators.*()` | Usually serializable via introspection |
 | Plain TypeScript predicates | `excluded` |
 
 The first tier is the only one with a guarantee. The second tier works for common patterns (`requires('a', 'b')`, `enabledWhen` with a `check()` predicate) but depends on introspection, which has limits. The third tier is always `excluded` — it still runs, it just won't cross runtimes.
@@ -192,6 +192,6 @@ The TypeScript implementation is the reference runtime. Other language ports are
 
 ## See also
 
-- [`@umpire/json`](/umpire/adapters/json/) — `fromJson`, `toJson`, portable checks, conditions, `excluded`
+- [`@umpire/json`](/umpire/adapters/json/) — `fromJson`, `toJson`, portable validators, conditions, `excluded`
 - [Composing with Validation](/umpire/concepts/validation/) — conceptual boundary between availability and validation
 - [check() helper](/umpire/api/rules/check/) — validator shapes in core

--- a/docs/src/content/docs/adapters/json/index.md
+++ b/docs/src/content/docs/adapters/json/index.md
@@ -42,38 +42,38 @@ Three tiers of output:
 
 - **Hydrated rules** (from `fromJson()`) round-trip exactly. Their original JSON definition is preserved and written back verbatim.
 - **Hydrated validators** (from `fromJson()`) round-trip exactly. Their original JSON definition is preserved and written back verbatim.
-- **Portable hand-written rules** — rules built with `checks.*()`, `expr.*`, and the portable builders — are serialized when they map cleanly to the contract.
-- **Portable hand-written validators** — validators built from `checks.*()` — are serialized when they map cleanly to the contract.
+- **Portable hand-written rules** — rules built with `namedValidators.*()`, `expr.*`, and the portable builders — are serialized when they map cleanly to the contract.
+- **Portable hand-written validators** — validators built from `namedValidators.*()` — are serialized when they map cleanly to the contract.
 - **Everything else** lands in `excluded`, not dropped silently.
 
 When the config started from a `fromJson()` parse, previously declared `conditions` and `excluded` entries carry forward too. If the current runtime can now serialize something that was previously excluded, `toJson()` replaces the old entry instead of duplicating it.
 
-## Portable checks
+## Portable validator helpers
 
-`checks.*()` are named validator helpers that carry stable metadata across the JSON boundary:
+`namedValidators.*()` are portable validator helpers that carry stable metadata across the JSON boundary:
 
 ```ts
 import { check, enabledWhen } from '@umpire/core'
-import { checks } from '@umpire/json'
+import { namedValidators } from '@umpire/json'
 
-enabledWhen('submit', check('email', checks.email()), {
+enabledWhen('submit', check('email', namedValidators.email()), {
   reason: 'Enter a valid email address',
 })
 ```
 
-Plain functions, regexes, Zod schemas, and Yup schemas all work with `check()`. The difference is that `checks.*()` helpers know how to serialize themselves — `toJson()` can write them out and `fromJson()` can rebuild them exactly. Plain validators land in `excluded`.
+Plain functions, regexes, Zod schemas, and Yup schemas all work with `check()`. The difference is that `namedValidators.*()` helpers know how to serialize themselves — `toJson()` can write them out and `fromJson()` can rebuild them exactly. Plain validators land in `excluded`.
 
-Built-in named checks in `version: 1`:
+Built-in portable validators in `version: 1`:
 
-- `checks.email()` — practical email syntax
-- `checks.url()` — absolute URL with a scheme
-- `checks.matches(pattern)` — regex from a serializable pattern string
-- `checks.minLength(n)` — string or array length at least `n`
-- `checks.maxLength(n)` — string or array length at most `n`
-- `checks.min(n)` — number at least `n`
-- `checks.max(n)` — number at most `n`
-- `checks.range(min, max)` — number within an inclusive range
-- `checks.integer()` — number must be an integer
+- `namedValidators.email()` — practical email syntax
+- `namedValidators.url()` — absolute URL with a scheme
+- `namedValidators.matches(pattern)` — regex from a serializable pattern string
+- `namedValidators.minLength(n)` — string or array length at least `n`
+- `namedValidators.maxLength(n)` — string or array length at most `n`
+- `namedValidators.min(n)` — number at least `n`
+- `namedValidators.max(n)` — number at most `n`
+- `namedValidators.range(min, max)` — number within an inclusive range
+- `namedValidators.integer()` — number must be an integer
 
 The surrounding rule owns the reason string — you can pair any portable check with your own product copy.
 
@@ -101,7 +101,7 @@ In `@umpire/core`, `check()` is already doing two things depending on context: i
 { "type": "check", "field": "email", "op": "email" }
 ```
 
-**`expr.check()`** is the portable predicate-source form. It appears inside a predicate expression, letting one field's availability depend on whether another field passes a named check:
+**`expr.check()`** is the portable predicate-source form. It appears inside a predicate expression, letting one field's availability depend on whether another field passes a portable validator:
 
 ```json
 {
@@ -114,7 +114,7 @@ In `@umpire/core`, `check()` is already doing two things depending on context: i
 The modern split is:
 
 - `validators` for field-local validation metadata
-- `expr.check()` for structural predicates that depend on another field passing a named check
+- `expr.check()` for structural predicates that depend on another field passing a portable validator
 - top-level `"check"` only when you need to preserve older JSON schemas
 
 See [DSL & Portable Builders](/umpire/adapters/json/dsl/) for the full expression vocabulary.
@@ -178,7 +178,7 @@ If your Umpire model needs to survive a runtime boundary, write it through the J
 
 The portable toolkit is:
 
-- `checks.*()` for field-local value constraints
+- `namedValidators.*()` for field-local value constraints
 - top-level `validators` for portable field-local validation
 - `expr.*` for predicate expressions inside `enabledWhen`, `requires`, `disables`, and `fairWhen`
 - Portable builders (`requiresJson`, `enabledWhenExpr`, `disablesExpr`, `fairWhenExpr`) for constructing rules that carry their own JSON definition from birth

--- a/docs/src/content/docs/adapters/json/index.md
+++ b/docs/src/content/docs/adapters/json/index.md
@@ -15,33 +15,35 @@ yarn add @umpire/core @umpire/json
 
 ## `fromJson(schema)`
 
-`fromJson()` parses a portable schema and returns `{ fields, rules }` you can pass straight into `umpire()`:
+`fromJson()` parses a portable schema and returns `{ fields, rules, validators }` you can pass straight into `umpire()`:
 
 ```ts
 import { umpire } from '@umpire/core'
 import { fromJson } from '@umpire/json'
 
-const { fields, rules } = fromJson(schema)
+const { fields, rules, validators } = fromJson(schema)
 
-const ump = umpire({ fields, rules })
+const ump = umpire({ fields, rules, validators })
 ```
 
 The result is composable. Hydrate most of a form from JSON and add a few hand-written rules for app-specific logic in the same `umpire()` call — the two sets coexist without conflict.
 
-## `toJson({ fields, rules, conditions })`
+## `toJson({ fields, rules, validators, conditions })`
 
 `toJson()` walks a TypeScript config and writes back the parts that fit the portable contract:
 
 ```ts
 import { toJson } from '@umpire/json'
 
-const json = toJson({ fields, rules, conditions })
+const json = toJson({ fields, rules, validators, conditions })
 ```
 
 Three tiers of output:
 
 - **Hydrated rules** (from `fromJson()`) round-trip exactly. Their original JSON definition is preserved and written back verbatim.
+- **Hydrated validators** (from `fromJson()`) round-trip exactly. Their original JSON definition is preserved and written back verbatim.
 - **Portable hand-written rules** — rules built with `checks.*()`, `expr.*`, and the portable builders — are serialized when they map cleanly to the contract.
+- **Portable hand-written validators** — validators built from `checks.*()` — are serialized when they map cleanly to the contract.
 - **Everything else** lands in `excluded`, not dropped silently.
 
 When the config started from a `fromJson()` parse, previously declared `conditions` and `excluded` entries carry forward too. If the current runtime can now serialize something that was previously excluded, `toJson()` replaces the old entry instead of duplicating it.
@@ -75,11 +77,25 @@ Built-in named checks in `version: 1`:
 
 The surrounding rule owns the reason string — you can pair any portable check with your own product copy.
 
+## Portable validators
+
+Top-level `validators` are the portable field-local validation surface. They attach to the matching field and feed Umpire's `valid` / `error` metadata directly:
+
+```json
+{
+  "validators": {
+    "email": { "op": "email", "error": "Enter a valid email address" }
+  }
+}
+```
+
+At runtime, `fromJson()` turns these into `umpire({ validators })` entries. The field stays structurally enabled or disabled according to rules; the validator only answers whether the current satisfied value is well-formed.
+
 ## Two check shapes
 
-In `@umpire/core`, `check()` is already doing two things depending on context: it's a predicate factory when used inside `enabledWhen()` or `requires()`, and it becomes a standalone availability constraint when registered as a rule on its own. The JSON contract reflects that same duality with two portable forms.
+In `@umpire/core`, `check()` is already doing two things depending on context: it's a predicate factory when used inside `enabledWhen()` or `requires()`, and older configs may still use it as a standalone structural constraint. `@umpire/json` now keeps field-local validation separate with `validators`, but preserves the older `check` rule shape for compatibility.
 
-**Top-level `"check"`** is the portable standalone form. It applies a named validator to a field and produces an availability result — the field is treated as unsatisfied if the check fails:
+**Top-level `"check"`** is the legacy standalone structural form. It still parses for compatibility, but it remains a fairness rule rather than validator metadata:
 
 ```json
 { "type": "check", "field": "email", "op": "email" }
@@ -95,7 +111,11 @@ In `@umpire/core`, `check()` is already doing two things depending on context: i
 }
 ```
 
-The same distinction that exists in TypeScript — constraint on a field vs. source in a predicate — maps directly to the two JSON shapes. The TypeScript builders handle both without touching raw JSON.
+The modern split is:
+
+- `validators` for field-local validation metadata
+- `expr.check()` for structural predicates that depend on another field passing a named check
+- top-level `"check"` only when you need to preserve older JSON schemas
 
 See [DSL & Portable Builders](/umpire/adapters/json/dsl/) for the full expression vocabulary.
 
@@ -159,6 +179,7 @@ If your Umpire model needs to survive a runtime boundary, write it through the J
 The portable toolkit is:
 
 - `checks.*()` for field-local value constraints
+- top-level `validators` for portable field-local validation
 - `expr.*` for predicate expressions inside `enabledWhen`, `requires`, `disables`, and `fairWhen`
 - Portable builders (`requiresJson`, `enabledWhenExpr`, `disablesExpr`, `fairWhenExpr`) for constructing rules that carry their own JSON definition from birth
 

--- a/packages/json/AGENTS.md
+++ b/packages/json/AGENTS.md
@@ -1,6 +1,6 @@
 # @umpire/json
 
-- Use `fromJson(schema)` to hydrate portable Umpire configs and `toJson({ fields, rules, conditions? })` to serialize them back out.
-- If a rule must round-trip through JSON, build it from `checks.*()` or the `*Expr` and `*Json` helpers. Arbitrary predicates cannot be serialized cleanly.
+- Use `fromJson(schema)` to hydrate portable Umpire configs and `toJson({ fields, rules, validators?, conditions? })` to serialize them back out.
+- If a rule or validator must round-trip through JSON, build it from `namedValidators.*()` or the `*Expr` and `*Json` helpers. Arbitrary predicates cannot be serialized cleanly.
 - `toJson()` preserves unsupported pieces in `excluded`; it should not silently drop behavior.
 - Use `validateSchema()` before hydration when JSON comes from an untrusted source.

--- a/packages/json/README.md
+++ b/packages/json/README.md
@@ -1,6 +1,6 @@
 # @umpire/json
 
-Portable schema parsing and serialization for [@umpire/core](https://www.npmjs.com/package/@umpire/core), plus named `checks.*()` helpers that round-trip cleanly through JSON.
+Portable schema parsing and serialization for [@umpire/core](https://www.npmjs.com/package/@umpire/core), plus portable `namedValidators.*()` helpers that round-trip cleanly through JSON.
 
 [Docs](https://sdougbrown.github.io/umpire/adapters/json/) · [Quick Start](https://sdougbrown.github.io/umpire/learn/)
 
@@ -14,7 +14,7 @@ npm install @umpire/core @umpire/json
 
 ```ts
 import { check, enabledWhen, umpire } from '@umpire/core'
-import { checks, fromJson, toJson } from '@umpire/json'
+import { namedValidators, fromJson, toJson } from '@umpire/json'
 
 const schema = {
   version: 1,
@@ -32,7 +32,7 @@ const { fields, rules, validators } = fromJson(schema)
 
 const mergedRules = [
   ...rules,
-  enabledWhen('submit', check('email', checks.email()), {
+  enabledWhen('submit', check('email', namedValidators.email()), {
     reason: 'Enter a valid email address',
   }),
 ]
@@ -63,22 +63,22 @@ Serializes a TypeScript config back into the portable JSON contract.
 - Rules hydrated from JSON round-trip exactly
 - Validators hydrated from JSON round-trip exactly
 - Hand-written rules serialize when they map cleanly to the contract
-- Hand-written validators serialize when they use portable named checks
+- Hand-written validators serialize when they use portable validator metadata
 - Unsupported pieces go into `excluded` instead of disappearing
 
-### `checks.*()`
+### `namedValidators.*()`
 
 Named validators for use with `check(field, validator)` and JSON `validators`:
 
-- `checks.email()`
-- `checks.url()`
-- `checks.matches(pattern)`
-- `checks.minLength(n)`
-- `checks.maxLength(n)`
-- `checks.min(n)`
-- `checks.max(n)`
-- `checks.range(min, max)`
-- `checks.integer()`
+- `namedValidators.email()`
+- `namedValidators.url()`
+- `namedValidators.matches(pattern)`
+- `namedValidators.minLength(n)`
+- `namedValidators.maxLength(n)`
+- `namedValidators.min(n)`
+- `namedValidators.max(n)`
+- `namedValidators.range(min, max)`
+- `namedValidators.integer()`
 
 Use these when you want a validator or check-backed rule to survive the JSON boundary. Plain functions, regexes, and library schemas still work at runtime, but they stay TypeScript-specific.
 

--- a/packages/json/README.md
+++ b/packages/json/README.md
@@ -22,12 +22,13 @@ const schema = {
     email: { isEmpty: 'string' },
     submit: {},
   },
-  rules: [
-    { type: 'check', field: 'email', op: 'email' },
-  ],
+  rules: [],
+  validators: {
+    email: { op: 'email', error: 'Enter a valid email address' },
+  },
 }
 
-const { fields, rules } = fromJson(schema)
+const { fields, rules, validators } = fromJson(schema)
 
 const mergedRules = [
   ...rules,
@@ -39,11 +40,13 @@ const mergedRules = [
 const ump = umpire({
   fields,
   rules: mergedRules,
+  validators,
 })
 
 const json = toJson({
   fields,
   rules: mergedRules,
+  validators,
 })
 ```
 
@@ -51,19 +54,21 @@ const json = toJson({
 
 ### `fromJson(schema)`
 
-Parses a portable Umpire JSON schema into `{ fields, rules }` values you can pass into `umpire()` or compose with hand-written rules.
+Parses a portable Umpire JSON schema into `{ fields, rules, validators }` values you can pass into `umpire()` or compose with hand-written rules.
 
-### `toJson({ fields, rules, conditions })`
+### `toJson({ fields, rules, validators, conditions })`
 
 Serializes a TypeScript config back into the portable JSON contract.
 
 - Rules hydrated from JSON round-trip exactly
+- Validators hydrated from JSON round-trip exactly
 - Hand-written rules serialize when they map cleanly to the contract
+- Hand-written validators serialize when they use portable named checks
 - Unsupported pieces go into `excluded` instead of disappearing
 
 ### `checks.*()`
 
-Named validators for use with `check(field, validator)`:
+Named validators for use with `check(field, validator)` and JSON `validators`:
 
 - `checks.email()`
 - `checks.url()`
@@ -75,7 +80,23 @@ Named validators for use with `check(field, validator)`:
 - `checks.range(min, max)`
 - `checks.integer()`
 
-Use these when you want a rule to survive the JSON boundary. Plain functions, regexes, and library schemas still work with `check()`, but they stay TypeScript-specific.
+Use these when you want a validator or check-backed rule to survive the JSON boundary. Plain functions, regexes, and library schemas still work at runtime, but they stay TypeScript-specific.
+
+## `validators`
+
+Use top-level `validators` for field-local correctness checks that should surface `valid` / `error` through `ump.check()`:
+
+```json
+{
+  "validators": {
+    "email": { "op": "email", "error": "Enter a valid email address" }
+  }
+}
+```
+
+This is the first-class validation path in `@umpire/json`.
+
+Top-level `"check"` rules still exist for legacy compatibility, but they remain structural fairness rules rather than validator metadata.
 
 ## `excluded`
 

--- a/packages/json/__tests__/builders.test.ts
+++ b/packages/json/__tests__/builders.test.ts
@@ -2,8 +2,8 @@ import { enabledWhen, umpire } from '@umpire/core'
 
 import {
   anyOfJson,
-  checks,
   createJsonRules,
+  namedValidators,
   toJson,
 } from '../src/index.js'
 import type { UmpireJsonSchema } from '../src/index.js'
@@ -55,7 +55,7 @@ describe('portable JSON builders', () => {
       requiresJson(
         'bullpenCart',
         'pitchType',
-        expr.check('starter', checks.minLength(4)),
+        expr.check('starter', namedValidators.minLength(4)),
         {
           reason: 'Bullpen cart waits for a pitch call and a full starter name',
         },
@@ -191,7 +191,7 @@ describe('portable JSON builders', () => {
       requiresJson(
         'bullpenCart',
         'pitchType',
-        expr.check('starter', checks.minLength(4)),
+        expr.check('starter', namedValidators.minLength(4)),
         {
           reason: 'Bullpen cart waits for a pitch call and a full starter name',
         },
@@ -279,7 +279,7 @@ describe('portable JSON builders', () => {
     ).toThrow('anyOfJson() requires every inner rule to carry JSON metadata')
   })
 
-  test('requiresJson supports mixed field and named-check dependencies', () => {
+  test('requiresJson supports mixed field and portable-validator dependencies', () => {
     const fields = {
       email: {},
       password: {},
@@ -291,7 +291,7 @@ describe('portable JSON builders', () => {
     const rule = requiresJson(
       'submit',
       'password',
-      expr.check('email', checks.email()),
+      expr.check('email', namedValidators.email()),
       {
         reason: 'Need a valid email and password before submit',
       },
@@ -325,7 +325,7 @@ describe('portable JSON builders', () => {
     })
   })
 
-  test('fairWhenExpr preserves named checks for serialization', () => {
+  test('fairWhenExpr preserves portable validators for serialization', () => {
     const fields = {
       email: {},
       submit: {},
@@ -333,7 +333,7 @@ describe('portable JSON builders', () => {
 
     const { expr, fairWhenExpr } = createJsonRules<typeof fields>()
 
-    const rule = fairWhenExpr('submit', expr.check('email', checks.email()), {
+    const rule = fairWhenExpr('submit', expr.check('email', namedValidators.email()), {
       reason: 'Submit stays foul until the scorer email is valid',
     })
 
@@ -440,7 +440,7 @@ describe('portable JSON builders', () => {
     })
   })
 
-  test('expr.check rejects non-portable named checks', () => {
+  test('expr.check rejects non-portable validators', () => {
     const { expr } = createJsonRules<Record<string, {}>>()
 
     expect(() =>
@@ -448,7 +448,7 @@ describe('portable JSON builders', () => {
         __check: 'custom',
         validate: () => true,
       } as Parameters<typeof expr.check>[1]),
-    ).toThrow('expr.check() requires a named check from @umpire/json')
+    ).toThrow('expr.check() requires a portable validator from @umpire/json')
   })
 
   test('requiresJson requires at least one dependency', () => {

--- a/packages/json/__tests__/check-ops.test.ts
+++ b/packages/json/__tests__/check-ops.test.ts
@@ -1,41 +1,46 @@
 import { check, getNamedCheckMetadata } from '@umpire/core'
 
-import { checks, createNamedCheckFromRule, defaultCheckReason, hydrateIsEmptyStrategy } from '../src/index.js'
 import {
-  assertValidCheckSpec,
+  createNamedValidatorFromRule,
+  defaultValidatorMessage,
+  hydrateIsEmptyStrategy,
+  namedValidators,
+} from '../src/index.js'
+import {
+  assertValidValidatorSpec,
+  createValidatorSpecFromMetadata,
   createCheckRuleFromMetadata,
-  createCheckSpecFromMetadata,
 } from '../src/check-ops.js'
 
-describe('checks', () => {
+describe('namedValidators', () => {
   test.each([
-    ['email', checks.email(), 'user@example.com', 'invalid', 'Must be a valid email address'],
-    ['url', checks.url(), 'https://example.com', '/relative', 'Must be a valid URL'],
-    ['minLength', checks.minLength(3), 'abcd', 'ab', 'Must be at least 3 characters'],
-    ['maxLength', checks.maxLength(3), 'abc', 'abcd', 'Must be 3 characters or fewer'],
-    ['min', checks.min(3), 4, 2, 'Must be at least 3'],
-    ['max', checks.max(3), 2, 4, 'Must be 3 or less'],
-    ['range', checks.range(2, 4), 3, 5, 'Must be between 2 and 4'],
-    ['integer', checks.integer(), 3, 3.5, 'Must be a whole number'],
+    ['email', namedValidators.email(), 'user@example.com', 'invalid', 'Must be a valid email address'],
+    ['url', namedValidators.url(), 'https://example.com', '/relative', 'Must be a valid URL'],
+    ['minLength', namedValidators.minLength(3), 'abcd', 'ab', 'Must be at least 3 characters'],
+    ['maxLength', namedValidators.maxLength(3), 'abc', 'abcd', 'Must be 3 characters or fewer'],
+    ['min', namedValidators.min(3), 4, 2, 'Must be at least 3'],
+    ['max', namedValidators.max(3), 2, 4, 'Must be 3 or less'],
+    ['range', namedValidators.range(2, 4), 3, 5, 'Must be between 2 and 4'],
+    ['integer', namedValidators.integer(), 3, 3.5, 'Must be a whole number'],
   ])(
     'validates %s',
     (_label, validator, passingValue, failingValue, expectedReason) => {
       expect(validator.validate(passingValue as never)).toBe(true)
       expect(validator.validate(failingValue as never)).toBe(false)
-      expect(defaultCheckReason(validator)).toBe(expectedReason)
+      expect(defaultValidatorMessage(validator)).toBe(expectedReason)
     },
   )
 
   test('matches validates a serializable regex pattern', () => {
-    const validator = checks.matches('^[a-z0-9_]+$')
+    const validator = namedValidators.matches('^[a-z0-9_]+$')
 
     expect(validator.validate('umpire_ok')).toBe(true)
     expect(validator.validate('Not OK')).toBe(false)
-    expect(defaultCheckReason(validator)).toBe('Must match the required format')
+    expect(defaultValidatorMessage(validator)).toBe('Must match the required format')
   })
 
   test('email accepts common valid forms and rejects obvious invalid dot forms', () => {
-    const validator = checks.email()
+    const validator = namedValidators.email()
 
     expect(validator.validate("first.last+tag_o'reilly@example-domain.com")).toBe(true)
     expect(validator.validate('.leading-dot@example.com')).toBe(false)
@@ -43,7 +48,7 @@ describe('checks', () => {
   })
 
   test('produces named check metadata compatible with core check()', () => {
-    const validator = checks.maxLength(5)
+    const validator = namedValidators.maxLength(5)
     const predicate = check<Record<string, {}>, Record<string, unknown>>('email', validator)
 
     expect(getNamedCheckMetadata(predicate)).toEqual({
@@ -53,7 +58,7 @@ describe('checks', () => {
   })
 
   test('hydrates a named check from a JSON rule definition', () => {
-    const validator = createNamedCheckFromRule({
+    const validator = createNamedValidatorFromRule({
       type: 'check',
       field: 'username',
       op: 'matches',
@@ -69,7 +74,7 @@ describe('checks', () => {
   })
 
   test('serializes named-check metadata back into portable specs', () => {
-    expect(createCheckSpecFromMetadata({
+    expect(createValidatorSpecFromMetadata({
       __check: 'matches',
       params: { pattern: '^[a-z]+$' },
     })).toEqual({
@@ -77,7 +82,7 @@ describe('checks', () => {
       pattern: '^[a-z]+$',
     })
 
-    expect(createCheckSpecFromMetadata({
+    expect(createValidatorSpecFromMetadata({
       __check: 'range',
       params: { min: 2, max: 4 },
     })).toEqual({
@@ -104,7 +109,7 @@ describe('checks', () => {
       __check: 'custom',
     },
   ])('returns undefined for malformed metadata: %j', (metadata) => {
-    expect(createCheckSpecFromMetadata(metadata as never)).toBeUndefined()
+    expect(createValidatorSpecFromMetadata(metadata as never)).toBeUndefined()
   })
 
   test('creates portable check rules and omits default reasons', () => {
@@ -139,19 +144,19 @@ describe('checks', () => {
   })
 
   test('falls back for unknown reason labels and rejects invalid specs', () => {
-    expect(defaultCheckReason({ __check: 'custom' } as never)).toBe('Invalid value')
+    expect(defaultValidatorMessage({ __check: 'custom' } as never)).toBe('Invalid value')
     expect(() => hydrateIsEmptyStrategy('mystery' as never)).toThrow('Unknown isEmpty strategy')
 
     expect(() =>
-      assertValidCheckSpec({ op: 'min', value: Number.NaN }),
-    ).toThrow('Check rule "min" requires a numeric value')
+      assertValidValidatorSpec({ op: 'min', value: Number.NaN }),
+    ).toThrow('Validator "min" requires a numeric value')
 
     expect(() =>
-      assertValidCheckSpec({ op: 'range', min: 1, max: Number.NaN }),
-    ).toThrow('Check rule "range" requires numeric min and max values')
+      assertValidValidatorSpec({ op: 'range', min: 1, max: Number.NaN }),
+    ).toThrow('Validator "range" requires numeric min and max values')
 
     expect(() =>
-      assertValidCheckSpec({ op: 'custom' } as never),
-    ).toThrow('Unknown named check op "custom"')
+      assertValidValidatorSpec({ op: 'custom' } as never),
+    ).toThrow('Unknown validator op "custom"')
   })
 })

--- a/packages/json/__tests__/conformance.test.ts
+++ b/packages/json/__tests__/conformance.test.ts
@@ -115,6 +115,7 @@ describe('JSON conformance fixtures', () => {
     const runtime = umpire({
       fields: parsed.fields,
       rules: parsed.rules,
+      validators: parsed.validators,
     })
 
     for (const testCase of cases) {
@@ -146,6 +147,7 @@ describe('JSON conformance failure fixtures', () => {
       const runtime = umpire({
         fields: parsed.fields,
         rules: parsed.rules,
+        validators: parsed.validators,
       })
 
       expect(() =>

--- a/packages/json/__tests__/conformance.test.ts
+++ b/packages/json/__tests__/conformance.test.ts
@@ -21,6 +21,8 @@ type ExpectedFieldStatus = {
   required: boolean
   reason: string | null
   reasons: string[]
+  valid?: boolean
+  error?: string
 }
 
 type ConformanceCase = {

--- a/packages/json/__tests__/parse.test.ts
+++ b/packages/json/__tests__/parse.test.ts
@@ -129,7 +129,7 @@ describe('fromJson', () => {
     ).toThrow('Unknown isEmpty strategy')
   })
 
-  test('round-trips fairWhen check expressions without dropping named-check metadata', () => {
+  test('round-trips fairWhen check expressions without dropping portable-validator metadata', () => {
     const schema: UmpireJsonSchema = {
       version: 1,
       fields: {

--- a/packages/json/__tests__/parse.test.ts
+++ b/packages/json/__tests__/parse.test.ts
@@ -73,6 +73,48 @@ describe('fromJson', () => {
     expect(getJsonDef(rules[2])).toEqual(schema.rules[2])
   })
 
+  test('hydrates validators into core config and surfaces validation metadata', () => {
+    const schema: UmpireJsonSchema = {
+      version: 1,
+      fields: {
+        email: { isEmpty: 'string' },
+      },
+      rules: [],
+      validators: {
+        email: {
+          op: 'email',
+          error: 'Must be a valid email address',
+        },
+      },
+    }
+
+    const parsed = fromJson(schema)
+    const runtime = umpire(parsed)
+
+    expect(runtime.check({ email: '' })).toMatchObject({
+      email: {
+        enabled: true,
+        fair: true,
+        required: false,
+      },
+    })
+    expect(runtime.check({ email: '' }).email.valid).toBeUndefined()
+    expect(runtime.check({ email: '' }).email.error).toBeUndefined()
+
+    expect(runtime.check({ email: 'invalid' })).toMatchObject({
+      email: {
+        enabled: true,
+        fair: true,
+        required: false,
+        valid: false,
+        error: 'Must be a valid email address',
+      },
+    })
+
+    expect(parsed.validators.email).toBeDefined()
+    expect(toJson(parsed)).toEqual(schema)
+  })
+
   test('rejects unknown isEmpty strategies', () => {
     expect(() =>
       fromJson({
@@ -148,5 +190,18 @@ describe('validateSchema', () => {
         ],
       }),
     ).toThrow('Invalid regex pattern')
+
+    expect(() =>
+      validateSchema({
+        version: 1,
+        fields: {},
+        rules: [],
+        validators: {
+          email: {
+            op: 'email',
+          },
+        },
+      }),
+    ).toThrow('Validator references unknown field "email"')
   })
 })

--- a/packages/json/__tests__/serialize.test.ts
+++ b/packages/json/__tests__/serialize.test.ts
@@ -9,7 +9,7 @@ import {
   requires,
 } from '@umpire/core'
 
-import { checks, fromJson, hydrateIsEmptyStrategy, toJson } from '../src/index.js'
+import { fromJson, hydrateIsEmptyStrategy, namedValidators, toJson } from '../src/index.js'
 import type { UmpireJsonSchema } from '../src/index.js'
 
 describe('toJson', () => {
@@ -76,9 +76,9 @@ describe('toJson', () => {
       fields,
       rules: [],
       validators: {
-        email: checks.email(),
+        email: namedValidators.email(),
         username: {
-          validator: checks.minLength(3),
+          validator: namedValidators.minLength(3),
           error: 'Username must be at least 3 characters',
         },
         slug: /^[a-z-]+$/,
@@ -105,7 +105,7 @@ describe('toJson', () => {
         {
           type: 'field:validator',
           field: 'slug',
-          description: 'Field validator cannot be serialized unless it uses a named check from @umpire/json',
+          description: 'Field validator cannot be serialized unless it uses portable validator metadata from @umpire/json',
           key: 'field:slug:validator',
         },
       ],
@@ -127,7 +127,7 @@ describe('toJson', () => {
       requires<typeof fields>('submit', 'email', 'username', {
         reason: 'Need an identity field',
       }),
-      requires<typeof fields>('submit', check('email', checks.email()), 'password', {
+      requires<typeof fields>('submit', check('email', namedValidators.email()), 'password', {
         reason: 'Need a valid email and password',
       }),
       disables<typeof fields>('mode', ['submit']),
@@ -218,7 +218,7 @@ describe('toJson', () => {
         {
           type: 'enabledWhen',
           field: 'submit',
-          description: 'enabledWhen() predicates are only serializable when hydrated from JSON or when they map to a named check',
+          description: 'enabledWhen() predicates are only serializable when hydrated from JSON or when they map to a portable validator',
           key: 'rule:enabledWhen:submit',
         },
       ],

--- a/packages/json/__tests__/serialize.test.ts
+++ b/packages/json/__tests__/serialize.test.ts
@@ -44,6 +44,12 @@ describe('toJson', () => {
           reason: 'Selected plan is not available for this account',
         },
       ],
+      validators: {
+        email: {
+          op: 'email',
+          error: 'Must be a valid email address',
+        },
+      },
       excluded: [
         {
           type: 'custom',
@@ -57,6 +63,53 @@ describe('toJson', () => {
     const parsed = fromJson(schema)
 
     expect(toJson(parsed)).toEqual(schema)
+  })
+
+  test('serializes portable validators and excludes unsupported validator shapes', () => {
+    const fields = {
+      email: {},
+      username: {},
+      slug: {},
+    }
+
+    expect(toJson({
+      fields,
+      rules: [],
+      validators: {
+        email: checks.email(),
+        username: {
+          validator: checks.minLength(3),
+          error: 'Username must be at least 3 characters',
+        },
+        slug: /^[a-z-]+$/,
+      },
+    })).toEqual({
+      version: 1,
+      fields: {
+        email: {},
+        username: {},
+        slug: {},
+      },
+      rules: [],
+      validators: {
+        email: {
+          op: 'email',
+        },
+        username: {
+          op: 'minLength',
+          value: 3,
+          error: 'Username must be at least 3 characters',
+        },
+      },
+      excluded: [
+        {
+          type: 'field:validator',
+          field: 'slug',
+          description: 'Field validator cannot be serialized unless it uses a named check from @umpire/json',
+          key: 'field:slug:validator',
+        },
+      ],
+    })
   })
 
   test('serializes structural hand-written rules and collects unsupported pieces in excluded', () => {

--- a/packages/json/__tests__/validate.test.ts
+++ b/packages/json/__tests__/validate.test.ts
@@ -163,6 +163,37 @@ describe('validateSchema', () => {
       },
       'Unknown rule type "mystery"',
     ],
+    [
+      'rejects validators that reference unknown fields',
+      {
+        version: 1,
+        fields: {},
+        rules: [],
+        validators: {
+          email: {
+            op: 'email',
+          },
+        },
+      },
+      'Validator references unknown field "email"',
+    ],
+    [
+      'rejects validators with non-string errors',
+      {
+        version: 1,
+        fields: {
+          email: {},
+        },
+        rules: [],
+        validators: {
+          email: {
+            op: 'email',
+            error: 7,
+          },
+        },
+      },
+      'Validator for field "email" must use a string error when provided',
+    ],
   ])('%s', (_label, schema, expectedMessage) => {
     expect(() =>
       validateSchema(schema as unknown as UmpireJsonSchema),

--- a/packages/json/conformance/README.md
+++ b/packages/json/conformance/README.md
@@ -51,7 +51,7 @@ the rules are still small enough to read at a glance.
 
 - structural rules
 - expression DSL operators, including combinators
-- named checks used as field-bound sources inside other rules
+- portable validators used as field-bound sources inside other rules
 - conditions
 - `oneOf()` with `prev`-assisted resolution
 - `anyOf()` reason collection
@@ -59,7 +59,7 @@ the rules are still small enough to read at a glance.
 - disabled-source cascades through downstream `disables()`
 - `fair: false` cascading into downstream availability failures
 - `fairWhen()`
-- named `check` ops
+- named validator ops
 - `isEmpty` strategies
 - schema round-trip, including carried `excluded` metadata
 - invalid schema references and runtime condition failures

--- a/packages/json/conformance/fixtures/validator-surface.json
+++ b/packages/json/conformance/fixtures/validator-surface.json
@@ -1,0 +1,109 @@
+{
+  "fixtureVersion": 1,
+  "id": "validator-surface",
+  "description": "Portable validators should only surface valid/error for enabled, satisfied fields and should not change structural availability.",
+  "schema": {
+    "version": 1,
+    "conditions": {
+      "emailEnabled": {
+        "type": "boolean"
+      }
+    },
+    "fields": {
+      "email": {
+        "isEmpty": "string"
+      }
+    },
+    "rules": [
+      {
+        "type": "enabledWhen",
+        "field": "email",
+        "when": { "op": "cond", "condition": "emailEnabled" },
+        "reason": "Email entry is disabled"
+      }
+    ],
+    "validators": {
+      "email": {
+        "op": "email",
+        "error": "Enter a valid email address"
+      }
+    }
+  },
+  "cases": [
+    {
+      "id": "disabled-field-skips-validator",
+      "values": {
+        "email": "not-an-email"
+      },
+      "conditions": {
+        "emailEnabled": false
+      },
+      "expectedAvailability": {
+        "email": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Email entry is disabled",
+          "reasons": ["Email entry is disabled"]
+        }
+      }
+    },
+    {
+      "id": "empty-satisfied-gate-skips-validator",
+      "values": {
+        "email": ""
+      },
+      "conditions": {
+        "emailEnabled": true
+      },
+      "expectedAvailability": {
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": []
+        }
+      }
+    },
+    {
+      "id": "invalid-email-surfaces-validation-error",
+      "values": {
+        "email": "not-an-email"
+      },
+      "conditions": {
+        "emailEnabled": true
+      },
+      "expectedAvailability": {
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "valid": false,
+          "error": "Enter a valid email address"
+        }
+      }
+    },
+    {
+      "id": "valid-email-surfaces-valid-true",
+      "values": {
+        "email": "crew@ballpark.example"
+      },
+      "conditions": {
+        "emailEnabled": true
+      },
+      "expectedAvailability": {
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "valid": true
+        }
+      }
+    }
+  ]
+}

--- a/packages/json/src/builders.ts
+++ b/packages/json/src/builders.ts
@@ -12,7 +12,7 @@ import {
   type Rule,
 } from '@umpire/core'
 
-import { createCheckSpecFromMetadata } from './check-ops.js'
+import { createValidatorSpecFromMetadata } from './check-ops.js'
 import { compileExpr, getExprFieldRefs } from './expr.js'
 import { attachJsonDef, getJsonDef } from './json-def.js'
 import type { JsonExpr, JsonRequiresDependency, JsonRule } from './schema.js'
@@ -78,10 +78,10 @@ function isPortableRuleOptions(value: unknown): value is PortableRuleOptions {
 }
 
 function createPortableCheckExpr(field: string, validator: NamedCheck<unknown>): JsonExpr {
-  const spec = createCheckSpecFromMetadata(validator)
+  const spec = createValidatorSpecFromMetadata(validator)
 
   if (!spec) {
-    throw new Error('[umpire/json] expr.check() requires a named check from @umpire/json')
+    throw new Error('[umpire/json] expr.check() requires a portable validator from @umpire/json')
   }
 
   return {

--- a/packages/json/src/check-ops.ts
+++ b/packages/json/src/check-ops.ts
@@ -1,13 +1,18 @@
 import type { JsonPrimitive, NamedCheck, NamedCheckMetadata } from '@umpire/core'
 
-import type { JsonCheckRule, JsonCheckOp, JsonCheckSpec, JsonValidatorDef } from './schema.js'
+import type {
+  JsonCheckRule,
+  JsonValidatorDef,
+  JsonValidatorOp,
+  JsonValidatorSpec,
+} from './schema.js'
 
 type Params = Readonly<Record<string, JsonPrimitive>>
 
 const EMAIL_REGEX = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/
 
-function createNamedCheck<T>(
-  name: JsonCheckOp,
+function createNamedValidator<T>(
+  name: JsonValidatorOp,
   validate: (value: NonNullable<T>) => boolean,
   params?: Params,
 ): NamedCheck<T> {
@@ -29,12 +34,12 @@ function isLengthLike(value: unknown): value is { length: number } {
   return (typeof value === 'string' || Array.isArray(value)) && typeof value.length === 'number'
 }
 
-export const checks = Object.freeze({
+export const namedValidators = Object.freeze({
   email() {
-    return createNamedCheck<string>('email', (value) => EMAIL_REGEX.test(value))
+    return createNamedValidator<string>('email', (value) => EMAIL_REGEX.test(value))
   },
   url() {
-    return createNamedCheck<string>('url', (value) => {
+    return createNamedValidator<string>('url', (value) => {
       try {
         const url = new URL(value)
         return url.protocol.length > 0
@@ -45,41 +50,41 @@ export const checks = Object.freeze({
   },
   matches(pattern: string) {
     const regex = new RegExp(pattern)
-    return createNamedCheck<string>('matches', (value) => regex.test(value), { pattern })
+    return createNamedValidator<string>('matches', (value) => regex.test(value), { pattern })
   },
   minLength(value: number) {
-    return createNamedCheck<string | unknown[]>('minLength', (input) =>
+    return createNamedValidator<string | unknown[]>('minLength', (input) =>
       isLengthLike(input) && input.length >= value, { value })
   },
   maxLength(value: number) {
-    return createNamedCheck<string | unknown[]>('maxLength', (input) =>
+    return createNamedValidator<string | unknown[]>('maxLength', (input) =>
       isLengthLike(input) && input.length <= value, { value })
   },
   min(value: number) {
-    return createNamedCheck<number>('min', (input) => typeof input === 'number' && input >= value, {
+    return createNamedValidator<number>('min', (input) => typeof input === 'number' && input >= value, {
       value,
     })
   },
   max(value: number) {
-    return createNamedCheck<number>('max', (input) => typeof input === 'number' && input <= value, {
+    return createNamedValidator<number>('max', (input) => typeof input === 'number' && input <= value, {
       value,
     })
   },
   range(min: number, max: number) {
-    return createNamedCheck<number>(
+    return createNamedValidator<number>(
       'range',
       (input) => typeof input === 'number' && input >= min && input <= max,
       { min, max },
     )
   },
   integer() {
-    return createNamedCheck<number>('integer', (input) => Number.isInteger(input))
+    return createNamedValidator<number>('integer', (input) => Number.isInteger(input))
   },
 })
 
-export function defaultCheckReason(rule: JsonCheckSpec | NamedCheckMetadata): string {
+export function defaultValidatorMessage(rule: JsonValidatorSpec | NamedCheckMetadata): string {
   const metadata = 'op' in rule
-    ? ({ __check: rule.op, params: paramsFromCheckSpec(rule) } satisfies NamedCheckMetadata)
+    ? ({ __check: rule.op, params: paramsFromValidatorSpec(rule) } satisfies NamedCheckMetadata)
     : rule
 
   switch (metadata.__check) {
@@ -106,7 +111,7 @@ export function defaultCheckReason(rule: JsonCheckSpec | NamedCheckMetadata): st
   }
 }
 
-function paramsFromCheckSpec(rule: JsonCheckSpec): Params | undefined {
+function paramsFromValidatorSpec(rule: JsonValidatorSpec): Params | undefined {
   switch (rule.op) {
     case 'matches':
       return { pattern: rule.pattern }
@@ -126,7 +131,9 @@ function paramsFromNamedCheckMetadata(metadata: NamedCheckMetadata): Params | un
   return metadata.params
 }
 
-export function createCheckSpecFromMetadata(metadata: NamedCheckMetadata): JsonCheckSpec | undefined {
+export function createValidatorSpecFromMetadata(
+  metadata: NamedCheckMetadata,
+): JsonValidatorSpec | undefined {
   const params = paramsFromNamedCheckMetadata(metadata)
 
   switch (metadata.__check) {
@@ -162,8 +169,8 @@ export function createCheckRuleFromMetadata(
   metadata: NamedCheckMetadata,
   reason?: string,
 ): JsonCheckRule | undefined {
-  const resolvedReason = reason && reason !== defaultCheckReason(metadata) ? reason : undefined
-  const spec = createCheckSpecFromMetadata(metadata)
+  const resolvedReason = reason && reason !== defaultValidatorMessage(metadata) ? reason : undefined
+  const spec = createValidatorSpecFromMetadata(metadata)
 
   if (!spec) {
     return undefined
@@ -178,7 +185,7 @@ export function createValidatorDefFromMetadata(
   metadata: NamedCheckMetadata,
   error?: string,
 ): JsonValidatorDef | undefined {
-  const spec = createCheckSpecFromMetadata(metadata)
+  const spec = createValidatorSpecFromMetadata(metadata)
 
   if (!spec) {
     return undefined
@@ -189,32 +196,32 @@ export function createValidatorDefFromMetadata(
     : { ...spec, error }
 }
 
-export function createNamedCheckFromSpec(spec: JsonCheckSpec): NamedCheck<any> {
+export function createNamedValidatorFromSpec(spec: JsonValidatorSpec): NamedCheck<any> {
   switch (spec.op) {
     case 'email':
-      return checks.email()
+      return namedValidators.email()
     case 'url':
-      return checks.url()
+      return namedValidators.url()
     case 'matches':
-      return checks.matches(spec.pattern)
+      return namedValidators.matches(spec.pattern)
     case 'minLength':
-      return checks.minLength(spec.value)
+      return namedValidators.minLength(spec.value)
     case 'maxLength':
-      return checks.maxLength(spec.value)
+      return namedValidators.maxLength(spec.value)
     case 'min':
-      return checks.min(spec.value)
+      return namedValidators.min(spec.value)
     case 'max':
-      return checks.max(spec.value)
+      return namedValidators.max(spec.value)
     case 'range':
-      return checks.range(spec.min, spec.max)
+      return namedValidators.range(spec.min, spec.max)
     case 'integer':
-      return checks.integer()
+      return namedValidators.integer()
   }
 }
 
-export const createNamedCheckFromRule: (rule: JsonCheckRule) => NamedCheck<any> = createNamedCheckFromSpec
+export const createNamedValidatorFromRule: (rule: JsonCheckRule) => NamedCheck<any> = createNamedValidatorFromSpec
 
-export function assertValidCheckSpec(rule: JsonCheckSpec): void {
+export function assertValidValidatorSpec(rule: JsonValidatorSpec): void {
   switch (rule.op) {
     case 'email':
     case 'url':
@@ -233,7 +240,7 @@ export function assertValidCheckSpec(rule: JsonCheckSpec): void {
     case 'min':
     case 'max':
       if (typeof rule.value !== 'number' || Number.isNaN(rule.value)) {
-        throw new Error(`[umpire/json] Check rule "${rule.op}" requires a numeric value`)
+        throw new Error(`[umpire/json] Validator "${rule.op}" requires a numeric value`)
       }
       return
     case 'range':
@@ -243,14 +250,14 @@ export function assertValidCheckSpec(rule: JsonCheckSpec): void {
         typeof rule.max !== 'number' ||
         Number.isNaN(rule.max)
       ) {
-        throw new Error('[umpire/json] Check rule "range" requires numeric min and max values')
+        throw new Error('[umpire/json] Validator "range" requires numeric min and max values')
       }
       return
     default:
-      throw new Error(`[umpire/json] Unknown named check op "${String((rule as { op?: unknown }).op)}"`)
+      throw new Error(`[umpire/json] Unknown validator op "${String((rule as { op?: unknown }).op)}"`)
   }
 }
 
 export function assertValidCheckRule(rule: JsonCheckRule): void {
-  assertValidCheckSpec(rule)
+  assertValidValidatorSpec(rule)
 }

--- a/packages/json/src/check-ops.ts
+++ b/packages/json/src/check-ops.ts
@@ -1,6 +1,6 @@
 import type { JsonPrimitive, NamedCheck, NamedCheckMetadata } from '@umpire/core'
 
-import type { JsonCheckRule, JsonCheckOp, JsonCheckSpec } from './schema.js'
+import type { JsonCheckRule, JsonCheckOp, JsonCheckSpec, JsonValidatorDef } from './schema.js'
 
 type Params = Readonly<Record<string, JsonPrimitive>>
 
@@ -172,6 +172,21 @@ export function createCheckRuleFromMetadata(
   return resolvedReason
     ? { type: 'check', field, reason: resolvedReason, ...spec }
     : { type: 'check', field, ...spec }
+}
+
+export function createValidatorDefFromMetadata(
+  metadata: NamedCheckMetadata,
+  error?: string,
+): JsonValidatorDef | undefined {
+  const spec = createCheckSpecFromMetadata(metadata)
+
+  if (!spec) {
+    return undefined
+  }
+
+  return error === undefined
+    ? spec
+    : { ...spec, error }
 }
 
 export function createNamedCheckFromSpec(spec: JsonCheckSpec): NamedCheck<any> {

--- a/packages/json/src/expr.ts
+++ b/packages/json/src/expr.ts
@@ -1,6 +1,6 @@
 import { getNamedCheckMetadata, type FieldDef, type FieldValues, type NamedCheckMetadata } from '@umpire/core'
 
-import { assertValidCheckSpec, createNamedCheckFromSpec } from './check-ops.js'
+import { assertValidValidatorSpec, createNamedValidatorFromSpec } from './check-ops.js'
 import type { JsonConditionDef, JsonExpr } from './schema.js'
 
 type ExprPredicate<
@@ -141,8 +141,8 @@ function compileInner<
       return (values) => !expr.values.includes(values[expr.field as keyof F & string] as never)
     case 'check': {
       assertField(expr.field, expr.op, options.fieldNames)
-      assertValidCheckSpec(expr.check)
-      const validator = createNamedCheckFromSpec(expr.check)
+      assertValidValidatorSpec(expr.check)
+      const validator = createNamedValidatorFromSpec(expr.check)
 
       return (values) => {
         const value = values[expr.field as keyof F & string]
@@ -227,7 +227,7 @@ export function compileExpr<
   }
 
   if (expr.op === 'check') {
-    predicate._namedCheck = getNamedCheckMetadata(createNamedCheckFromSpec(expr.check))
+    predicate._namedCheck = getNamedCheckMetadata(createNamedValidatorFromSpec(expr.check))
   }
 
   return predicate

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -1,4 +1,8 @@
-export { checks, createNamedCheckFromRule, defaultCheckReason } from './check-ops.js'
+export {
+  namedValidators,
+  createNamedValidatorFromRule,
+  defaultValidatorMessage,
+} from './check-ops.js'
 export {
   anyOfJson,
   createJsonRules,
@@ -18,8 +22,9 @@ export { validateSchema } from './validate.js'
 
 export type {
   ExcludedRule,
-  JsonCheckOp,
-  JsonCheckSpec,
+  JsonValidatorOp,
+  JsonValidatorSpec,
+  JsonValidatorDef,
   JsonCheckRule,
   JsonConditionDef,
   JsonConditionType,
@@ -28,7 +33,6 @@ export type {
   JsonIsEmptyStrategy,
   JsonRequiresDependency,
   JsonRule,
-  JsonValidatorDef,
   UmpireJsonSchema,
 } from './schema.js'
 export type { JsonExprBuilder, PortableRuleOptions } from './builders.js'

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -28,6 +28,7 @@ export type {
   JsonIsEmptyStrategy,
   JsonRequiresDependency,
   JsonRule,
+  JsonValidatorDef,
   UmpireJsonSchema,
 } from './schema.js'
 export type { JsonExprBuilder, PortableRuleOptions } from './builders.js'

--- a/packages/json/src/parse.ts
+++ b/packages/json/src/parse.ts
@@ -12,7 +12,11 @@ import {
   type ValidationMap,
 } from '@umpire/core'
 
-import { createNamedCheckFromRule, createNamedCheckFromSpec, defaultCheckReason } from './check-ops.js'
+import {
+  createNamedValidatorFromSpec,
+  createNamedValidatorFromRule,
+  defaultValidatorMessage,
+} from './check-ops.js'
 import { compileExpr } from './expr.js'
 import { attachJsonDef } from './json-def.js'
 import type {
@@ -76,7 +80,7 @@ function parseFieldDefs(fields: UmpireJsonSchema['fields']): ParsedFields {
 }
 
 function parseCheckRule<C extends Record<string, unknown>>(rule: JsonCheckRule): Rule<ParsedFields, C> {
-  const validator = createNamedCheckFromRule(rule)
+  const validator = createNamedValidatorFromRule(rule)
   const metadata = getNamedCheckMetadata(validator)
   const predicate = ((value: unknown) => validator.validate(value as never)) as NamedFairPredicate<C>
 
@@ -84,14 +88,14 @@ function parseCheckRule<C extends Record<string, unknown>>(rule: JsonCheckRule):
   predicate._namedCheck = metadata
 
   const parsedRule = fairWhen<ParsedFields, C>(rule.field, predicate, {
-    reason: rule.reason ?? defaultCheckReason(rule),
+    reason: rule.reason ?? defaultValidatorMessage(rule),
   })
 
   return attachJsonDef(parsedRule, rule)
 }
 
 function parseValidatorDef(definition: JsonValidatorDef) {
-  const validator = createNamedCheckFromSpec(definition)
+  const validator = createNamedValidatorFromSpec(definition)
 
   return attachJsonDef(
     definition.error === undefined

--- a/packages/json/src/parse.ts
+++ b/packages/json/src/parse.ts
@@ -9,17 +9,26 @@ import {
   type FieldDef,
   type FieldValues,
   type Rule,
+  type ValidationMap,
 } from '@umpire/core'
 
-import { createNamedCheckFromRule, defaultCheckReason } from './check-ops.js'
+import { createNamedCheckFromRule, createNamedCheckFromSpec, defaultCheckReason } from './check-ops.js'
 import { compileExpr } from './expr.js'
 import { attachJsonDef } from './json-def.js'
-import type { ExcludedRule, JsonCheckRule, JsonConditionDef, JsonRule, UmpireJsonSchema } from './schema.js'
+import type {
+  ExcludedRule,
+  JsonCheckRule,
+  JsonConditionDef,
+  JsonRule,
+  JsonValidatorDef,
+  UmpireJsonSchema,
+} from './schema.js'
 import { hydrateIsEmptyStrategy } from './strategies.js'
 import { validateSchema } from './validate.js'
 
 type ParsedFields = Record<string, FieldDef>
 type ParsedRules<C extends Record<string, unknown>> = Rule<ParsedFields, C>[]
+type ParsedValidators = ValidationMap<ParsedFields>
 type ParsedSchemaMeta = {
   conditions?: Record<string, JsonConditionDef>
   excluded?: ExcludedRule[]
@@ -79,6 +88,27 @@ function parseCheckRule<C extends Record<string, unknown>>(rule: JsonCheckRule):
   })
 
   return attachJsonDef(parsedRule, rule)
+}
+
+function parseValidatorDef(definition: JsonValidatorDef) {
+  const validator = createNamedCheckFromSpec(definition)
+
+  return attachJsonDef(
+    definition.error === undefined
+      ? { validator }
+      : { validator, error: definition.error },
+    definition,
+  )
+}
+
+function parseValidators(validators: UmpireJsonSchema['validators']): ParsedValidators {
+  const parsed = {} as ParsedValidators
+
+  for (const [field, definition] of Object.entries(validators ?? {})) {
+    parsed[field] = parseValidatorDef(definition)
+  }
+
+  return parsed
 }
 
 function parseRule<C extends Record<string, unknown>>(
@@ -152,6 +182,7 @@ export function fromJson<C extends Record<string, unknown> = Record<string, unkn
 ): {
   fields: ParsedFields
   rules: ParsedRules<C>
+  validators: ParsedValidators
 } {
   validateSchema(schema)
 
@@ -162,9 +193,11 @@ export function fromJson<C extends Record<string, unknown> = Record<string, unkn
 
   const fields = attachJsonDef(parseFieldDefs(schema.fields), meta)
   const rules = attachJsonDef(schema.rules.map((rule) => parseRule<C>(rule, schema)), meta)
+  const validators = parseValidators(schema.validators)
 
   return {
     fields,
     rules,
+    validators,
   }
 }

--- a/packages/json/src/schema.ts
+++ b/packages/json/src/schema.ts
@@ -28,7 +28,7 @@ export type JsonExpr =
   | { op: 'falsy'; field: string }
   | { op: 'in'; field: string; values: JsonPrimitive[] }
   | { op: 'notIn'; field: string; values: JsonPrimitive[] }
-  | { op: 'check'; field: string; check: JsonCheckSpec }
+  | { op: 'check'; field: string; check: JsonValidatorSpec }
   | { op: 'cond'; condition: string }
   | { op: 'condEq'; condition: string; value: JsonPrimitive }
   | { op: 'condIn'; condition: string; values: JsonPrimitive[] }
@@ -37,7 +37,7 @@ export type JsonExpr =
   | { op: 'or'; exprs: JsonExpr[] }
   | { op: 'not'; expr: JsonExpr }
 
-export type JsonCheckOp =
+export type JsonValidatorOp =
   | 'email'
   | 'url'
   | 'matches'
@@ -48,7 +48,7 @@ export type JsonCheckOp =
   | 'range'
   | 'integer'
 
-export type JsonCheckSpec =
+export type JsonValidatorSpec =
   | { op: 'email' | 'url' | 'integer' }
   | { op: 'matches'; pattern: string }
   | { op: 'minLength' | 'maxLength' | 'min' | 'max'; value: number }
@@ -58,9 +58,9 @@ export type JsonCheckRule = {
   type: 'check'
   field: string
   reason?: string
-} & JsonCheckSpec
+} & JsonValidatorSpec
 
-export type JsonValidatorDef = JsonCheckSpec & {
+export type JsonValidatorDef = JsonValidatorSpec & {
   error?: string
 }
 

--- a/packages/json/src/schema.ts
+++ b/packages/json/src/schema.ts
@@ -60,6 +60,10 @@ export type JsonCheckRule = {
   reason?: string
 } & JsonCheckSpec
 
+export type JsonValidatorDef = JsonCheckSpec & {
+  error?: string
+}
+
 export type JsonRequiresDependency = string | JsonExpr
 
 export type JsonRule =
@@ -87,5 +91,6 @@ export interface UmpireJsonSchema {
   conditions?: Record<string, JsonConditionDef>
   fields: Record<string, JsonFieldDef>
   rules: JsonRule[]
+  validators?: Record<string, JsonValidatorDef>
   excluded?: ExcludedRule[]
 }

--- a/packages/json/src/serialize.ts
+++ b/packages/json/src/serialize.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   createCheckRuleFromMetadata,
-  createCheckSpecFromMetadata,
+  createValidatorSpecFromMetadata,
   createValidatorDefFromMetadata,
 } from './check-ops.js'
 import { getJsonDef } from './json-def.js'
@@ -121,9 +121,9 @@ function createCheckParamsKeyPart(rule: Extract<JsonRule, { type: 'check' }>): s
 
 function createCheckExprFromMetadata(
   field: string,
-  metadata: Parameters<typeof createCheckSpecFromMetadata>[0],
+  metadata: Parameters<typeof createValidatorSpecFromMetadata>[0],
 ): Extract<JsonExpr, { op: 'check' }> | undefined {
-  const spec = createCheckSpecFromMetadata(metadata)
+  const spec = createValidatorSpecFromMetadata(metadata)
 
   return spec
     ? {
@@ -291,7 +291,7 @@ function serializeValidator(field: string, entry: unknown): SerializeValidatorRe
     return {
       excluded: [createExcluded(
         'field:validator',
-        'Field validator cannot be serialized unless it uses a named check from @umpire/json',
+        'Field validator cannot be serialized unless it uses portable validator metadata from @umpire/json',
         field,
         coverageKey,
       )],
@@ -305,7 +305,7 @@ function serializeValidator(field: string, entry: unknown): SerializeValidatorRe
     return {
       excluded: [createExcluded(
         'field:validator',
-        'Field validator uses named metadata that is not part of the JSON validator spec',
+        'Field validator uses metadata that is not part of the JSON validator spec',
         field,
         coverageKey,
       )],
@@ -374,7 +374,7 @@ function serializeInspection(
 
       return excludeInspection(
         inspection,
-        'enabledWhen() predicates are only serializable when hydrated from JSON or when they map to a named check',
+        'enabledWhen() predicates are only serializable when hydrated from JSON or when they map to a portable validator',
         undefined,
         createKey('rule', 'enabledWhen', inspection.target),
       )
@@ -422,7 +422,7 @@ function serializeInspection(
 
         return excludeInspection(
           inspection,
-          'disables() with predicate sources cannot be serialized unless hydrated from JSON or when they map to a named check',
+          'disables() with predicate sources cannot be serialized unless hydrated from JSON or when they map to a portable validator',
         )
       }
 
@@ -491,7 +491,7 @@ function serializeInspection(
 
       return excludeInspection(
         inspection,
-        'fairWhen() predicates are only serializable when hydrated from JSON or when they map to a named check on the same field',
+        'fairWhen() predicates are only serializable when hydrated from JSON or when they map to a portable validator on the same field',
         '(value, values, conditions) => boolean',
         createKey('rule', 'fairWhen', inspection.target),
       )
@@ -531,7 +531,7 @@ function serializeInspection(
       if (serializedDependencies.some((dependency) => dependency === undefined)) {
         return excludeInspection(
           inspection,
-          'requires() with predicate dependencies cannot be serialized unless hydrated from JSON or when those predicates map to named checks',
+          'requires() with predicate dependencies cannot be serialized unless hydrated from JSON or when those predicates map to portable validators',
           undefined,
         )
       }

--- a/packages/json/src/serialize.ts
+++ b/packages/json/src/serialize.ts
@@ -1,12 +1,18 @@
 import {
+  getNamedCheckMetadata,
   inspectRule,
   type FieldDef,
   type JsonPrimitive,
   type Rule,
   type RuleInspection,
+  type ValidationMap,
 } from '@umpire/core'
 
-import { createCheckRuleFromMetadata, createCheckSpecFromMetadata } from './check-ops.js'
+import {
+  createCheckRuleFromMetadata,
+  createCheckSpecFromMetadata,
+  createValidatorDefFromMetadata,
+} from './check-ops.js'
 import { getJsonDef } from './json-def.js'
 import type {
   ExcludedRule,
@@ -14,6 +20,7 @@ import type {
   JsonFieldDef,
   JsonExpr,
   JsonRule,
+  JsonValidatorDef,
   UmpireJsonSchema,
 } from './schema.js'
 import { getJsonIsEmptyStrategy } from './strategies.js'
@@ -30,11 +37,18 @@ export type ToJsonConfig<
 > = {
   fields: F
   rules: Rule<F, C>[]
+  validators?: ValidationMap<F>
   conditions?: Record<string, JsonConditionDef>
 }
 
 type SerializeRuleResult = {
   rules: JsonRule[]
+  excluded: ExcludedRule[]
+  coverageKeys: string[]
+}
+
+type SerializeValidatorResult = {
+  validator?: JsonValidatorDef
   excluded: ExcludedRule[]
   coverageKeys: string[]
 }
@@ -73,8 +87,16 @@ function createKey(...parts: string[]): string {
   return parts.map((part) => encodeURIComponent(part)).join(':')
 }
 
-function createFieldSlotKey(field: string, slot: 'default' | 'isEmpty'): string {
+function createFieldSlotKey(field: string, slot: 'default' | 'isEmpty' | 'validator'): string {
   return createKey('field', field, slot)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isValidationEntryObject(value: unknown): value is { validator: unknown; error?: unknown } {
+  return isRecord(value) && 'validator' in value
 }
 
 function createTargetsKeyPart(targets: string[]): string {
@@ -247,6 +269,55 @@ function serializeField(name: string, definition: FieldDef): {
   }
 
   return { field, excluded, coverageKeys }
+}
+
+function serializeValidator(field: string, entry: unknown): SerializeValidatorResult {
+  const coverageKey = createFieldSlotKey(field, 'validator')
+  const carried = getJsonDef<JsonValidatorDef>(entry)
+
+  if (carried) {
+    return {
+      validator: cloneJson(carried),
+      excluded: [],
+      coverageKeys: [coverageKey],
+    }
+  }
+
+  const validator = isValidationEntryObject(entry) ? entry.validator : entry
+  const error = isValidationEntryObject(entry) && typeof entry.error === 'string' ? entry.error : undefined
+  const metadata = getNamedCheckMetadata(validator)
+
+  if (!metadata) {
+    return {
+      excluded: [createExcluded(
+        'field:validator',
+        'Field validator cannot be serialized unless it uses a named check from @umpire/json',
+        field,
+        coverageKey,
+      )],
+      coverageKeys: [],
+    }
+  }
+
+  const serialized = createValidatorDefFromMetadata(metadata, error)
+
+  if (!serialized) {
+    return {
+      excluded: [createExcluded(
+        'field:validator',
+        'Field validator uses named metadata that is not part of the JSON validator spec',
+        field,
+        coverageKey,
+      )],
+      coverageKeys: [],
+    }
+  }
+
+  return {
+    validator: serialized,
+    excluded: [],
+    coverageKeys: [coverageKey],
+  }
 }
 
 function excludeInspection(
@@ -641,6 +712,7 @@ export function toJson<
   const meta = getJsonDef<SerializeMeta>(config.fields) ?? getJsonDef<SerializeMeta>(config.rules)
   const fields = {} as Record<string, JsonFieldDef>
   const rules: JsonRule[] = []
+  const validators = {} as Record<string, JsonValidatorDef>
   const generatedExcluded: ExcludedRule[] = []
   const coverageKeys = new Set<string>()
 
@@ -662,6 +734,23 @@ export function toJson<
     }
   }
 
+  for (const [fieldName, entry] of Object.entries(config.validators ?? {})) {
+    if (entry === undefined) {
+      continue
+    }
+
+    const serializedValidator = serializeValidator(fieldName, entry)
+
+    if (serializedValidator.validator) {
+      validators[fieldName] = serializedValidator.validator
+    }
+
+    generatedExcluded.push(...serializedValidator.excluded)
+    for (const key of serializedValidator.coverageKeys) {
+      coverageKeys.add(key)
+    }
+  }
+
   const conditions = config.conditions ?? meta?.conditions
   const excluded = mergeExcluded(
     meta?.excluded ? cloneJson(meta.excluded) : [],
@@ -672,6 +761,7 @@ export function toJson<
     version: 1,
     fields,
     rules,
+    ...(Object.keys(validators).length > 0 ? { validators } : {}),
     ...(conditions ? { conditions: cloneJson(conditions) } : {}),
     ...(excluded.length > 0 ? { excluded } : {}),
   }

--- a/packages/json/src/validate.ts
+++ b/packages/json/src/validate.ts
@@ -5,7 +5,7 @@ import type {
   JsonFieldDef,
   JsonValidatorDef,
 } from './schema.js'
-import { assertValidCheckRule, assertValidCheckSpec } from './check-ops.js'
+import { assertValidCheckRule, assertValidValidatorSpec } from './check-ops.js'
 import { compileExpr } from './expr.js'
 import { isJsonIsEmptyStrategy } from './strategies.js'
 
@@ -59,7 +59,7 @@ function validateValidator(field: string, validator: JsonValidatorDef, fieldName
     throw new Error(`[umpire/json] Validator references unknown field "${field}"`)
   }
 
-  assertValidCheckSpec(validator)
+  assertValidValidatorSpec(validator)
 
   if (validator.error !== undefined && typeof validator.error !== 'string') {
     throw new Error(`[umpire/json] Validator for field "${field}" must use a string error when provided`)

--- a/packages/json/src/validate.ts
+++ b/packages/json/src/validate.ts
@@ -1,5 +1,11 @@
-import type { ExcludedRule, UmpireJsonSchema, JsonRule, JsonFieldDef } from './schema.js'
-import { assertValidCheckRule } from './check-ops.js'
+import type {
+  ExcludedRule,
+  UmpireJsonSchema,
+  JsonRule,
+  JsonFieldDef,
+  JsonValidatorDef,
+} from './schema.js'
+import { assertValidCheckRule, assertValidCheckSpec } from './check-ops.js'
 import { compileExpr } from './expr.js'
 import { isJsonIsEmptyStrategy } from './strategies.js'
 
@@ -45,6 +51,18 @@ function validateExcludedRule(rule: ExcludedRule) {
 function assertField(field: string, fieldNames: Set<string>, context: string) {
   if (!fieldNames.has(field)) {
     throw new Error(`[umpire/json] Rule ${context} references unknown field "${field}"`)
+  }
+}
+
+function validateValidator(field: string, validator: JsonValidatorDef, fieldNames: Set<string>) {
+  if (!fieldNames.has(field)) {
+    throw new Error(`[umpire/json] Validator references unknown field "${field}"`)
+  }
+
+  assertValidCheckSpec(validator)
+
+  if (validator.error !== undefined && typeof validator.error !== 'string') {
+    throw new Error(`[umpire/json] Validator for field "${field}" must use a string error when provided`)
   }
 }
 
@@ -134,6 +152,10 @@ export function validateSchema(schema: UmpireJsonSchema): void {
 
   for (const rule of schema.rules ?? []) {
     validateRule(rule, fieldNames, schema.conditions)
+  }
+
+  for (const [field, validator] of Object.entries(schema.validators ?? {})) {
+    validateValidator(field, validator, fieldNames)
   }
 
   for (const rule of schema.excluded ?? []) {


### PR DESCRIPTION
Previous implementation of this portable json concept relied too heavily on "checks" to the point of confusion. Now migrated validators to utilize core's validator concepts. Fits much better this way.
