### PR TITLE
👯‍♀️ `eitherOf` in core - new rule primitive!

### DIFF
--- a/.changeset/green-mails-kneel.md
+++ b/.changeset/green-mails-kneel.md
@@ -1,7 +1,9 @@
 ---
 "@umpire/core": minor
+"@umpire/devtools": patch
 ---
 
 - Add `eitherOf(groupName, branches)`, a new core rule helper for named OR paths where each branch is a group of ANDed rules.
 - `eitherOf()` supports both availability and fairness constraints, validates that inner rules share the same targets and constraint, and allows multiple branches to pass at once.
 - `challenge()` and `inspectRule()` now preserve `eitherOf()` branch structure so named paths are visible in debugging output.
+- `@umpire/devtools` now renders `eitherOf()` branch groups in the challenge drawer so named paths are readable during inspection.

--- a/.changeset/green-mails-kneel.md
+++ b/.changeset/green-mails-kneel.md
@@ -1,0 +1,7 @@
+---
+"@umpire/core": minor
+---
+
+- Add `eitherOf(groupName, branches)`, a new core rule helper for named OR paths where each branch is a group of ANDed rules.
+- `eitherOf()` supports both availability and fairness constraints, validates that inner rules share the same targets and constraint, and allows multiple branches to pass at once.
+- `challenge()` and `inspectRule()` now preserve `eitherOf()` branch structure so named paths are visible in debugging output.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -105,6 +105,7 @@ export default defineConfig({
               { label: 'disables()', slug: 'api/rules/disables' },
               { label: 'oneOf()', slug: 'api/rules/one-of' },
               { label: 'anyOf()', slug: 'api/rules/any-of' },
+              { label: 'eitherOf()', slug: 'api/rules/either-of' },
               { label: 'check()', slug: 'api/rules/check' },
             ] },
             { label: 'check()', slug: 'api/check' },

--- a/docs/src/components/LearnDemos.tsx
+++ b/docs/src/components/LearnDemos.tsx
@@ -4,6 +4,7 @@ import {
   anyOf,
   check,
   disables,
+  eitherOf,
   enabledWhen,
   oneOf,
   requires,
@@ -485,6 +486,96 @@ export function AnyOfDemo() {
           Request link
         </button>
       </FieldCard>
+    </div>
+  )
+}
+
+const eitherOfFields = {
+  username: { isEmpty: (value: unknown) => !value },
+  password: { isEmpty: (value: unknown) => !value },
+  token:    { isEmpty: (value: unknown) => !value },
+  submit:   {},
+}
+
+const eitherOfUmp = umpire<typeof eitherOfFields>({
+  fields: eitherOfFields,
+  rules: [
+    eitherOf('loginPath', {
+      token: [
+        enabledWhen('submit', ({ token }) => !!token, {
+          reason: 'Enter a token',
+        }),
+      ],
+      credentials: [
+        enabledWhen('submit', ({ username }) => !!username, {
+          reason: 'Enter a username',
+        }),
+        enabledWhen('submit', ({ password }) => !!password, {
+          reason: 'Enter a password',
+        }),
+      ],
+    }),
+  ],
+})
+
+export function EitherOfDemo() {
+  const [values, setValues] = useState({
+    username: '',
+    password: '',
+    token: '',
+  })
+  const availability = eitherOfUmp.check({ ...values, submit: undefined })
+
+  function update(field: 'username' | 'password' | 'token', v: string) {
+    setValues((current) => ({ ...current, [field]: v }))
+  }
+
+  return (
+    <div className="learn-demo__stack">
+      <div className="learn-demo__row">
+        <FieldCard label="Username" availability={availability.username}>
+          <input
+            className="umpire-demo__input"
+            type="text"
+            aria-label="Username"
+            placeholder="alice"
+            value={values.username}
+            onInput={(event) => update('username', event.currentTarget.value)}
+          />
+        </FieldCard>
+
+        <FieldCard label="Password" availability={availability.password}>
+          <input
+            className="umpire-demo__input"
+            type="password"
+            aria-label="Password"
+            placeholder="••••••••"
+            value={values.password}
+            onInput={(event) => update('password', event.currentTarget.value)}
+          />
+        </FieldCard>
+
+        <FieldCard label="Backup token" availability={availability.token}>
+          <input
+            className="umpire-demo__input"
+            type="text"
+            aria-label="Backup token"
+            placeholder="ABC-123"
+            value={values.token}
+            onInput={(event) => update('token', event.currentTarget.value)}
+          />
+        </FieldCard>
+
+        <FieldCard label="Submit" availability={availability.submit}>
+          <button
+            type="button"
+            className="learn-demo__submit"
+            disabled={!availability.submit.enabled}
+          >
+            Sign in
+          </button>
+        </FieldCard>
+      </div>
     </div>
   )
 }

