### PR TITLE
Add rejectFoul option to activeSchema for server-side validation

### DIFF
--- a/.changeset/zod-reject-foul.md
+++ b/.changeset/zod-reject-foul.md
@@ -1,0 +1,9 @@
+---
+"@umpire/zod": minor
+---
+
+- `activeSchema` now accepts an optional third argument `{ rejectFoul?: boolean }`.
+- When `rejectFoul: true`, enabled fields whose value is foul (`fair: false`) are included in the schema with a refinement that always fails, using the field's `reason` as the error message.
+- `createZodValidation` accepts the same `rejectFoul` option and threads it through every `run()` call.
+- Use this option on the server to reject contextually invalid submissions (e.g. a gas vehicle in an electric-only parking spot) rather than silently accepting or stripping them.
+- Default is `false`; existing client-side usage is unaffected.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -153,7 +153,10 @@ export default defineConfig({
         {
           label: 'Integrations',
           items: [
-            { label: 'Zod', slug: 'adapters/zod' },
+            { label: 'Validators', collapsed: false, items: [
+              { label: 'Overview', slug: 'integrations/validators' },
+              { label: 'Zod', slug: 'integrations/zod' },
+            ] },
           ],
         },
         {

--- a/docs/src/content/docs/concepts/satisfaction.md
+++ b/docs/src/content/docs/concepts/satisfaction.md
@@ -145,4 +145,4 @@ const loginUmp = umpire({
 
 `requires()` handles presence. `check()` bridges into richer validation logic when you need it.
 
-For full validation composition — building dynamic Zod schemas from availability, filtering errors to enabled fields, gating submit on both layers — see the [Signup Form + Zod](/umpire/examples/signup/) example and [`@umpire/zod`](/umpire/concepts/validation/) adapter.
+For full validation composition — building dynamic Zod schemas from availability, filtering errors to enabled fields, gating submit on both layers — see the [Signup Form + Zod](/umpire/examples/signup/) example and the [`@umpire/zod`](/umpire/integrations/zod/) integration.

--- a/docs/src/content/docs/integrations/validators.md
+++ b/docs/src/content/docs/integrations/validators.md
@@ -1,0 +1,91 @@
+---
+title: Validator Integrations
+description: How Umpire's availability map connects to schema-based validation libraries like Zod, Yup, and Valibot.
+---
+
+Umpire decides which fields are active. Validation libraries decide whether their values are correct. Validator integrations are the glue between the two: they read the availability map and build a schema that reflects the current shape of your data.
+
+## The contract
+
+A validator integration does three things:
+
+1. **Skip disabled fields** — fields where `enabled: false` are not in play. Excluded from the schema entirely. A validation library should never produce errors for them.
+2. **Respect required/optional** — `status.required` from Umpire overrides your static schema definition. A field can be declared `required: true` in the engine config but report `required: false` when disabled.
+3. **Optionally reject foul values** — fields where `fair: false` hold values that are structurally valid but contextually wrong. On a server, you can choose to reject those submissions rather than accept them.
+
+## Client vs server usage
+
+On the **client**, you call `engine.check(values)` during the render cycle and pass the resulting availability map to your validator. The active schema changes as the user changes fields.
+
+On the **server**, the same pattern acts as a guard. The incoming request body drives `engine.check()`, which returns the same availability map the client would have produced for that data. Any inconsistency — a required field missing, a foul value present — fails validation.
+
+```ts
+// Shared — same engine on client and server
+export const engine = umpire({ fields, rules })
+export const schemas = { /* per-field schemas */ }
+
+// Server handler
+const body = await req.json()
+const availability = engine.check(body)
+const schema = activeSchema(availability, schemas, { rejectFoul: true })
+const result = schema.safeParse(body)
+```
+
+`engine.check()` is deterministic: the same values produce the same availability map. If the client and server share the engine definition, they will always agree on which fields are active and required.
+
+## Foul values and server guards
+
+`fairWhen()` rules mark a field `fair: false` when its current value is no longer appropriate for the context — a selection that was valid before something else changed. On a form this is shown as an error the user needs to correct. On a server it means the submission contains a value that the client should have caught.
+
+The `rejectFoul` option handles this:
+
+```ts
+// Without rejectFoul (default) — foul values pass base schema, behave like fair fields
+activeSchema(availability, schemas)
+
+// With rejectFoul — foul fields get an always-failing refinement
+activeSchema(availability, schemas, { rejectFoul: true })
+```
+
+When `rejectFoul: true`:
+- An enabled field with `fair: false` and a present value fails with the field's `reason` as the error message.
+- An enabled field with `fair: false` that is absent (optional, no value submitted) passes — only present foul values are rejected.
+
+## The pattern for other libraries
+
+The same three-step logic maps to any schema library:
+
+```ts
+// Generic pseudocode — works for Zod, Yup, Valibot, Joi, etc.
+for (const [field, status] of Object.entries(availability)) {
+  if (!status.enabled) continue                     // skip disabled
+
+  const base = schemas[field]
+  if (!base) continue
+
+  if (rejectFoul && !status.fair) {
+    const refined = base.alwaysFail(status.reason)  // library-specific
+    shape[field] = status.required ? refined : refined.optional()
+    continue
+  }
+
+  shape[field] = status.required ? base : base.optional()
+}
+```
+
+Each library's "always-fail with message" primitive:
+
+| Library  | Expression |
+|----------|-----------|
+| Zod      | `.refine(() => false, { message })` |
+| Yup      | `.test('foul', message, () => false)` |
+| Valibot  | `check(() => false, message)` |
+| Joi      | `.custom(() => { throw new Error(message) })` |
+
+`@umpire/zod` is the reference implementation. Future packages like `@umpire/yup` or `@umpire/valibot` would follow the same contract.
+
+## See also
+
+- [`@umpire/zod`](/umpire/integrations/zod/) — reference implementation
+- [Composing with Validation](/umpire/concepts/validation/) — manual patterns and the `check()` bridge
+- [`fairWhen()`](/umpire/api/rules/fair-when/) — the rule that produces `fair: false`

--- a/docs/src/content/docs/integrations/zod.md
+++ b/docs/src/content/docs/integrations/zod.md
@@ -15,13 +15,14 @@ yarn add @umpire/core @umpire/zod zod
 
 ## API
 
-### `activeSchema(availability, shape)`
+### `activeSchema(availability, shape, options?)`
 
 Builds a `z.object()` from the availability map:
 
 - **Disabled fields** — excluded from the schema entirely
 - **Enabled + required** — field uses the base schema as-is
 - **Enabled + optional** — field is wrapped with `.optional()`
+- **Foul fields** — see `rejectFoul` below
 
 ```ts
 import { z } from 'zod'
@@ -54,6 +55,19 @@ activeSchema(availability, myFormSchema.shape)
 ```
 
 `activeSchema` throws a descriptive error if it detects a Zod object was passed instead of its shape.
+
+#### `rejectFoul` option
+
+Fields where `fair: false` hold values that were once valid but are now contextually wrong — a selection that no longer fits the current state. By default these pass through with their base schema (useful on the client where the user is still editing). On a **server**, you may want to reject them outright:
+
+```ts
+// Server handler — rejects any submission containing a foul value
+const availability = engine.check(body)
+const schema = activeSchema(availability, fieldSchemas, { rejectFoul: true })
+const result = schema.safeParse(body)
+```
+
+When `rejectFoul: true`, a foul field with a present value fails with the field's `reason` as the Zod issue message. If the field is optional and absent, it passes — only submissions that *contain* a foul value are rejected.
 
 ### `zodErrors(error)`
 
@@ -124,5 +138,6 @@ If `confirmPassword` is disabled, `activeSchema` excludes it and the refinement 
 
 ## See also
 
+- [Validator Integrations](/umpire/integrations/validators/) — the general contract and how it extends to other libraries
 - [Composing with Validation](/umpire/concepts/validation/) — conceptual boundary and manual patterns
 - [Signup Form + Zod](/umpire/examples/signup/) — full walkthrough with `activeSchema`, the render loop, and foul handling

--- a/packages/zod/__tests__/active-schema.test.ts
+++ b/packages/zod/__tests__/active-schema.test.ts
@@ -215,6 +215,27 @@ describe('activeSchema rejectFoul', () => {
     expect(schema.safeParse({ optionalNickname: 'Doug' }).success).toBe(true)
   })
 
+  test('omitting a foul optional field passes when rejectFoul is true', () => {
+    const schema = activeSchema(
+      createAvailabilityWithFoul({
+        optionalNickname: {
+          enabled: true,
+          fair: false,
+          required: false,
+          reason: 'stale value',
+          reasons: ['stale value'],
+        },
+      }),
+      { optionalNickname: z.string() },
+      { rejectFoul: true },
+    )
+
+    // Clearing the field (absent from submission) should be accepted
+    expect(schema.safeParse({}).success).toBe(true)
+    // Submitting the stale value should be rejected
+    expect(schema.safeParse({ optionalNickname: 'Doug' }).success).toBe(false)
+  })
+
   test('fair fields are unaffected when rejectFoul is true', () => {
     const schema = activeSchema(
       createAvailabilityWithFoul(),

--- a/packages/zod/__tests__/active-schema.test.ts
+++ b/packages/zod/__tests__/active-schema.test.ts
@@ -112,3 +112,117 @@ describe('activeSchema', () => {
     )
   })
 })
+
+describe('activeSchema rejectFoul', () => {
+  function createAvailabilityWithFoul(
+    overrides: Partial<AvailabilityMap<TestFields>> = {},
+  ): AvailabilityMap<TestFields> {
+    return {
+      requiredName: {
+        enabled: true,
+        fair: true,
+        required: true,
+        reason: null,
+        reasons: [],
+      },
+      optionalNickname: {
+        enabled: true,
+        fair: true,
+        required: false,
+        reason: null,
+        reasons: [],
+      },
+      disabledSecret: {
+        enabled: false,
+        fair: true,
+        required: false,
+        reason: 'disabled',
+        reasons: ['disabled'],
+      },
+      missingSchema: {
+        enabled: true,
+        fair: true,
+        required: true,
+        reason: null,
+        reasons: [],
+      },
+      ...overrides,
+    }
+  }
+
+  test('rejects a foul field value when rejectFoul is true', () => {
+    const schema = activeSchema(
+      createAvailabilityWithFoul({
+        optionalNickname: {
+          enabled: true,
+          fair: false,
+          required: false,
+          reason: 'Nickname is not valid for the current context',
+          reasons: ['Nickname is not valid for the current context'],
+        },
+      }),
+      { optionalNickname: z.string() },
+      { rejectFoul: true },
+    )
+
+    const result = schema.safeParse({ optionalNickname: 'Doug' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        'Nickname is not valid for the current context',
+      )
+    }
+  })
+
+  test('uses a fallback message when reason is null', () => {
+    const schema = activeSchema(
+      createAvailabilityWithFoul({
+        optionalNickname: {
+          enabled: true,
+          fair: false,
+          required: false,
+          reason: null,
+          reasons: [],
+        },
+      }),
+      { optionalNickname: z.string() },
+      { rejectFoul: true },
+    )
+
+    const result = schema.safeParse({ optionalNickname: 'Doug' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        'Value is not valid for the current context',
+      )
+    }
+  })
+
+  test('passes through foul fields without error when rejectFoul is false', () => {
+    const schema = activeSchema(
+      createAvailabilityWithFoul({
+        optionalNickname: {
+          enabled: true,
+          fair: false,
+          required: false,
+          reason: 'stale value',
+          reasons: ['stale value'],
+        },
+      }),
+      { optionalNickname: z.string() },
+    )
+
+    expect(schema.safeParse({ optionalNickname: 'Doug' }).success).toBe(true)
+  })
+
+  test('fair fields are unaffected when rejectFoul is true', () => {
+    const schema = activeSchema(
+      createAvailabilityWithFoul(),
+      { requiredName: z.string() },
+      { rejectFoul: true },
+    )
+
+    expect(schema.safeParse({ requiredName: 'Douglas' }).success).toBe(true)
+    expect(schema.safeParse({}).success).toBe(false)
+  })
+})

--- a/packages/zod/__tests__/validation.test.ts
+++ b/packages/zod/__tests__/validation.test.ts
@@ -114,7 +114,7 @@ describe('createZodValidation', () => {
       rules: [
         fairWhen(
           'vehicleType',
-          (values) => values.vehicleType === values.spotType || values.spotType === 'standard',
+          (value, values) => value === values.spotType || values.spotType === 'standard',
           { reason: 'Vehicle type does not match the reserved spot' },
         ),
       ],

--- a/packages/zod/__tests__/validation.test.ts
+++ b/packages/zod/__tests__/validation.test.ts
@@ -1,4 +1,4 @@
-import { enabledWhen, umpire } from '@umpire/core'
+import { enabledWhen, fairWhen, umpire } from '@umpire/core'
 import { z } from 'zod'
 import { createZodValidation } from '../src/validation.js'
 
@@ -93,5 +93,44 @@ describe('createZodValidation', () => {
     expect(() => createZodValidation({
       schemas: undefined as never,
     })).toThrow('createZodValidation() expects a per-field schema map object.')
+  })
+
+  test('rejects foul field values when rejectFoul is true', () => {
+    const fields = {
+      spotType: {},
+      vehicleType: {},
+    }
+
+    const validation = createZodValidation({
+      schemas: {
+        spotType: z.enum(['electric', 'standard']),
+        vehicleType: z.enum(['electric', 'gas']),
+      },
+      rejectFoul: true,
+    })
+
+    const ump = umpire({
+      fields,
+      rules: [
+        fairWhen(
+          'vehicleType',
+          (values) => values.vehicleType === values.spotType || values.spotType === 'standard',
+          { reason: 'Vehicle type does not match the reserved spot' },
+        ),
+      ],
+    })
+
+    // Electric vehicle in an electric spot — fair, passes
+    const fairAvailability = ump.check({ spotType: 'electric', vehicleType: 'electric' })
+    const fairResult = validation.run(fairAvailability, { spotType: 'electric', vehicleType: 'electric' })
+    expect(fairResult.result.success).toBe(true)
+
+    // Gas vehicle in an electric spot — foul, rejected with reason as error
+    const foulAvailability = ump.check({ spotType: 'electric', vehicleType: 'gas' })
+    const foulResult = validation.run(foulAvailability, { spotType: 'electric', vehicleType: 'gas' })
+    expect(foulResult.result.success).toBe(false)
+    expect(foulResult.errors).toEqual({
+      vehicleType: 'Vehicle type does not match the reserved spot',
+    })
   })
 })

--- a/packages/zod/src/active-schema.ts
+++ b/packages/zod/src/active-schema.ts
@@ -60,7 +60,8 @@ export function activeSchema<F extends Record<string, FieldDef>>(
 
     if (rejectFoul && !status.fair) {
       const message = status.reason ?? 'Value is not valid for the current context'
-      shape[field] = base.refine(() => false, { message })
+      const refined = base.refine(() => false, { message })
+      shape[field] = status.required ? refined : refined.optional()
       continue
     }
 

--- a/packages/zod/src/active-schema.ts
+++ b/packages/zod/src/active-schema.ts
@@ -6,6 +6,19 @@ type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
   Record<keyof F & string, z.ZodTypeAny>
 >
 
+export type ActiveSchemaOptions = {
+  /**
+   * When true, enabled fields whose value is foul (`fair: false`) are
+   * included in the schema with a refinement that always fails, using the
+   * field's `reason` as the error message. Use this on the server to reject
+   * submissions that contain contextually invalid values rather than
+   * silently accepting them.
+   *
+   * Defaults to false (foul fields pass through with their base schema).
+   */
+  rejectFoul?: boolean
+}
+
 /**
  * Pass per-field schemas directly, or use `yourSchema.shape` to extract
  * them from an existing `z.object()`.
@@ -16,15 +29,20 @@ type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
  *
  * // From an existing z.object()
  * activeSchema(availability, formSchema.shape)
+ *
+ * // Server guard — reject foul values outright
+ * activeSchema(availability, schemas, { rejectFoul: true })
  * ```
  */
 export function activeSchema<F extends Record<string, FieldDef>>(
   availability: AvailabilityMap<F>,
   schemas: FieldSchemas<F>,
+  options?: ActiveSchemaOptions,
 ): z.ZodObject<Record<string, z.ZodTypeAny>> {
   assertFieldSchemas(schemas, 'activeSchema')
 
   const fieldSchemas = schemas
+  const rejectFoul = options?.rejectFoul ?? false
 
   const shape: Record<string, z.ZodTypeAny> = {}
 
@@ -37,6 +55,12 @@ export function activeSchema<F extends Record<string, FieldDef>>(
 
     const base = fieldSchemas[field]
     if (!base) {
+      continue
+    }
+
+    if (rejectFoul && !status.fair) {
+      const message = status.reason ?? 'Value is not valid for the current context'
+      shape[field] = base.refine(() => false, { message })
       continue
     }
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,4 +1,5 @@
 export { activeSchema } from './active-schema.js'
+export type { ActiveSchemaOptions } from './active-schema.js'
 export { activeErrors, zodErrors } from './active-errors.js'
 export type { NormalizedFieldError } from './active-errors.js'
 export { createZodValidation } from './validation.js'

--- a/packages/zod/src/validation.ts
+++ b/packages/zod/src/validation.ts
@@ -6,7 +6,7 @@ import type {
 } from '@umpire/core'
 import type { z } from 'zod'
 import { activeErrors, zodErrors, type NormalizedFieldError } from './active-errors.js'
-import { activeSchema } from './active-schema.js'
+import { activeSchema, type ActiveSchemaOptions } from './active-schema.js'
 import { assertFieldSchemas, isRecord } from './schema-guards.js'
 
 type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
@@ -33,7 +33,7 @@ type ZodSchemaLike = {
 export type CreateZodValidationOptions<F extends Record<string, FieldDef>> = {
   schemas: FieldSchemas<F>
   build?(schema: z.ZodObject<Record<string, z.ZodTypeAny>>): ZodSchemaLike
-}
+} & ActiveSchemaOptions
 
 export type ZodValidationRunResult<F extends Record<string, FieldDef>> = {
   errors: Partial<Record<keyof F & string, string>>
@@ -69,6 +69,7 @@ export function createZodValidation<F extends Record<string, FieldDef>>(
   const {
     schemas,
     build,
+    rejectFoul,
   } = options
   const validators = {} as ValidationMap<F>
 
@@ -95,7 +96,7 @@ export function createZodValidation<F extends Record<string, FieldDef>>(
   return {
     validators,
     run(availability, values) {
-      const baseSchema = activeSchema(availability, schemas)
+      const baseSchema = activeSchema(availability, schemas, { rejectFoul })
       const schema = build ? build(baseSchema) : baseSchema
       const result = schema.safeParse(values)
       const normalizedErrors = isFailedParseResult(result) ? zodErrors(result.error) : []


### PR DESCRIPTION
## Summary

- `activeSchema` gains an optional `{ rejectFoul?: boolean }` third argument. When `true`, enabled fields where `fair: false` receive a `.refine(() => false)` using the field's `reason` as the Zod issue message — so contextually invalid values are explicitly rejected rather than stripped or silently accepted.
- `createZodValidation` accepts the same option at construction time and threads it through every `run()` call.
- Default is `false`; existing client-side usage is unaffected.
- `ActiveSchemaOptions` is exported from the package index.
- Changeset included for a minor bump to `@umpire/zod`.

## Motivation

When sharing an umpire engine between client and server, the server needs to guard against requests that bypass client validation (direct curl, etc.). Disabled fields are already excluded from `activeSchema`, but foul fields (`fair: false`) — fields that are structurally enabled but hold a contextually wrong value — were previously passing through with their base schema. `rejectFoul: true` closes that gap.

The parking lot analogy: a gas truck in an electric-only spot is a valid vehicle (`enabled: true`) but the wrong kind for that space (`fair: false`). Without this option the truck parks anyway; with it the gate rejects it outright.

## Test plan

- [ ] `activeSchema rejectFoul` suite in `__tests__/active-schema.test.ts` — foul rejection, fallback message, opt-out default, fair fields unaffected
- [ ] `createZodValidation` suite extended with a `fairWhen`-based scenario (gas/electric vehicle + spot type) exercising the `rejectFoul` path through `run()`, including error message propagation

https://claude.ai/code/session_01SMMXCxD2n1tDmMrtWRuBJj