### PR TITLE
🛠️ Make release PR workflow manual

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release PR
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- change the release PR workflow trigger from push-to-main to manual dispatch
- stop automatic Changesets version PR creation on every main push
 
## Testing
- not run (workflow trigger change only)