--- a/docs/src/components/SignupDemo.tsx
+++ b/docs/src/components/SignupDemo.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { z } from 'zod'
-import { anyOf, check, disables, enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
+import { check, disables, eitherOf, enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
 import type { FieldValues } from '@umpire/core'
 // useUmpireWithDevtools powers the named instance in the optional panel on this page.
 // Swap back to: import { useUmpire } from '@umpire/react'  (remove leading id arg)
@@ -72,10 +72,6 @@ const hasNumericCompanySize = check('companySize', fieldSchemas.shape.companySiz
 
 type SignupPredicate = (values: FieldValues<typeof signupFields>, conditions: SignupConditions) => boolean
 
-function allowWhenSsoOr(predicate: SignupPredicate): SignupPredicate {
-  return (values, conditions) => conditions.sso || predicate(values, conditions)
-}
-
 function allowWhenNotBusiness(predicate: SignupPredicate): SignupPredicate {
   return (values, conditions) => conditions.plan !== 'business' || predicate(values, conditions)
 }
@@ -103,32 +99,31 @@ const signupUmp = umpire<typeof signupFields, SignupConditions>({
       reason: 'SSO login — no password needed',
     }),
 
-    // Submit is available via EITHER path:
-    //   Path A — standard auth: email passes format validation
-    //   Path B — SSO: the domain is a known SSO provider
-    // anyOf enables submit when at least one path is satisfied.
-    anyOf(
-      enabledWhen('submit', hasValidEmail, {
-        reason: 'Enter a valid email address',
-      }),
-      enabledWhen('submit', (_v, c) => c.sso, {
-        reason: 'No SSO available for this domain',
-      }),
-    ),
-
-    // `oneOf()` does not fit here because it switches field branches, not
-    // predicate branches. These helpers keep the submit-path split readable.
-    enabledWhen('submit', allowWhenSsoOr((v) => !!v.password), {
-      reason: 'Enter a password',
-    }),
-    enabledWhen('submit', allowWhenSsoOr(hasStrongPassword), {
-      reason: 'Use at least 8 password characters',
-    }),
-    enabledWhen('submit', allowWhenSsoOr((v) => !!v.confirmPassword), {
-      reason: 'Confirm your password',
-    }),
-    enabledWhen('submit', allowWhenSsoOr((v) => v.confirmPassword === v.password), {
-      reason: 'Passwords must match',
+    // Submit can unlock through named auth paths without forcing a single
+    // winning branch the way oneOf() would.
+    eitherOf('submitAuth', {
+      sso: [
+        enabledWhen('submit', (_v, c) => c.sso, {
+          reason: 'No SSO available for this domain',
+        }),
+      ],
+      password: [
+        enabledWhen('submit', hasValidEmail, {
+          reason: 'Enter a valid email address',
+        }),
+        enabledWhen('submit', (v) => !!v.password, {
+          reason: 'Enter a password',
+        }),
+        enabledWhen('submit', hasStrongPassword, {
+          reason: 'Use at least 8 password characters',
+        }),
+        enabledWhen('submit', (v) => !!v.confirmPassword, {
+          reason: 'Confirm your password',
+        }),
+        enabledWhen('submit', (v) => v.confirmPassword === v.password, {
+          reason: 'Passwords must match',
+        }),
+      ],
     }),
 
     enabledWhen('submit', allowWhenNotBusiness((v) => !!v.companyName), {

--- a/docs/src/content/docs/api/rules.md
+++ b/docs/src/content/docs/api/rules.md
@@ -3,7 +3,7 @@ title: Rules Overview
 description: The built-in rule helpers for composing field availability.
 ---
 
-Every rule helper returns a `Rule<F, C>` object. Rules are plain values — they can be composed, stored, and combined with `anyOf()`.
+Every rule helper returns a `Rule<F, C>` object. Rules are plain values — they can be composed, stored, and combined with `anyOf()` or `eitherOf()`.
 
 | Rule | Purpose |
 |------|---------|
@@ -13,6 +13,7 @@ Every rule helper returns a `Rule<F, C>` object. Rules are plain values — they
 | [`disables()`](/umpire/api/rules/disables/) | Active source disables target fields |
 | [`oneOf()`](/umpire/api/rules/one-of/) | Only one branch of fields is active at a time |
 | [`anyOf()`](/umpire/api/rules/any-of/) | OR logic — pass if any inner rule passes |
+| [`eitherOf()`](/umpire/api/rules/either-of/) | Named OR paths where each branch is a group of ANDed rules |
 | [`check()`](/umpire/api/rules/check/) | Bridge validators into rules with preserved field metadata |
 
 Try each one interactively on the [Quick Start](/umpire/learn/) page.

--- a/docs/src/content/docs/api/rules/any-of.md
+++ b/docs/src/content/docs/api/rules/any-of.md
@@ -5,6 +5,8 @@ description: Pass if any inner rule passes — OR logic for availability.
 
 Multiple rules targeting the same field are ANDed by default. Wrap them in `anyOf()` when any one successful path should unlock the target.
 
+Use [`eitherOf()`](/umpire/api/rules/either-of/) when those OR paths need names and each path is itself a group of ANDed rules.
+
 ## Signature
 
 ```ts
@@ -31,4 +33,5 @@ Either a password or a bypass flag unlocks submit. When both fail, all inner rea
 ## See also
 
 - [Quick Start: anyOf](/umpire/learn/#anyof) — interactive demo
+- [`eitherOf()`](/umpire/api/rules/either-of/) — named OR branches built from rule groups
 - [`enabledWhen()`](/umpire/api/rules/enabled-when/) — the most common inner rule for `anyOf`

--- a/docs/src/content/docs/api/rules/either-of.md
+++ b/docs/src/content/docs/api/rules/either-of.md
@@ -1,0 +1,67 @@
+---
+title: eitherOf()
+description: Named OR paths built from ANDed rule groups.
+---
+
+Use `eitherOf()` when a field can unlock through one of several named paths, and each path has multiple rules that must all pass together.
+
+Unlike [`oneOf()`](/umpire/api/rules/one-of/), `eitherOf()` does not disable sibling branches and does not resolve a single active branch. Multiple branches may match at once.
+
+## Signature
+
+```ts
+eitherOf(
+  groupName,
+  {
+    branchA: [ruleA, ruleB],
+    branchB: [ruleC],
+  },
+)
+```
+
+Each branch must be non-empty. All inner rules across all branches must target the same fields and share the same constraint (`enabled` or `fair`).
+
+## Semantics
+
+- Rules inside a branch are ANDed.
+- Branches are ORed.
+- If any branch passes, the outer rule passes.
+- If every branch fails, inner reasons flatten in declaration order.
+- Multiple branches may pass at once.
+
+## Example
+
+```ts
+eitherOf('submitPath', {
+  sso: [
+    enabledWhen('submit', (_v, c) => c.sso, {
+      reason: 'No SSO available for this domain',
+    }),
+  ],
+  password: [
+    enabledWhen('submit', check('email', /^[^\s@]+@[^\s@]+\.[^\s@]+$/), {
+      reason: 'Enter a valid email address',
+    }),
+    enabledWhen('submit', ({ password }) => !!password, {
+      reason: 'Enter a password',
+    }),
+    enabledWhen('submit', ({ confirmPassword, password }) => confirmPassword === password, {
+      reason: 'Passwords must match',
+    }),
+  ],
+  magicLink: [
+    enabledWhen('submit', (_v, c) => c.magicLink === true, {
+      reason: 'Magic link is not available',
+    }),
+  ],
+})
+```
+
+## Challenge Output
+
+`challenge()` preserves the group name and each named branch's nested inner rule results. It reports matching branches rather than resolving a single winner.
+
+## See also
+
+- [`anyOf()`](/umpire/api/rules/any-of/) — plain OR across inner rules
+- [`oneOf()`](/umpire/api/rules/one-of/) — mutually exclusive field branches

--- a/docs/src/content/docs/api/rules/either-of.md
+++ b/docs/src/content/docs/api/rules/either-of.md
@@ -3,9 +3,11 @@ title: eitherOf()
 description: Named OR paths built from ANDed rule groups.
 ---
 
-Use `eitherOf()` when a field can unlock through one of several named paths, and each path has multiple rules that must all pass together.
+Named OR paths — each branch is a group of rules that must all pass together (AND). If any branch fully satisfies, the outer rule passes (OR). Name your branches when you need to debug which path matched, or when each path is more than one rule.
 
 Unlike [`oneOf()`](/umpire/api/rules/one-of/), `eitherOf()` does not disable sibling branches and does not resolve a single active branch. Multiple branches may match at once.
+
+Reach for [`anyOf()`](/umpire/api/rules/any-of/) when the OR paths are single rules and you don't need them named. Reach for `eitherOf()` when each path has multiple rules, or when you want `challenge()` to tell you exactly which path matched.
 
 ## Signature
 
@@ -26,18 +28,20 @@ Each branch must be non-empty. All inner rules across all branches must target t
 - Rules inside a branch are ANDed.
 - Branches are ORed.
 - If any branch passes, the outer rule passes.
-- If every branch fails, inner reasons flatten in declaration order.
+- If every branch fails, the outer rule's `reason` is the first inner reason of the first failing branch. `challenge()` gives you the full per-branch breakdown.
 - Multiple branches may pass at once.
 
 ## Example
 
 ```ts
-eitherOf('submitPath', {
+eitherOf('submitAuth', {
+  // SSO path: the IdP handles auth — no password needed
   sso: [
     enabledWhen('submit', (_v, c) => c.sso, {
       reason: 'No SSO available for this domain',
     }),
   ],
+  // Password path: email + password must both check out
   password: [
     enabledWhen('submit', check('email', /^[^\s@]+@[^\s@]+\.[^\s@]+$/), {
       reason: 'Enter a valid email address',
@@ -49,19 +53,62 @@ eitherOf('submitPath', {
       reason: 'Passwords must match',
     }),
   ],
-  magicLink: [
-    enabledWhen('submit', (_v, c) => c.magicLink === true, {
-      reason: 'Magic link is not available',
-    }),
-  ],
 })
 ```
 
+Submit unlocks the moment either branch fully passes. If you're on a known SSO domain, the password branch is irrelevant — and vice versa. Neither branch locks the other out.
+
 ## Challenge Output
 
-`challenge()` preserves the group name and each named branch's nested inner rule results. It reports matching branches rather than resolving a single winner.
+`challenge()` preserves the group name, each branch's inner results, and which branches matched. This makes it straightforward to see exactly why a path failed — or confirm which one succeeded.
+
+```ts
+// When all branches fail:
+{
+  rule: 'eitherOf',
+  group: 'submitAuth',
+  passed: false,
+  reason: 'No SSO available for this domain',  // first inner reason of first failing branch
+  matchedBranches: [],
+  branches: {
+    sso: {
+      passed: false,
+      inner: [{ rule: 'enabledWhen', reason: 'No SSO available for this domain', passed: false }],
+    },
+    password: {
+      passed: false,
+      inner: [
+        { rule: 'enabledWhen', reason: 'Enter a valid email address', passed: false },
+        { rule: 'enabledWhen', reason: 'Enter a password', passed: false },
+      ],
+    },
+  },
+}
+
+// When the 'password' branch passes:
+{
+  rule: 'eitherOf',
+  group: 'submitAuth',
+  passed: true,
+  matchedBranches: ['password'],
+  branches: {
+    sso:      { passed: false, inner: [...] },
+    password: { passed: true,  inner: [...] },
+  },
+}
+```
+
+## Creation-time validation
+
+`eitherOf()` rejects at creation time if:
+
+- no branches are provided
+- any branch has zero inner rules
+- inner rules across branches target different fields
+- inner rules mix `enabledWhen` and `fairWhen` (constraint must be consistent)
 
 ## See also
 
-- [`anyOf()`](/umpire/api/rules/any-of/) — plain OR across inner rules
+- [`anyOf()`](/umpire/api/rules/any-of/) — plain OR across single rules, no branch names
 - [`oneOf()`](/umpire/api/rules/one-of/) — mutually exclusive field branches
+- [Signup Form example](/umpire/examples/signup/) — `eitherOf` wiring SSO and password auth paths on a real form

--- a/docs/src/content/docs/api/rules/either-of.md
+++ b/docs/src/content/docs/api/rules/either-of.md
@@ -109,6 +109,7 @@ Submit unlocks the moment either branch fully passes. If you're on a known SSO d
 
 ## See also
 
+- [Quick Start: eitherOf](/umpire/learn/#eitherof) — interactive demo
 - [`anyOf()`](/umpire/api/rules/any-of/) — plain OR across single rules, no branch names
 - [`oneOf()`](/umpire/api/rules/one-of/) — mutually exclusive field branches
 - [Signup Form example](/umpire/examples/signup/) — `eitherOf` wiring SSO and password auth paths on a real form

--- a/docs/src/content/docs/examples/signup.mdx
+++ b/docs/src/content/docs/examples/signup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Signup Form + Zod Validation
-description: Availability and validation composed — Umpire decides which fields are in play, Zod validates the ones that are. Includes SSO detection via anyOf.
+description: Availability and validation composed — Umpire decides which fields are in play, Zod validates the ones that are. Includes SSO detection via eitherOf.
 ---
 
 import DevtoolsPanel from '../../../components/DevtoolsPanel.tsx'
@@ -20,15 +20,11 @@ Try typing `bob@acme.com` — the form recognizes the domain as an SSO provider,
 Assume the `fieldSchemas` object from the validation section below is already defined. The submit rules reuse those same field schemas through `check()` anywhere the logic is just “is this value well-formed?”
 
 ```ts
-import { anyOf, check, disables, enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
+import { check, disables, eitherOf, enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
 
 const hasValidEmail = check('email', fieldSchemas.shape.email)
 const hasStrongPassword = check('password', fieldSchemas.shape.password)
 const hasNumericCompanySize = check('companySize', fieldSchemas.shape.companySize)
-
-function allowWhenSsoOr(predicate) {
-  return (values, conditions) => conditions.sso || predicate(values, conditions)
-}
 
 function allowWhenNotBusiness(predicate) {
   return (values, conditions) => conditions.plan !== 'business' || predicate(values, conditions)
@@ -62,29 +58,31 @@ const signupUmp = umpire({
       reason: 'SSO login — no password needed',
     }),
 
-    // Submit is available via EITHER path — anyOf enables it when at least one passes
-    anyOf(
-      enabledWhen('submit', hasValidEmail, {
-        reason: 'Enter a valid email address',
-      }),
-      enabledWhen('submit', (_v, c) => c.sso, {
-        reason: 'No SSO available for this domain',
-      }),
-    ),
-
-    // `oneOf()` is not the right fit here because it selects field branches,
-    // not predicate branches. These helpers keep the path gating readable.
-    enabledWhen('submit', allowWhenSsoOr((v) => !!v.password), {
-      reason: 'Enter a password',
-    }),
-    enabledWhen('submit', allowWhenSsoOr(hasStrongPassword), {
-      reason: 'Use at least 8 password characters',
-    }),
-    enabledWhen('submit', allowWhenSsoOr((v) => !!v.confirmPassword), {
-      reason: 'Confirm your password',
-    }),
-    enabledWhen('submit', allowWhenSsoOr((v) => v.confirmPassword === v.password), {
-      reason: 'Passwords must match',
+    // Submit can unlock through named auth paths without resolving a single
+    // active branch.
+    eitherOf('submitAuth', {
+      sso: [
+        enabledWhen('submit', (_v, c) => c.sso, {
+          reason: 'No SSO available for this domain',
+        }),
+      ],
+      password: [
+        enabledWhen('submit', hasValidEmail, {
+          reason: 'Enter a valid email address',
+        }),
+        enabledWhen('submit', (v) => !!v.password, {
+          reason: 'Enter a password',
+        }),
+        enabledWhen('submit', hasStrongPassword, {
+          reason: 'Use at least 8 password characters',
+        }),
+        enabledWhen('submit', (v) => !!v.confirmPassword, {
+          reason: 'Confirm your password',
+        }),
+        enabledWhen('submit', (v) => v.confirmPassword === v.password, {
+          reason: 'Passwords must match',
+        }),
+      ],
     }),
 
     enabledWhen('submit', allowWhenNotBusiness((v) => !!v.companyName), {
@@ -102,7 +100,7 @@ const signupUmp = umpire({
 
 `confirmPassword` waits for `password`, and `fairWhen()` gives it a direct mismatch reason without disabling it. Company fields gate on the business plan. Company size waits for company name. The value-shape checks for email, password strength, and numeric company size are reused directly from the Zod field schemas instead of being rewritten by hand. When a field is disabled, Umpire suppresses `required` to `false` — a validation library should never complain about a field that isn't in play.
 
-The `submit` field ties the paths together. `anyOf` expresses OR-logic: submit is available if the standard auth path OR the SSO path is satisfied. The extra `enabledWhen` rules keep submit blocked until the active path has everything it needs, including password confirmation and business-only fields.
+The `submit` field ties the paths together. `eitherOf()` names the auth paths directly: submit is available if the password path OR the SSO path is satisfied. The extra `enabledWhen` rules still handle business-only fields that apply regardless of auth path.
 
 ## The SSO Conditions
 
@@ -221,7 +219,7 @@ Availability, required markers, disabled states, inline feedback, and blocked-su
 
 **Business plan** — company fields enable. Umpire keeps submit blocked until the company fields are filled, and Zod still checks that `companySize` is digits only.
 
-**Type a known domain** (e.g. `bob@acme.com`) — SSO condition activates. Plan flips to business. Company name fills automatically. Password fields disable via `disables()`. `anyOf` switches to the SSO path — submit no longer needs a password, just an email.
+**Type a known domain** (e.g. `bob@acme.com`) — SSO condition activates. Plan flips to business. Company name fills automatically. Password fields disable via `disables()`. `eitherOf()` matches the SSO path, so submit no longer needs a password.
 
 **Switch plans with stale values** — `play()` recommends clearing company fields. Apply resets and any stale submit or validation issues disappear with the values.
 
@@ -232,7 +230,7 @@ Availability, required markers, disabled states, inline feedback, and blocked-su
 | Concern | Owner | Example |
 | --- | --- | --- |
 | Should this field be in play? | Umpire | `companyName` disabled on personal plan; `password` disabled via SSO |
-| Which submit path is valid? | Umpire `anyOf` | Password auth OR SSO — whichever path satisfies |
+| Which submit path is valid? | Umpire `eitherOf` | Password auth OR SSO — whichever named path satisfies |
 | Is this value well-formed? | Zod | `email` must match a pattern |
 | What should reset after a transition? | Umpire `play()` | Password fields flagged when SSO activates |
 | Do we want a final submit-time schema pass? | Userland | Run Zod on button click and show a summary if desired |

--- a/docs/src/content/docs/learn.mdx
+++ b/docs/src/content/docs/learn.mdx
@@ -10,6 +10,7 @@ import {
   OneOfDemo,
   CheckDemo,
   AnyOfDemo,
+  EitherOfDemo,
   PlayDemo,
 } from '../../components/LearnDemos.tsx'
 
@@ -170,6 +171,34 @@ ump.check({ phone: '', email: '', submit: undefined }).submit
 
 <div class="umpire-demo learn-demo">
   <AnyOfDemo client:load />
+</div>
+
+## `eitherOf()`
+
+Use `eitherOf()` when the OR paths each require multiple rules to all pass. Each branch is ANDed internally — any one branch satisfying is enough to unlock the target. Branches are named so `challenge()` can tell you exactly which path matched.
+
+```ts
+const ump = umpire({
+  fields: { username: {}, password: {}, token: {}, submit: {} },
+  rules: [eitherOf('loginPath', {
+    token: [
+      enabledWhen('submit', ({ token }) => !!token, { reason: 'Enter a token' }),
+    ],
+    credentials: [
+      enabledWhen('submit', ({ username }) => !!username, { reason: 'Enter a username' }),
+      enabledWhen('submit', ({ password }) => !!password, { reason: 'Enter a password' }),
+    ],
+  })],
+})
+
+ump.check({ username: 'alice', password: '', token: '', submit: undefined }).submit
+// disabled — credentials branch needs both fields, token branch needs a token
+// fill username + password → enabled via 'credentials'
+// fill token alone → enabled via 'token'
+```
+
+<div class="umpire-demo learn-demo">
+  <EitherOfDemo client:load />
 </div>
 
 ## `play()`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -89,6 +89,7 @@ See the docs for full type details and behavior notes: https://sdougbrown.github
 - `disables(source, targets, options?)` — active source disables target fields
 - `oneOf(groupName, branches, options?)` — only one branch of fields is active at a time
 - `anyOf(...rules)` — OR logic: pass if any inner rule passes
+- `eitherOf(groupName, branches)` — named OR paths where each branch is a group of ANDed rules
 - `check(field, validator)` — bridge validators into rules with preserved field metadata
 
 Use `field<V>('name')` to create a typed field reference. Pass it to `fairWhen` (or any rule) to get a typed `value` parameter instead of `unknown`.

--- a/packages/core/__tests__/challenge.test.ts
+++ b/packages/core/__tests__/challenge.test.ts
@@ -400,6 +400,47 @@ describe('challenge', () => {
     ])
   })
 
+  test('does not recurse into eitherOf branches that already pass', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        disables<TestFields>('dates', ['endTime']),
+        eitherOf<TestFields>('endTimePaths', {
+          scheduled: [
+            requires('endTime', 'startTime'),
+          ],
+          fallback: [
+            enabledWhen('endTime', () => true),
+          ],
+        }),
+        requires<TestFields>('submit', 'endTime'),
+      ],
+    })
+
+    const challenge = ump.challenge('submit', {
+      dates: ['2026-04-01'],
+      endTime: '10:00',
+    })
+
+    expect(challenge.transitiveDeps).toEqual([
+      expect.objectContaining({
+        field: 'endTime',
+        enabled: false,
+        reason: 'overridden by dates',
+      }),
+    ])
+    expect(challenge.transitiveDeps.map((entry) => entry.field)).not.toContain('startTime')
+  })
+
   test('surfaces preserved field metadata for check()-based predicates', () => {
     const ump = umpire<TestFields>({
       fields: {

--- a/packages/core/__tests__/challenge.test.ts
+++ b/packages/core/__tests__/challenge.test.ts
@@ -1,4 +1,14 @@
-import { anyOf, check, defineRule, disables, enabledWhen, fairWhen, oneOf, requires } from '../src/rules.js'
+import {
+  anyOf,
+  check,
+  defineRule,
+  disables,
+  eitherOf,
+  enabledWhen,
+  fairWhen,
+  oneOf,
+  requires,
+} from '../src/rules.js'
 import { umpire } from '../src/umpire.js'
 
 type TestFields = {
@@ -250,6 +260,142 @@ describe('challenge', () => {
           expect.objectContaining({ rule: 'enabledWhen', reason: 'first failed', passed: false }),
           expect.objectContaining({ rule: 'enabledWhen', reason: 'second failed', passed: false }),
         ],
+      }),
+    ])
+  })
+
+  test('groups inner results by named branch for eitherOf rules', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        eitherOf<TestFields>('auth', {
+          sso: [
+            enabledWhen<TestFields>('submit', () => false, {
+              reason: 'No SSO available for this domain',
+            }),
+          ],
+          password: [
+            requires<TestFields>('submit', 'email', {
+              reason: 'Enter a valid email address',
+            }),
+            enabledWhen<TestFields>('submit', () => false, {
+              reason: 'Enter a password',
+            }),
+          ],
+        }),
+      ],
+    })
+
+    const challenge = ump.challenge('submit', {})
+
+    expect(challenge.directReasons).toEqual([
+      expect.objectContaining({
+        rule: 'eitherOf',
+        passed: false,
+        reason: 'No SSO available for this domain',
+        group: 'auth',
+        matchedBranches: [],
+        branches: {
+          sso: {
+            passed: false,
+            inner: [
+              expect.objectContaining({
+                rule: 'enabledWhen',
+                reason: 'No SSO available for this domain',
+                passed: false,
+              }),
+            ],
+          },
+          password: {
+            passed: false,
+            inner: [
+              expect.objectContaining({
+                rule: 'requires',
+                reason: 'Enter a valid email address',
+                passed: false,
+              }),
+              expect.objectContaining({
+                rule: 'enabledWhen',
+                reason: 'Enter a password',
+                passed: false,
+              }),
+            ],
+          },
+        },
+      }),
+    ])
+  })
+
+  test('follows nested requires chains inside eitherOf rules', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        disables<TestFields>('dates', ['startTime']),
+        eitherOf<TestFields>('endTimePaths', {
+          scheduled: [
+            requires('endTime', 'startTime'),
+          ],
+          fallback: [
+            enabledWhen('endTime', () => false, { reason: 'fallback failed' }),
+          ],
+        }),
+        requires<TestFields>('submit', 'endTime'),
+      ],
+    })
+
+    const challenge = ump.challenge('submit', {
+      dates: ['2026-04-01'],
+      startTime: '09:00',
+      endTime: '10:00',
+    })
+
+    expect(challenge.transitiveDeps).toEqual([
+      expect.objectContaining({
+        field: 'endTime',
+        enabled: false,
+        reason: 'requires startTime',
+        causedBy: [
+          expect.objectContaining({
+            rule: 'eitherOf',
+            branches: {
+              scheduled: {
+                passed: false,
+                inner: [
+                  expect.objectContaining({ rule: 'requires', dependency: 'startTime' }),
+                ],
+              },
+              fallback: {
+                passed: false,
+                inner: [
+                  expect.objectContaining({ rule: 'enabledWhen', reason: 'fallback failed' }),
+                ],
+              },
+            },
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        field: 'startTime',
+        enabled: false,
+        reason: 'overridden by dates',
       }),
     ])
   })

--- a/packages/core/__tests__/emptiness.test.ts
+++ b/packages/core/__tests__/emptiness.test.ts
@@ -1,4 +1,12 @@
-import { isEmptyArray, isEmptyObject, isEmptyPresent, isEmptyString, isSatisfied } from '../src/index.js'
+import {
+  eitherOf,
+  enabledWhen,
+  isEmptyArray,
+  isEmptyObject,
+  isEmptyPresent,
+  isEmptyString,
+  isSatisfied,
+} from '../src/index.js'
 
 describe('emptiness helpers', () => {
   test('isEmptyPresent matches the default nil-only emptiness semantics', () => {
@@ -34,5 +42,13 @@ describe('emptiness helpers', () => {
     expect(isEmptyObject(undefined)).toBe(true)
     expect(isSatisfied({}, { isEmpty: isEmptyObject })).toBe(false)
     expect(isSatisfied({ theme: 'dark' }, { isEmpty: isEmptyObject })).toBe(true)
+  })
+
+  test('re-exports eitherOf from the public entrypoint', () => {
+    const rule = eitherOf<{ alpha: {} }>('entry', {
+      only: [enabledWhen('alpha', () => true)],
+    })
+
+    expect(rule.type).toBe('eitherOf')
   })
 })

--- a/packages/core/__tests__/graph.test.ts
+++ b/packages/core/__tests__/graph.test.ts
@@ -1,4 +1,4 @@
-import { check, defineRule, disables, enabledWhen, oneOf, requires } from '../src/rules.js'
+import { check, defineRule, disables, eitherOf, enabledWhen, oneOf, requires } from '../src/rules.js'
 import { buildGraph, detectCycles, exportGraph, topologicalSort } from '../src/graph.js'
 
 type TestFields = {
@@ -201,6 +201,41 @@ describe('graph utilities', () => {
         { from: 'gamma', to: 'beta', type: 'oneOf' },
       ],
     })
+  })
+
+  test('unions eitherOf branch sources into ordering and informational edges', () => {
+    const fields: TestFields = {
+      alpha: {},
+      beta: {},
+      gamma: {},
+      delta: {},
+      epsilon: {},
+    }
+    const graph = buildGraph(fields, [
+      eitherOf<TestFields>('betaPaths', {
+        dependency: [
+          requires('beta', 'alpha'),
+        ],
+        conditional: [
+          enabledWhen('beta', check('gamma', (value) => value === 'ready')),
+        ],
+      }),
+    ])
+
+    expect(graph.edges).toEqual([
+      { from: 'alpha', to: 'beta', type: 'eitherOf', ordering: true },
+      { from: 'gamma', to: 'beta', type: 'eitherOf', ordering: false },
+    ])
+    expect(exportGraph(graph)).toEqual({
+      nodes: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'],
+      edges: [
+        { from: 'alpha', to: 'beta', type: 'eitherOf' },
+        { from: 'gamma', to: 'beta', type: 'eitherOf' },
+      ],
+    })
+
+    const order = topologicalSort(graph, Object.keys(fields))
+    expect(order.indexOf('alpha')).toBeLessThan(order.indexOf('beta'))
   })
 
   test('deduplicates duplicate edges and skips self-references', () => {

--- a/packages/core/__tests__/rules.test.ts
+++ b/packages/core/__tests__/rules.test.ts
@@ -7,7 +7,9 @@ import {
   createRules,
   defineRule,
   disables,
+  eitherOf,
   enabledWhen,
+  fairWhen,
   getNamedCheckMetadata,
   inspectPredicate,
   inspectRule,
@@ -500,6 +502,127 @@ describe('anyOf', () => {
   })
 })
 
+describe('eitherOf', () => {
+  test('throws when no branches are provided', () => {
+    expect(() => eitherOf<TestFields, TestConditions>('auth', {})).toThrow(
+      'eitherOf("auth") must include at least one branch',
+    )
+  })
+
+  test('throws on empty branches', () => {
+    expect(() =>
+      eitherOf<TestFields, TestConditions>('auth', {
+        sso: [],
+        password: [enabledWhen('alpha', () => true)],
+      }),
+    ).toThrow('eitherOf("auth") branch "sso" must not be empty')
+  })
+
+  test('validates that all inner rules target the same fields', () => {
+    expect(() =>
+      eitherOf<TestFields, TestConditions>('auth', {
+        sso: [enabledWhen('alpha', () => true)],
+        password: [enabledWhen('beta', () => true)],
+      }),
+    ).toThrow('eitherOf("auth") rules must target the same fields')
+  })
+
+  test('validates that all inner rules share the same constraint', () => {
+    expect(() =>
+      eitherOf<TestFields, TestConditions>('auth', {
+        sso: [
+          enabledWhen('alpha', () => true),
+        ],
+        password: [
+          fairWhen('alpha', () => true),
+        ],
+      }),
+    ).toThrow('eitherOf("auth") cannot mix fairWhen rules with availability rules')
+  })
+
+  test('passes if one branch passes', () => {
+    const rule = eitherOf<TestFields, TestConditions>('auth', {
+      sso: [
+        enabledWhen('alpha', () => false, { reason: 'sso unavailable' }),
+      ],
+      password: [
+        enabledWhen('alpha', () => true, { reason: 'need password' }),
+      ],
+    })
+
+    expect(rule.evaluate({}, { allow: false }).get('alpha')).toEqual({
+      enabled: true,
+      reason: null,
+    })
+  })
+
+  test('passes if multiple branches pass', () => {
+    const rule = eitherOf<TestFields, TestConditions>('auth', {
+      sso: [
+        enabledWhen('alpha', () => true, { reason: 'sso unavailable' }),
+      ],
+      password: [
+        enabledWhen('alpha', () => true, { reason: 'need password' }),
+      ],
+      magicLink: [
+        enabledWhen('alpha', () => false, { reason: 'magic link unavailable' }),
+      ],
+    })
+
+    expect(rule.evaluate({}, { allow: false }).get('alpha')).toEqual({
+      enabled: true,
+      reason: null,
+    })
+  })
+
+  test('collects flattened failure reasons in branch order when every branch fails', () => {
+    const rule = eitherOf<TestFields, TestConditions>('auth', {
+      sso: [
+        enabledWhen('alpha', () => false, { reason: 'sso unavailable' }),
+      ],
+      password: [
+        enabledWhen('alpha', () => false, { reason: 'enter a password' }),
+        enabledWhen('alpha', () => false, { reason: 'password too short' }),
+      ],
+    })
+
+    expect(rule.evaluate({}, { allow: false }).get('alpha')).toEqual({
+      enabled: false,
+      reason: 'sso unavailable',
+      reasons: ['sso unavailable', 'enter a password', 'password too short'],
+    })
+  })
+
+  test('supports fair OR logic across named branches', () => {
+    const rule = eitherOf<TestFields, TestConditions>('compatibility', {
+      socket: [
+        fairWhen('alpha', (value, values) => value === values.beta, {
+          reason: 'socket mismatch',
+        }),
+      ],
+      override: [
+        fairWhen('alpha', (_value, values) => values.delta === 'override', {
+          reason: 'override missing',
+        }),
+      ],
+    })
+
+    expect(rule.evaluate({ alpha: 'am5', beta: 'am5' }, { allow: false }).get('alpha')).toEqual({
+      enabled: true,
+      fair: true,
+      reason: null,
+    })
+    expect(
+      rule.evaluate({ alpha: 'am5', beta: 'lga1700', delta: 'missing' }, { allow: false }).get('alpha'),
+    ).toEqual({
+      enabled: true,
+      fair: false,
+      reason: 'socket mismatch',
+      reasons: ['socket mismatch', 'override missing'],
+    })
+  })
+})
+
 describe('defineRule', () => {
   test('creates an enabled custom rule by default', () => {
     const rule = defineRule<TestFields, TestConditions>({
@@ -775,6 +898,40 @@ describe('inspectRule', () => {
       ],
     })
   })
+
+  test('describes eitherOf branches', () => {
+    const rule = eitherOf<TestFields, TestConditions>('auth', {
+      sso: [
+        enabledWhen('alpha', () => false, { reason: 'sso unavailable' }),
+      ],
+      password: [
+        enabledWhen('alpha', () => true),
+      ],
+    })
+
+    expect(inspectRule(rule)).toEqual({
+      kind: 'eitherOf',
+      groupName: 'auth',
+      constraint: 'enabled',
+      branches: {
+        sso: [
+          {
+            kind: 'enabledWhen',
+            target: 'alpha',
+            reason: 'sso unavailable',
+            hasDynamicReason: false,
+          },
+        ],
+        password: [
+          {
+            kind: 'enabledWhen',
+            target: 'alpha',
+            hasDynamicReason: false,
+          },
+        ],
+      },
+    })
+  })
 })
 
 describe('createRules', () => {
@@ -786,6 +943,7 @@ describe('createRules', () => {
       'check',
       'defineRule',
       'disables',
+      'eitherOf',
       'enabledWhen',
       'fairWhen',
       'oneOf',

--- a/packages/core/__tests__/rules.test.ts
+++ b/packages/core/__tests__/rules.test.ts
@@ -16,6 +16,7 @@ import {
   oneOf,
   requires,
 } from '../src/rules.js'
+import type { Rule } from '../src/types.js'
 
 type TestFields = {
   alpha: {}
@@ -931,6 +932,26 @@ describe('inspectRule', () => {
         ],
       },
     })
+  })
+
+  test('returns undefined when eitherOf contains an uninspectable inner rule', () => {
+    const opaqueRule: Rule<TestFields, TestConditions> = {
+      type: 'opaque',
+      targets: ['alpha'],
+      sources: ['beta'],
+      evaluate: () => new Map([
+        ['alpha', { enabled: true, reason: null }],
+      ]),
+    }
+
+    const rule = eitherOf<TestFields, TestConditions>('auth', {
+      password: [
+        enabledWhen('alpha', () => true),
+      ],
+      opaque: [opaqueRule],
+    })
+
+    expect(inspectRule(rule)).toBeUndefined()
   })
 })
 

--- a/packages/core/src/composite.ts
+++ b/packages/core/src/composite.ts
@@ -1,0 +1,66 @@
+import type { RuleEvaluation } from './types.js'
+
+export type CompositeConstraint = 'enabled' | 'fair'
+export type CompositeMode = 'and' | 'or'
+
+export function getCompositeFailureReasons(result: RuleEvaluation): string[] {
+  if (result.reasons && result.reasons.length > 0) {
+    return [...result.reasons]
+  }
+
+  if (result.reason !== null) {
+    return [result.reason]
+  }
+
+  return []
+}
+
+export function combineCompositeResults(
+  constraint: CompositeConstraint,
+  mode: CompositeMode,
+  results: RuleEvaluation[],
+): RuleEvaluation {
+  const passed =
+    constraint === 'fair'
+      ? mode === 'and'
+        ? results.every((result) => result.fair !== false)
+        : results.some((result) => result.fair !== false)
+      : mode === 'and'
+        ? results.every((result) => result.enabled)
+        : results.some((result) => result.enabled)
+
+  if (passed) {
+    return constraint === 'fair'
+      ? {
+          enabled: true,
+          fair: true,
+          reason: null,
+        }
+      : {
+          enabled: true,
+          reason: null,
+        }
+  }
+
+  const reasons = results.flatMap(getCompositeFailureReasons)
+
+  return constraint === 'fair'
+    ? {
+        enabled: true,
+        fair: false,
+        reason: reasons[0] ?? null,
+        reasons: reasons.length === 0 ? undefined : reasons,
+      }
+    : {
+        enabled: false,
+        reason: reasons[0] ?? null,
+        reasons: reasons.length === 0 ? undefined : reasons,
+      }
+}
+
+export function getCompositeTargetEvaluation(
+  evaluation: Map<string, RuleEvaluation>,
+  target: string,
+): RuleEvaluation {
+  return evaluation.get(target) ?? { enabled: true, reason: null }
+}

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -14,6 +14,68 @@ function getFailureReasons(result: RuleEvaluation): string[] {
   return []
 }
 
+function combineOrResults(constraint: 'enabled' | 'fair', results: RuleEvaluation[]): RuleEvaluation {
+  if (constraint === 'fair') {
+    if (results.some((result) => result.fair !== false)) {
+      return {
+        enabled: true,
+        fair: true,
+        reason: null,
+      }
+    }
+
+    const reasons = results.flatMap(getFailureReasons)
+    return {
+      enabled: true,
+      fair: false,
+      reason: reasons[0] ?? null,
+      reasons: reasons.length === 0 ? undefined : reasons,
+    }
+  }
+
+  if (results.some((result) => result.enabled)) {
+    return { enabled: true, reason: null }
+  }
+
+  const reasons = results.flatMap(getFailureReasons)
+  return {
+    enabled: false,
+    reason: reasons[0] ?? null,
+    reasons: reasons.length === 0 ? undefined : reasons,
+  }
+}
+
+function combineAndResults(constraint: 'enabled' | 'fair', results: RuleEvaluation[]): RuleEvaluation {
+  if (constraint === 'fair') {
+    if (results.every((result) => result.fair !== false)) {
+      return {
+        enabled: true,
+        fair: true,
+        reason: null,
+      }
+    }
+
+    const reasons = results.flatMap(getFailureReasons)
+    return {
+      enabled: true,
+      fair: false,
+      reason: reasons[0] ?? null,
+      reasons: reasons.length === 0 ? undefined : reasons,
+    }
+  }
+
+  if (results.every((result) => result.enabled)) {
+    return { enabled: true, reason: null }
+  }
+
+  const reasons = results.flatMap(getFailureReasons)
+  return {
+    enabled: false,
+    reason: reasons[0] ?? null,
+    reasons: reasons.length === 0 ? undefined : reasons,
+  }
+}
+
 function partitionRulesByPhase<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -88,34 +150,27 @@ export function evaluateRuleForField<
       ),
     )
 
-    if (metadata.constraint === 'fair') {
-      if (innerResults.some((result) => result.fair !== false)) {
-        return {
-          enabled: true,
-          fair: true,
-          reason: null,
-        }
-      }
+    return combineOrResults(metadata.constraint, innerResults)
+  }
 
-      const reasons = innerResults.flatMap(getFailureReasons)
-      return {
-        enabled: true,
-        fair: false,
-        reason: reasons[0] ?? null,
-        reasons: reasons.length === 0 ? undefined : reasons,
-      }
-    }
+  if (metadata?.kind === 'eitherOf') {
+    const branchResults = Object.values(metadata.branches).map((branchRules) =>
+      combineAndResults(
+        metadata.constraint,
+        branchRules.map((innerRule) =>
+          evaluateRuleForField(
+            innerRule,
+            field,
+            fields,
+            values,
+            conditions,
+            prev,
+            availability,
+            baseRuleCache,
+          )),
+      ))
 
-    if (innerResults.some((result) => result.enabled)) {
-      return { enabled: true, reason: null }
-    }
-
-    const reasons = innerResults.flatMap(getFailureReasons)
-    return {
-      enabled: false,
-      reason: reasons[0] ?? null,
-      reasons: reasons.length === 0 ? undefined : reasons,
-    }
+    return combineOrResults(metadata.constraint, branchResults)
   }
 
   if (metadata?.kind === 'requires') {

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -1,80 +1,10 @@
+import {
+  combineCompositeResults,
+  getCompositeFailureReasons,
+} from './composite.js'
 import { isSatisfied } from './satisfaction.js'
 import { getInternalRuleMetadata, isFairRule, isGateRule, resolveReason } from './rules.js'
 import type { AvailabilityMap, FieldDef, FieldValues, Rule, RuleEvaluation } from './types.js'
-
-function getFailureReasons(result: RuleEvaluation): string[] {
-  if (result.reasons && result.reasons.length > 0) {
-    return [...result.reasons]
-  }
-
-  if (result.reason !== null) {
-    return [result.reason]
-  }
-
-  return []
-}
-
-function combineOrResults(constraint: 'enabled' | 'fair', results: RuleEvaluation[]): RuleEvaluation {
-  if (constraint === 'fair') {
-    if (results.some((result) => result.fair !== false)) {
-      return {
-        enabled: true,
-        fair: true,
-        reason: null,
-      }
-    }
-
-    const reasons = results.flatMap(getFailureReasons)
-    return {
-      enabled: true,
-      fair: false,
-      reason: reasons[0] ?? null,
-      reasons: reasons.length === 0 ? undefined : reasons,
-    }
-  }
-
-  if (results.some((result) => result.enabled)) {
-    return { enabled: true, reason: null }
-  }
-
-  const reasons = results.flatMap(getFailureReasons)
-  return {
-    enabled: false,
-    reason: reasons[0] ?? null,
-    reasons: reasons.length === 0 ? undefined : reasons,
-  }
-}
-
-function combineAndResults(constraint: 'enabled' | 'fair', results: RuleEvaluation[]): RuleEvaluation {
-  if (constraint === 'fair') {
-    if (results.every((result) => result.fair !== false)) {
-      return {
-        enabled: true,
-        fair: true,
-        reason: null,
-      }
-    }
-
-    const reasons = results.flatMap(getFailureReasons)
-    return {
-      enabled: true,
-      fair: false,
-      reason: reasons[0] ?? null,
-      reasons: reasons.length === 0 ? undefined : reasons,
-    }
-  }
-
-  if (results.every((result) => result.enabled)) {
-    return { enabled: true, reason: null }
-  }
-
-  const reasons = results.flatMap(getFailureReasons)
-  return {
-    enabled: false,
-    reason: reasons[0] ?? null,
-    reasons: reasons.length === 0 ? undefined : reasons,
-  }
-}
 
 function partitionRulesByPhase<
   F extends Record<string, FieldDef>,
@@ -150,13 +80,14 @@ export function evaluateRuleForField<
       ),
     )
 
-    return combineOrResults(metadata.constraint, innerResults)
+    return combineCompositeResults(metadata.constraint, 'or', innerResults)
   }
 
   if (metadata?.kind === 'eitherOf') {
     const branchResults = Object.values(metadata.branches).map((branchRules) =>
-      combineAndResults(
+      combineCompositeResults(
         metadata.constraint,
+        'and',
         branchRules.map((innerRule) =>
           evaluateRuleForField(
             innerRule,
@@ -168,9 +99,10 @@ export function evaluateRuleForField<
             availability,
             baseRuleCache,
           )),
-      ))
+      ),
+    )
 
-    return combineOrResults(metadata.constraint, branchResults)
+    return combineCompositeResults(metadata.constraint, 'or', branchResults)
   }
 
   if (metadata?.kind === 'requires') {
@@ -271,7 +203,7 @@ export function evaluate<
         reason = result.reason
       }
 
-      reasons.push(...getFailureReasons(result))
+      reasons.push(...getCompositeFailureReasons(result))
     }
 
     if (enabled) {
@@ -297,7 +229,7 @@ export function evaluate<
           reason = result.reason
         }
 
-        reasons.push(...getFailureReasons(result))
+        reasons.push(...getCompositeFailureReasons(result))
       }
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export {
   requires,
   oneOf,
   anyOf,
+  eitherOf,
   check,
   createRules,
   getNamedCheckMetadata,

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -89,6 +89,12 @@ export type RuleInspection<
       rules: Array<RuleInspection<F, C>>
     }
   | {
+      kind: 'eitherOf'
+      groupName: string
+      constraint: RuleConstraint
+      branches: Record<string, Array<RuleInspection<F, C>>>
+    }
+  | {
       kind: 'custom'
       type: string
       constraint: RuleConstraint
@@ -151,6 +157,11 @@ type OneOfBranchesInput<F extends Record<string, FieldDef>> = Record<
   Array<FieldSelector<F>>
 >
 
+type EitherOfBranches<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+> = Record<string, Array<Rule<F, C>>>
+
 type OneOfOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -212,6 +223,12 @@ export type InternalRuleMetadata<
       constraint: 'enabled' | 'fair'
     }
   | {
+      kind: 'eitherOf'
+      groupName: string
+      branches: EitherOfBranches<F, C>
+      constraint: 'enabled' | 'fair'
+    }
+  | {
       kind: 'custom'
       constraint: RuleConstraint
     }
@@ -219,7 +236,10 @@ export type InternalRuleMetadata<
 type InternalRuleMetadataWithOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-> = Exclude<InternalRuleMetadata<F, C>, { kind: 'anyOf' } | { kind: 'custom' }>
+> = Exclude<
+  InternalRuleMetadata<F, C>,
+  { kind: 'anyOf' } | { kind: 'eitherOf' } | { kind: 'custom' }
+>
 
 type InternalRuleCarrier<
   F extends Record<string, FieldDef>,
@@ -501,6 +521,60 @@ function cloneBranches<F extends Record<string, FieldDef>>(
   ) as Record<string, Array<keyof F & string>>
 }
 
+function getRuleEvaluationReasons(result: RuleEvaluation): string[] {
+  if (result.reasons && result.reasons.length > 0) {
+    return [...result.reasons]
+  }
+
+  if (result.reason !== null) {
+    return [result.reason]
+  }
+
+  return []
+}
+
+function getBranchRules<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(branches: EitherOfBranches<F, C>): Rule<F, C>[] {
+  return Object.values(branches).flatMap((branchRules) => branchRules)
+}
+
+function validateCompositeTargets<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(label: string, rules: Rule<F, C>[]): Array<keyof F & string> {
+  const expectedTargets = uniqueFields([...rules[0].targets]).sort()
+
+  for (const rule of rules.slice(1)) {
+    const currentTargets = uniqueFields([...rule.targets]).sort()
+
+    if (
+      currentTargets.length !== expectedTargets.length ||
+      currentTargets.some((target, index) => target !== expectedTargets[index])
+    ) {
+      throw new Error(`[umpire] ${label} rules must target the same fields`)
+    }
+  }
+
+  return [...rules[0].targets]
+}
+
+function validateCompositeConstraint<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(label: string, rules: Rule<F, C>[]): RuleConstraint {
+  const constraint = getRuleConstraint(rules[0])
+
+  for (const innerRule of rules.slice(1)) {
+    if (getRuleConstraint(innerRule) !== constraint) {
+      throw new Error(`[umpire] ${label} cannot mix fairWhen rules with availability rules`)
+    }
+  }
+
+  return constraint
+}
+
 export function inspectRule<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -576,6 +650,29 @@ export function inspectRule<
     }
   }
 
+  if (metadata.kind === 'eitherOf') {
+    const inspectedBranches = Object.fromEntries(
+      Object.entries(metadata.branches).map(([branchName, branchRules]) => [
+        branchName,
+        branchRules.map((innerRule) => inspectRule(innerRule)),
+      ]),
+    ) as Record<string, Array<RuleInspection<F, C> | undefined>>
+
+    if (
+      Object.values(inspectedBranches).some((branchRules) =>
+        branchRules.some((entry) => entry === undefined))
+    ) {
+      return undefined
+    }
+
+    return {
+      kind: 'eitherOf',
+      groupName: metadata.groupName,
+      constraint: metadata.constraint,
+      branches: inspectedBranches as Record<string, Array<RuleInspection<F, C>>>,
+    }
+  }
+
   if (metadata.kind === 'custom') {
     return {
       kind: 'custom',
@@ -631,6 +728,24 @@ export function getGraphSourceInfo<
     const orderingSet = new Set(ordering)
     const informational = uniqueFields(
       metadata.rules
+        .flatMap((innerRule) => getGraphSourceInfo(innerRule).informational)
+        .filter((field) => !orderingSet.has(field)),
+    )
+
+    return {
+      ordering,
+      informational,
+    }
+  }
+
+  if (metadata?.kind === 'eitherOf') {
+    const branchRules = getBranchRules(metadata.branches)
+    const ordering = uniqueFields(
+      branchRules.flatMap((innerRule) => getGraphSourceInfo(innerRule).ordering),
+    )
+    const orderingSet = new Set(ordering)
+    const informational = uniqueFields(
+      branchRules
         .flatMap((innerRule) => getGraphSourceInfo(innerRule).informational)
         .filter((field) => !orderingSet.has(field)),
     )
@@ -722,6 +837,10 @@ export function getRuleConstraint<
     return metadata.constraint
   }
 
+  if (metadata?.kind === 'eitherOf') {
+    return metadata.constraint
+  }
+
   if (metadata?.kind === 'custom') {
     return metadata.constraint
   }
@@ -747,10 +866,10 @@ export function isGateRule<
  * Advanced escape hatch for defining custom low-level rules.
  *
  * Prefer the built-in factories (`enabledWhen`, `fairWhen`, `disables`,
- * `requires`, `oneOf`, and `anyOf`) unless you truly need custom evaluation
+ * `requires`, `oneOf`, `anyOf`, and `eitherOf`) unless you truly need custom evaluation
  * behavior. `defineRule()` is intended for power users who need to plug a rule
  * directly into Umpire's evaluation pipeline while still participating in
- * graphing, `anyOf()`, and `challenge()`.
+ * graphing, composite helpers, and `challenge()`.
  *
  * `defineRule()` supports custom rule `type` labels and `constraint`
  * classification, but it does not expose a public API for defining new
@@ -1209,40 +1328,22 @@ export function anyOf<
     throw new Error('[umpire] anyOf() requires at least one rule')
   }
 
-  const expectedTargets = uniqueFields([...rules[0].targets]).sort()
-
-  for (const rule of rules.slice(1)) {
-    const currentTargets = uniqueFields([...rule.targets]).sort()
-    if (
-      currentTargets.length !== expectedTargets.length ||
-      currentTargets.some((target, index) => target !== expectedTargets[index])
-    ) {
-      throw new Error('[umpire] anyOf() rules must target the same fields')
-    }
-  }
-
+  const targets = validateCompositeTargets('anyOf()', rules)
   const sources = uniqueFields(rules.flatMap((rule) => rule.sources))
-  const constraint = getRuleConstraint(rules[0])
-
-  for (const innerRule of rules.slice(1)) {
-    if (getRuleConstraint(innerRule) !== constraint) {
-      throw new Error('[umpire] anyOf() cannot mix fairWhen rules with availability rules')
-    }
-  }
+  const constraint = validateCompositeConstraint('anyOf()', rules)
 
   const rule: InternalRuleCarrier<F, C> = {
     type: 'anyOf',
-    targets: [...rules[0].targets],
+    targets,
     sources,
     evaluate(values, conditions, prev, fields, availability) {
       const evaluations = rules.map((rule) =>
         rule.evaluate(values, conditions, prev, fields, availability),
       )
 
-      return createResultMap(rules[0].targets, (target) => {
+      return createResultMap(targets, (target) => {
         const targetResults = evaluations
-          .map((evaluation) => evaluation.get(target))
-          .filter((result): result is RuleEvaluation => !!result)
+          .map((evaluation) => evaluation.get(target) ?? { enabled: true, reason: null })
 
         if (constraint === 'fair') {
           if (targetResults.some((result) => result.fair !== false)) {
@@ -1291,6 +1392,113 @@ export function anyOf<
   return rule
 }
 
+export function eitherOf<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  groupName: string,
+  branches: EitherOfBranches<F, C>,
+): Rule<F, C> {
+  const branchNames = Object.keys(branches)
+
+  if (branchNames.length === 0) {
+    throw new Error(`[umpire] eitherOf("${groupName}") must include at least one branch`)
+  }
+
+  for (const branchName of branchNames) {
+    if (branches[branchName].length === 0) {
+      throw new Error(`[umpire] eitherOf("${groupName}") branch "${branchName}" must not be empty`)
+    }
+  }
+
+  const rules = getBranchRules(branches)
+  const label = `eitherOf("${groupName}")`
+  const targets = validateCompositeTargets(label, rules)
+  const constraint = validateCompositeConstraint(label, rules)
+  const sources = uniqueFields(rules.flatMap((rule) => rule.sources))
+
+  const rule: InternalRuleCarrier<F, C> = {
+    type: 'eitherOf',
+    targets,
+    sources,
+    evaluate(values, conditions, prev, fields, availability) {
+      const branchEvaluations = Object.fromEntries(
+        branchNames.map((branchName) => [
+          branchName,
+          branches[branchName].map((branchRule) =>
+            branchRule.evaluate(values, conditions, prev, fields, availability)),
+        ]),
+      ) as Record<string, Array<Map<string, RuleEvaluation>>>
+
+      return createResultMap(targets, (target) => {
+        const branchResults = branchNames.map((branchName) => {
+          const targetResults = branchEvaluations[branchName].map((evaluation) =>
+            evaluation.get(target) ?? { enabled: true, reason: null })
+
+          if (constraint === 'fair') {
+            const passed = targetResults.every((result) => result.fair !== false)
+            const reasons = targetResults.flatMap(getRuleEvaluationReasons)
+
+            return {
+              enabled: true,
+              fair: passed,
+              reason: passed ? null : reasons[0] ?? null,
+              reasons: passed || reasons.length === 0 ? undefined : reasons,
+            }
+          }
+
+          const passed = targetResults.every((result) => result.enabled)
+          const reasons = targetResults.flatMap(getRuleEvaluationReasons)
+
+          return {
+            enabled: passed,
+            reason: passed ? null : reasons[0] ?? null,
+            reasons: passed || reasons.length === 0 ? undefined : reasons,
+          }
+        })
+
+        if (constraint === 'fair') {
+          if (branchResults.some((result) => result.fair !== false)) {
+            return {
+              enabled: true,
+              fair: true,
+              reason: null,
+            }
+          }
+
+          const reasons = branchResults.flatMap(getRuleEvaluationReasons)
+          return {
+            enabled: true,
+            fair: false,
+            reason: reasons[0] ?? null,
+            reasons: reasons.length === 0 ? undefined : reasons,
+          }
+        }
+
+        if (branchResults.some((result) => result.enabled)) {
+          return { enabled: true, reason: null }
+        }
+
+        const reasons = branchResults.flatMap(getRuleEvaluationReasons)
+        return {
+          enabled: false,
+          reason: reasons[0] ?? null,
+          reasons: reasons.length === 0 ? undefined : reasons,
+        }
+      })
+    },
+  }
+
+  rule._umpire = {
+    kind: 'eitherOf',
+    groupName,
+    branches,
+    constraint,
+  }
+
+  return rule
+}
+
 export function check<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
@@ -1328,7 +1536,7 @@ export function check<
  * condition types. Purely a type-level convenience — zero runtime overhead.
  *
  * ```ts
- * const { enabledWhen, requires } = createRules<typeof fields, MyConditions>()
+ * const { enabledWhen, requires, eitherOf } = createRules<typeof fields, MyConditions>()
  * // Predicate callbacks now have typed conditions automatically
  * ```
  */
@@ -1344,6 +1552,7 @@ export function createRules<
     requires: requires as typeof requires<F, C>,
     oneOf: oneOf as typeof oneOf<F, C>,
     anyOf: anyOf as typeof anyOf<F, C>,
+    eitherOf: eitherOf as typeof eitherOf<F, C>,
     check: check as typeof check<F, C>,
   }
 }

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -1,3 +1,7 @@
+import {
+  combineCompositeResults,
+  getCompositeTargetEvaluation,
+} from './composite.js'
 import { shouldWarnInDev } from './dev.js'
 import { getFieldBuilderName } from './field.js'
 import { isSatisfied } from './satisfaction.js'
@@ -521,18 +525,6 @@ function cloneBranches<F extends Record<string, FieldDef>>(
   ) as Record<string, Array<keyof F & string>>
 }
 
-function getRuleEvaluationReasons(result: RuleEvaluation): string[] {
-  if (result.reasons && result.reasons.length > 0) {
-    return [...result.reasons]
-  }
-
-  if (result.reason !== null) {
-    return [result.reason]
-  }
-
-  return []
-}
-
 function getBranchRules<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -540,10 +532,14 @@ function getBranchRules<
   return Object.values(branches).flatMap((branchRules) => branchRules)
 }
 
-function validateCompositeTargets<
+function resolveCompositeRuleShape<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(label: string, rules: Rule<F, C>[]): Array<keyof F & string> {
+>(label: string, rules: Rule<F, C>[]): {
+  targets: Array<keyof F & string>
+  sources: Array<keyof F & string>
+  constraint: RuleConstraint
+} {
   const expectedTargets = uniqueFields([...rules[0].targets]).sort()
 
   for (const rule of rules.slice(1)) {
@@ -557,13 +553,6 @@ function validateCompositeTargets<
     }
   }
 
-  return [...rules[0].targets]
-}
-
-function validateCompositeConstraint<
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown>,
->(label: string, rules: Rule<F, C>[]): RuleConstraint {
   const constraint = getRuleConstraint(rules[0])
 
   for (const innerRule of rules.slice(1)) {
@@ -572,7 +561,11 @@ function validateCompositeConstraint<
     }
   }
 
-  return constraint
+  return {
+    targets: [...rules[0].targets],
+    sources: uniqueFields(rules.flatMap((rule) => rule.sources)),
+    constraint,
+  }
 }
 
 export function inspectRule<
@@ -1328,9 +1321,7 @@ export function anyOf<
     throw new Error('[umpire] anyOf() requires at least one rule')
   }
 
-  const targets = validateCompositeTargets('anyOf()', rules)
-  const sources = uniqueFields(rules.flatMap((rule) => rule.sources))
-  const constraint = validateCompositeConstraint('anyOf()', rules)
+  const { targets, sources, constraint } = resolveCompositeRuleShape('anyOf()', rules)
 
   const rule: InternalRuleCarrier<F, C> = {
     type: 'anyOf',
@@ -1343,42 +1334,9 @@ export function anyOf<
 
       return createResultMap(targets, (target) => {
         const targetResults = evaluations
-          .map((evaluation) => evaluation.get(target) ?? { enabled: true, reason: null })
+          .map((evaluation) => getCompositeTargetEvaluation(evaluation, target))
 
-        if (constraint === 'fair') {
-          if (targetResults.some((result) => result.fair !== false)) {
-            return {
-              enabled: true,
-              fair: true,
-              reason: null,
-            }
-          }
-
-          const reasons = targetResults
-            .map((result) => result.reason)
-            .filter((reason): reason is string => reason !== null)
-
-          return {
-            enabled: true,
-            fair: false,
-            reason: reasons[0] ?? null,
-            reasons: reasons.length === 0 ? undefined : reasons,
-          }
-        }
-
-        if (targetResults.some((result) => result.enabled)) {
-          return { enabled: true, reason: null }
-        }
-
-        const reasons = targetResults
-          .map((result) => result.reason)
-          .filter((reason): reason is string => reason !== null)
-
-        return {
-          enabled: false,
-          reason: reasons[0] ?? null,
-          reasons: reasons.length === 0 ? undefined : reasons,
-        }
+        return combineCompositeResults(constraint, 'or', targetResults)
       })
     },
   }
@@ -1413,9 +1371,7 @@ export function eitherOf<
 
   const rules = getBranchRules(branches)
   const label = `eitherOf("${groupName}")`
-  const targets = validateCompositeTargets(label, rules)
-  const constraint = validateCompositeConstraint(label, rules)
-  const sources = uniqueFields(rules.flatMap((rule) => rule.sources))
+  const { targets, sources, constraint } = resolveCompositeRuleShape(label, rules)
 
   const rule: InternalRuleCarrier<F, C> = {
     type: 'eitherOf',
@@ -1433,58 +1389,12 @@ export function eitherOf<
       return createResultMap(targets, (target) => {
         const branchResults = branchNames.map((branchName) => {
           const targetResults = branchEvaluations[branchName].map((evaluation) =>
-            evaluation.get(target) ?? { enabled: true, reason: null })
+            getCompositeTargetEvaluation(evaluation, target))
 
-          if (constraint === 'fair') {
-            const passed = targetResults.every((result) => result.fair !== false)
-            const reasons = targetResults.flatMap(getRuleEvaluationReasons)
-
-            return {
-              enabled: true,
-              fair: passed,
-              reason: passed ? null : reasons[0] ?? null,
-              reasons: passed || reasons.length === 0 ? undefined : reasons,
-            }
-          }
-
-          const passed = targetResults.every((result) => result.enabled)
-          const reasons = targetResults.flatMap(getRuleEvaluationReasons)
-
-          return {
-            enabled: passed,
-            reason: passed ? null : reasons[0] ?? null,
-            reasons: passed || reasons.length === 0 ? undefined : reasons,
-          }
+          return combineCompositeResults(constraint, 'and', targetResults)
         })
 
-        if (constraint === 'fair') {
-          if (branchResults.some((result) => result.fair !== false)) {
-            return {
-              enabled: true,
-              fair: true,
-              reason: null,
-            }
-          }
-
-          const reasons = branchResults.flatMap(getRuleEvaluationReasons)
-          return {
-            enabled: true,
-            fair: false,
-            reason: reasons[0] ?? null,
-            reasons: reasons.length === 0 ? undefined : reasons,
-          }
-        }
-
-        if (branchResults.some((result) => result.enabled)) {
-          return { enabled: true, reason: null }
-        }
-
-        const reasons = branchResults.flatMap(getRuleEvaluationReasons)
-        return {
-          enabled: false,
-          reason: reasons[0] ?? null,
-          reasons: reasons.length === 0 ? undefined : reasons,
-        }
+        return combineCompositeResults(constraint, 'or', branchResults)
       })
     },
   }

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -415,6 +415,43 @@ function describeRuleForField<
     }
   }
 
+  if (metadata?.kind === 'eitherOf') {
+    const branches = Object.fromEntries(
+      Object.entries(metadata.branches).map(([branchName, branchRules]) => {
+        const inner = branchRules.map((innerRule) =>
+          describeRuleForField(
+            innerRule,
+            field,
+            fields,
+            values,
+            conditions,
+            prev,
+            availability,
+            baseRuleCache,
+          ))
+
+        return [branchName, {
+          passed: inner.every((entry) => entry.passed),
+          inner,
+        }]
+      }),
+    ) as Record<string, { passed: boolean; inner: ChallengeTrace['directReasons'] }>
+
+    const matchedBranches = Object.entries(branches)
+      .filter(([, branch]) => branch.passed)
+      .map(([branchName]) => branchName)
+
+    return {
+      rule: 'eitherOf',
+      passed: didRulePass(rule, evaluation),
+      reason: evaluation.reason,
+      group: metadata.groupName,
+      constraint: metadata.constraint,
+      matchedBranches,
+      branches,
+    }
+  }
+
   return withRuleTrace({
     rule: rule.type,
     passed: didRulePass(rule, evaluation),
@@ -465,6 +502,36 @@ function collectFailedDependenciesForRule<
         baseRuleCache,
       ),
     )
+  }
+
+  if (metadata?.kind === 'eitherOf') {
+    const evaluation = evaluateRuleForField(
+      rule,
+      field,
+      fields,
+      values,
+      conditions,
+      prev,
+      availability,
+      baseRuleCache,
+    )
+
+    if (metadata.constraint === 'fair' ? evaluation.fair !== false : evaluation.enabled) {
+      return []
+    }
+
+    return Object.values(metadata.branches).flatMap((branchRules) =>
+      branchRules.flatMap((innerRule) =>
+        collectFailedDependenciesForRule(
+          innerRule,
+          field,
+          fields,
+          values,
+          conditions,
+          prev,
+          availability,
+          baseRuleCache,
+        )))
   }
 
   if (metadata?.kind !== 'requires') {
@@ -706,8 +773,8 @@ function getStaticOneOfGroupFromRule<
  *   satisfied"
  * - dynamic `oneOf({ activeBranch })` functions, because runtime conditions can
  *   legitimately reopen states that look contradictory from static structure
- * - `anyOf()` and custom rules, because they would require deeper semantic
- *   analysis than this validator is meant to provide
+ * - `anyOf()`, `eitherOf()`, and custom rules, because they would require
+ *   deeper semantic analysis than this validator is meant to provide
  *
  * Future additions here should follow the same bar: only add checks that are
  * provably impossible by construction, with no need to reason about runtime

--- a/packages/devtools/__tests__/panel.test.ts
+++ b/packages/devtools/__tests__/panel.test.ts
@@ -1,4 +1,4 @@
-import { umpire } from '@umpire/core'
+import { eitherOf, enabledWhen, umpire } from '@umpire/core'
 import { mount, register, unregister, unmount } from '../src/index.js'
 import { resetRegistry } from '../src/registry.js'
 
@@ -115,5 +115,70 @@ describe('Panel', () => {
     expect(text).toContain('Summary')
     expect(text).toContain('blocked')
     expect(text).toContain('2')
+  })
+
+  it('renders named eitherOf branches in the challenge drawer', async () => {
+    const authUmp = umpire({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+      },
+      rules: [
+        eitherOf('submitAuth', {
+          sso: [
+            enabledWhen('submit', () => false, {
+              reason: 'No SSO available for this domain',
+            }),
+          ],
+          password: [
+            enabledWhen('submit', (values) => !!values.email, {
+              reason: 'Enter a valid email address',
+            }),
+            enabledWhen('submit', () => false, {
+              reason: 'Enter a password',
+            }),
+          ],
+        }),
+      ],
+    })
+
+    register('auth', authUmp, {
+      email: '',
+      password: '',
+      submit: undefined,
+    })
+
+    mount()
+
+    const host = document.getElementById('umpire-devtools')
+    const root = host?.shadowRoot
+    const toggle = root?.querySelector('button[aria-expanded="false"]')
+
+    expect(toggle).not.toBeNull()
+
+    toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    await flushUi()
+
+    const submitRow = [...(root?.querySelectorAll('tr') ?? [])]
+      .find((row) => row.textContent?.includes('submit'))
+
+    expect(submitRow).not.toBeNull()
+
+    submitRow?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    await flushUi()
+
+    const text = root?.textContent ?? ''
+
+    expect(text).toContain('challenge(submit)')
+    expect(text).toContain('eitherOf')
+    expect(text).toContain('submitAuth')
+    expect(text).toContain('matchedBranches')
+    expect(text).toContain('sso')
+    expect(text).toContain('password')
+    expect(text).toContain('No SSO available for this domain')
+    expect(text).toContain('Enter a valid email address')
+    expect(text).toContain('Enter a password')
+    expect(text).toContain('no match')
   })
 })

--- a/packages/devtools/src/panel/ChallengeDrawer.tsx
+++ b/packages/devtools/src/panel/ChallengeDrawer.tsx
@@ -23,6 +23,11 @@ type ReasonProps = {
   reason: ReasonLike
 }
 
+type BranchReasonGroup = {
+  passed: boolean
+  inner: ReasonLike[]
+}
+
 function MetaRows({
   entries,
 }: {
@@ -56,6 +61,45 @@ function MetaRows({
   )
 }
 
+function BranchGroupsView({
+  branches,
+  depth,
+}: {
+  branches: Record<string, BranchReasonGroup>
+  depth: number
+}) {
+  return (
+    <div style={{ display: 'grid', gap: 10 }}>
+      {Object.entries(branches).map(([branchName, branch]) => (
+        <div
+          key={branchName}
+          style={{
+            background: theme.surfaceMuted,
+            border: `1px solid ${theme.border}`,
+            borderRadius: 10,
+            display: 'grid',
+            gap: 8,
+            padding: 12,
+          }}
+        >
+          <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
+            <strong style={{ color: theme.fg, fontSize: 12 }}>{branchName}</strong>
+            <span style={pillStyle(branch.passed ? theme.enabled : theme.disabled, true)}>
+              {branch.passed ? 'match' : 'no match'}
+            </span>
+          </div>
+
+          <div style={{ display: 'grid', gap: 0 }}>
+            {branch.inner.map((entry, index) => (
+              <ReasonView key={`${branchName}:${entry.rule}:${index}`} depth={depth + 1} reason={entry} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function TraceAttachmentView({ trace }: { trace: ChallengeTraceAttachment }) {
   return (
     <div
@@ -86,6 +130,13 @@ function TraceAttachmentView({ trace }: { trace: ChallengeTraceAttachment }) {
 function ReasonView({ depth = 0, reason }: ReasonProps) {
   const tone = getRuleTone(reason.rule)
   const inner = Array.isArray(reason.inner) ? reason.inner as ReasonLike[] : []
+  const branches = (
+    reason.branches &&
+    typeof reason.branches === 'object' &&
+    !Array.isArray(reason.branches)
+  )
+    ? reason.branches as Record<string, BranchReasonGroup>
+    : null
   const passed = reason.passed ?? false
 
   return (
@@ -122,6 +173,10 @@ function ReasonView({ depth = 0, reason }: ReasonProps) {
             <TraceAttachmentView key={`${trace.kind}:${trace.id}`} trace={trace} />
           ))}
         </div>
+      )}
+
+      {branches && Object.keys(branches).length > 0 && (
+        <BranchGroupsView branches={branches} depth={depth} />
       )}
 
       {inner.length > 0 && (

--- a/packages/devtools/src/panel/theme.ts
+++ b/packages/devtools/src/panel/theme.ts
@@ -13,6 +13,7 @@ export const theme = {
   fgMuted: '#a8afc5',
   overlay: 'rgba(14, 14, 26, 0.96)',
   ruleDisables: '#ff5f5f',
+  ruleEitherOf: '#5fd7ff',
   ruleEnabledWhen: '#d78fff',
   ruleFairWhen: '#ffd700',
   ruleOneOf: '#87d7d7',
@@ -59,6 +60,10 @@ export function getRuleTone(rule: string) {
 
   if (rule === 'oneOf') {
     return theme.ruleOneOf
+  }
+
+  if (rule === 'eitherOf') {
+    return theme.ruleEitherOf
   }
 
   if (rule === 'disables') {

--- a/packages/json/src/serialize.ts
+++ b/packages/json/src/serialize.ts
@@ -579,6 +579,19 @@ function serializeInspection(
           : [],
       }
     }
+    case 'eitherOf':
+      return {
+        rules: [],
+        excluded: [
+          createExcluded(
+            'eitherOf',
+            'eitherOf() is not part of the JSON spec',
+            undefined,
+            undefined,
+          ),
+        ],
+        coverageKeys: [],
+      }
     case 'custom':
       return {
         rules: [],


### PR DESCRIPTION
## Summary

Adds `eitherOf()` to `@umpire/core` for named OR paths where each branch is a group of ANDed rules.

This is aimed at cases like submit-path gating, where `oneOf()` is too strong because there is no mutually exclusive branch selection, but `anyOf()` loses helpful branch structure and readability.

Note:
 - `eitherOf()` is added to `core`
 - JSON serialization support is intentionally deferred 
 - `@umpire/json` now excludes `eitherOf()` explicitly until the JSON spec grows a matching construct

## Changes

- Add `eitherOf(groupName, branches)` to `@umpire/core`
- Support both availability and fairness constraints
- Preserve `eitherOf()` structure in `inspectRule()` and `challenge()`
- Refactor shared composite-rule internals used by `anyOf()` / `eitherOf()`
- Update devtools challenge rendering to show named `eitherOf()` branches
- Add docs for `eitherOf()` and update the signup example to use it

## Semantics

- Rules inside a branch are ANDed
- Branches are ORed
- Multiple branches may match at once
- No `activeBranch`
- No `prev`-based branch resolution
- No `oneOf()`-style winning branch behavior

## Testing

- `yarn turbo run test --filter=@umpire/core`
- `yarn workspace @umpire/devtools test`
- `yarn workspace @umpire/core build`
- `yarn workspace @umpire/devtools build`
- `cd docs && yarn build`