### PR TITLE
🔌 Add @umpire/eslint-plugin

### DIFF
--- a/.changeset/polite-lobsters-taste.md
+++ b/.changeset/polite-lobsters-taste.md
@@ -1,0 +1,6 @@
+---
+"@umpire/eslint-plugin": patch
+---
+
+- Fix `no-inline-umpire-init` so `useMemo()` only suppresses warnings when it wraps `umpire()` inside the nearest React component or hook boundary.
+- Add `eitherOf()` coverage to `no-unknown-fields` so nested branch field references stay validated.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -120,6 +120,7 @@ export default defineConfig({
             { label: 'DevTools', slug: 'extensions/devtools' },
             { label: 'Reads', slug: 'extensions/reads' },
             { label: 'Testing', slug: 'extensions/testing' },
+            { label: 'ESLint Plugin', slug: 'extensions/eslint-plugin' },
             { label: 'JSON', collapsed: true, items: [
               { label: 'Overview', slug: 'adapters/json' },
               { label: 'DSL & Builders', slug: 'adapters/json/dsl' },

--- a/docs/src/content/docs/api/rules.md
+++ b/docs/src/content/docs/api/rules.md
@@ -16,7 +16,7 @@ Every rule helper returns a `Rule<F, C>` object. Rules are plain values — they
 | [`eitherOf()`](/umpire/api/rules/either-of/) | Named OR paths where each branch is a group of ANDed rules |
 | [`check()`](/umpire/api/rules/check/) | Bridge validators into rules with preserved field metadata |
 
-Try each one interactively on the [Quick Start](/umpire/learn/) page.
+Try each one interactively on the [Quick Start](/umpire/learn/) page. For lint-time validation of `requires()`, `disables()`, and the rest — see the [ESLint Plugin](/umpire/extensions/eslint-plugin/).
 
 ## Custom Reasons
 

--- a/docs/src/content/docs/extensions/eslint-plugin.mdx
+++ b/docs/src/content/docs/extensions/eslint-plugin.mdx
@@ -1,0 +1,240 @@
+---
+title: ESLint Plugin
+description: Catch umpire schema errors, performance pitfalls, and logical impossibilities at lint time.
+---
+
+`@umpire/eslint-plugin` adds five ESLint rules that catch umpire mistakes before your tests run. Two catch likely bugs (unknown fields, inline instantiation), three catch logical impossibilities that would silently produce fields that can never be enabled.
+
+## Compatibility
+
+| | |
+|---|---|
+| ESLint | ≥ 9.0.0 |
+| Config format | Flat config only (`eslint.config.js`) — legacy `.eslintrc` is not supported |
+| Node | Whatever ESLint 9 requires (≥ 18.18) |
+
+## Install
+
+```bash
+npm install --save-dev @umpire/eslint-plugin
+```
+
+## Setup
+
+Add the recommended config to your `eslint.config.js`:
+
+```js
+import umpire from '@umpire/eslint-plugin'
+
+export default [
+  umpire.configs.recommended,
+  // ... rest of your config
+]
+```
+
+This enables all five rules with the severities shown in the table below. To customize individual rules, spread the config and override:
+
+```js
+import umpire from '@umpire/eslint-plugin'
+
+export default [
+  {
+    ...umpire.configs.recommended,
+    rules: {
+      ...umpire.configs.recommended.rules,
+      '@umpire/no-unknown-fields': 'error', // promote to error
+      '@umpire/no-inline-umpire-init': 'off', // disable if you prefer useMemo discipline elsewhere
+    },
+  },
+]
+```
+
+Or register the plugin manually and pick individual rules:
+
+```js
+import umpire from '@umpire/eslint-plugin'
+
+export default [
+  {
+    plugins: { '@umpire': umpire },
+    rules: {
+      '@umpire/no-self-disable': 'error',
+      '@umpire/no-circular-requires': 'error',
+    },
+  },
+]
+```
+
+## Rules
+
+| Rule | Severity | What it catches |
+|------|----------|-----------------|
+| `no-unknown-fields` | `warn` | Field names in rules that aren't declared in `fields` |
+| `no-inline-umpire-init` | `warn` | `umpire()` called inside a component or hook body without `useMemo` |
+| `no-self-disable` | `error` | A field listed as both source and target of `disables()` |
+| `no-contradicting-rules` | `error` | `requires`/`disables` pairs that make a field permanently unavailable |
+| `no-circular-requires` | `error` | Circular `requires` chains where fields mutually depend on each other |
+
+`warn` rules are style/perf issues you should fix. `error` rules are logical impossibilities — the field they affect can never be enabled, ever.
+
+---
+
+## `no-unknown-fields`
+
+Catches field names used inside rules that don't match any key in the `fields` config. Typos here fail silently at runtime — `check()` just ignores the unknown dependency.
+
+```ts
+// ✗ — 'submitt' is not declared in fields
+const ump = umpire({
+  fields: { mode: {}, details: {}, submit: {} },
+  rules: [
+    requires('submitt', 'mode'), // typo
+  ],
+})
+
+// ✓
+const ump = umpire({
+  fields: { mode: {}, details: {}, submit: {} },
+  rules: [
+    requires('submit', 'mode'),
+  ],
+})
+```
+
+---
+
+## `no-inline-umpire-init`
+
+`umpire()` builds a dependency graph when called. Calling it inside a React component or hook body without `useMemo` rebuilds that graph on every render.
+
+```ts
+// ✗ — umpire() runs on every render
+function CheckoutForm() {
+  const ump = umpire({
+    fields: { card: {}, billing: {}, submit: {} },
+    rules: [requires('submit', 'card')],
+  })
+  const { check } = useUmpire(ump, values)
+  // ...
+}
+
+// ✓ — defined once at module scope
+const ump = umpire({
+  fields: { card: {}, billing: {}, submit: {} },
+  rules: [requires('submit', 'card')],
+})
+
+function CheckoutForm() {
+  const { check } = useUmpire(ump, values)
+  // ...
+}
+
+// ✓ — or memoized if it depends on props
+function CheckoutForm({ requireBilling }: Props) {
+  const ump = useMemo(() => umpire({
+    fields: { card: {}, billing: {}, submit: {} },
+    rules: [
+      requires('submit', 'card'),
+      ...(requireBilling ? [requires('submit', 'billing')] : []),
+    ],
+  }), [requireBilling])
+  // ...
+}
+```
+
+---
+
+## `no-self-disable`
+
+A field listed as both the source and a target of `disables()` would disable itself when it has a value — making it immediately unavailable.
+
+```ts
+// ✗ — 'promo' disables itself
+const ump = umpire({
+  fields: { promo: {}, discount: {} },
+  rules: [
+    disables('promo', ['promo', 'discount']),
+  ],
+})
+
+// ✓
+const ump = umpire({
+  fields: { promo: {}, discount: {} },
+  rules: [
+    disables('promo', ['discount']),
+  ],
+})
+```
+
+---
+
+## `no-contradicting-rules`
+
+Detects `requires`/`disables` pairs that make a field's requirement permanently unsatisfiable. Two patterns are caught:
+
+**Case A** — the dependency disables the requiring field: `requires(A, B)` + `disables(B, [A])`. A needs B to be available, but when B is satisfied it disables A — so A can never hold a value.
+
+**Case B** — the field disables its own dependency: `requires(A, B)` + `disables(A, [B])`. A needs B, but when A is satisfied it disables B — so A's own requirement can never hold while A has a value.
+
+```ts
+// ✗ — Case A: 'annual' requires 'plan', but 'plan' disables 'annual'
+const ump = umpire({
+  fields: { plan: {}, annual: {}, discount: {} },
+  rules: [
+    requires('annual', 'plan'),
+    disables('plan', ['annual']),
+  ],
+})
+
+// ✓ — remove the contradicting disables, or restructure the dependency
+const ump = umpire({
+  fields: { plan: {}, annual: {}, discount: {} },
+  rules: [
+    requires('annual', 'plan'),
+    disables('plan', ['discount']),
+  ],
+})
+```
+
+---
+
+## `no-circular-requires`
+
+Detects cycles in the `requires` dependency graph. If A requires B and B requires A (or a longer chain), neither field can ever satisfy its own requirement.
+
+```ts
+// ✗ — A and B mutually require each other
+const ump = umpire({
+  fields: { a: {}, b: {}, c: {} },
+  rules: [
+    requires('a', 'b'),
+    requires('b', 'a'),
+  ],
+})
+
+// ✗ — three-node cycle: a → b → c → a
+const ump = umpire({
+  fields: { a: {}, b: {}, c: {} },
+  rules: [
+    requires('a', 'b'),
+    requires('b', 'c'),
+    requires('c', 'a'),
+  ],
+})
+
+// ✓ — linear dependency, no cycle
+const ump = umpire({
+  fields: { a: {}, b: {}, c: {} },
+  rules: [
+    requires('a', 'b'),
+    requires('b', 'c'),
+  ],
+})
+```
+
+---
+
+## See also
+
+- [`umpire()` construction-time checks](/api/umpire/#structural-contradiction-detection) — runtime validation that runs when the instance is created
+- [Testing](/extensions/testing/) — `monkeyTest()` for invariant testing across exhaustive input combinations

--- a/packages/eslint-plugin/AGENTS.md
+++ b/packages/eslint-plugin/AGENTS.md
@@ -1,0 +1,7 @@
+# @umpire/eslint-plugin
+
+- Catches umpire misuse that TypeScript and runtime cannot: typo'd field names in rules, inline instance creation in React components, and self-disabling fields.
+- Rules match calls by function name (`umpire`, `requires`, `disables`, etc.) — no import tracking.
+- `no-unknown-fields`: bails out silently if the `fields` object contains spread elements, to avoid false positives.
+- `no-inline-umpire-init`: only fires inside functions whose name starts with an uppercase letter or `use`; wrapping with `useMemo` suppresses the warning.
+- Add new rules in `src/rules/`, export from `src/index.ts`, and add test coverage in `__tests__/`.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,38 @@
+# @umpire/eslint-plugin
+
+ESLint rules that catch umpire mistakes at lint time: typo'd field names, inline instance creation, and logical impossibilities like self-disabling fields and circular requires chains.
+
+Requires **ESLint ≥ 9** (flat config only).
+
+## Install
+
+```bash
+npm install --save-dev @umpire/eslint-plugin
+```
+
+## Setup
+
+Add the recommended config to your `eslint.config.js`:
+
+```js
+import umpire from '@umpire/eslint-plugin'
+
+export default [
+  umpire.configs.recommended,
+  // ... rest of your config
+]
+```
+
+## Rules
+
+| Rule | Severity | What it catches |
+|------|----------|-----------------|
+| `no-unknown-fields` | `warn` | Field names in rules that aren't declared in `fields` |
+| `no-inline-umpire-init` | `warn` | `umpire()` called inside a component or hook body without `useMemo` |
+| `no-self-disable` | `error` | A field listed as both source and target of `disables()` |
+| `no-contradicting-rules` | `error` | `requires`/`disables` pairs that make a field permanently unavailable |
+| `no-circular-requires` | `error` | Circular `requires` chains where fields mutually depend on each other |
+
+## Docs
+
+https://sdougbrown.github.io/umpire/extensions/eslint-plugin/

--- a/packages/eslint-plugin/__tests__/no-circular-requires.test.ts
+++ b/packages/eslint-plugin/__tests__/no-circular-requires.test.ts
@@ -1,0 +1,135 @@
+import { RuleTester } from 'eslint'
+import rule from '../src/rules/no-circular-requires.js'
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+tester.run('no-circular-requires', rule, {
+  valid: [
+    // Linear chain — no cycle.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {} },
+          rules: [
+            requires('b', 'a'),
+            requires('c', 'b'),
+          ],
+        })
+      `,
+    },
+    // Diamond dependency — no cycle (a and b both require c).
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {} },
+          rules: [
+            requires('a', 'c'),
+            requires('b', 'c'),
+          ],
+        })
+      `,
+    },
+    // No requires rules at all.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [disables('a', ['b'])],
+        })
+      `,
+    },
+    // Non-string dep (field builder) — skip.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [requires(field('a'), 'b')],
+        })
+      `,
+    },
+    // Not an umpire() call — ignore.
+    {
+      code: `
+        const x = configure({
+          fields: { a: {}, b: {} },
+          rules: [requires('a', 'b'), requires('b', 'a')],
+        })
+      `,
+    },
+  ],
+
+  invalid: [
+    // Direct 2-node cycle: a ↔ b.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [
+            requires('a', 'b'),
+            requires('b', 'a'),
+          ],
+        })
+      `,
+      errors: [{ messageId: 'circular' }],
+    },
+    // 3-node cycle: a → b → c → a.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {} },
+          rules: [
+            requires('a', 'b'),
+            requires('b', 'c'),
+            requires('c', 'a'),
+          ],
+        })
+      `,
+      errors: [{ messageId: 'circular' }],
+    },
+    // Self-cycle: a requires itself.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {} },
+          rules: [requires('a', 'a')],
+        })
+      `,
+      errors: [{ messageId: 'circular' }],
+    },
+    // Two separate 2-node cycles in one config — two errors.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {}, d: {} },
+          rules: [
+            requires('a', 'b'),
+            requires('b', 'a'),
+            requires('c', 'd'),
+            requires('d', 'c'),
+          ],
+        })
+      `,
+      errors: [{ messageId: 'circular' }, { messageId: 'circular' }],
+    },
+    // Cycle message includes the full path.
+    {
+      code: `
+        const ump = umpire({
+          fields: { x: {}, y: {} },
+          rules: [
+            requires('x', 'y'),
+            requires('y', 'x'),
+          ],
+        })
+      `,
+      errors: [
+        {
+          messageId: 'circular',
+          data: { cycle: "'x' → 'y' → 'x'" },
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin/__tests__/no-contradicting-rules.test.ts
+++ b/packages/eslint-plugin/__tests__/no-contradicting-rules.test.ts
@@ -1,0 +1,150 @@
+import { RuleTester } from 'eslint'
+import rule from '../src/rules/no-contradicting-rules.js'
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+tester.run('no-contradicting-rules', rule, {
+  valid: [
+    // No relationship between requires and disables targets.
+    {
+      code: `
+        const ump = umpire({
+          fields: { user: {}, order: {}, note: {} },
+          rules: [
+            requires('order', 'user'),
+            disables('note', ['user']),
+          ],
+        })
+      `,
+    },
+    // requires(A, B) + disables(A, [C]) — A disables an unrelated field, fine.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {} },
+          rules: [
+            requires('a', 'b'),
+            disables('a', ['c']),
+          ],
+        })
+      `,
+    },
+    // requires(A, B) + disables(C, [A]) — C disables A, but A doesn't require C.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {} },
+          rules: [
+            requires('a', 'b'),
+            disables('c', ['a']),
+          ],
+        })
+      `,
+    },
+    // disables with predicate source — skip (can't statically analyze).
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [
+            requires('a', 'b'),
+            disables((v) => !!v.b, ['a']),
+          ],
+        })
+      `,
+    },
+    // Not an umpire() call — ignore.
+    {
+      code: `
+        const x = configure({
+          fields: { a: {}, b: {} },
+          rules: [requires('a', 'b'), disables('b', ['a'])],
+        })
+      `,
+    },
+  ],
+
+  invalid: [
+    // Case A: dep disables the requiring field.
+    // requires(order, user) + disables(user, [order]) → order stuck
+    {
+      code: `
+        const ump = umpire({
+          fields: { user: {}, order: {} },
+          rules: [
+            requires('order', 'user'),
+            disables('user', ['order']),
+          ],
+        })
+      `,
+      errors: [
+        {
+          messageId: 'contradiction',
+          data: {
+            target: 'order',
+            dep: 'user',
+            disSource: 'user',
+            disTarget: 'order',
+          },
+        },
+      ],
+    },
+    // Case B: field disables its own dep.
+    // requires(order, user) + disables(order, [user]) → order's own requirement fails
+    {
+      code: `
+        const ump = umpire({
+          fields: { user: {}, order: {} },
+          rules: [
+            requires('order', 'user'),
+            disables('order', ['user']),
+          ],
+        })
+      `,
+      errors: [
+        {
+          messageId: 'contradiction',
+          data: {
+            target: 'order',
+            dep: 'user',
+            disSource: 'order',
+            disTarget: 'user',
+          },
+        },
+      ],
+    },
+    // requires with multiple deps — all are checked.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {} },
+          rules: [
+            requires('a', 'b', 'c'),
+            disables('b', ['a']),
+          ],
+        })
+      `,
+      errors: [{ messageId: 'contradiction' }],
+    },
+    // Both cases present in one config — two errors.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {} },
+          rules: [
+            requires('a', 'b'),
+            requires('c', 'b'),
+            disables('b', ['a']),
+            disables('c', ['b']),
+          ],
+        })
+      `,
+      errors: [
+        { messageId: 'contradiction' },
+        { messageId: 'contradiction' },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin/__tests__/no-inline-umpire-init.test.ts
+++ b/packages/eslint-plugin/__tests__/no-inline-umpire-init.test.ts
@@ -1,0 +1,111 @@
+import { RuleTester } from 'eslint'
+import rule from '../src/rules/no-inline-umpire-init.js'
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+tester.run('no-inline-umpire-init', rule, {
+  valid: [
+    // Module-level — always fine.
+    {
+      code: `
+        const ump = umpire({ fields: { a: {} }, rules: [] })
+        function MyComponent({ values }) {
+          const { check } = useUmpire(ump, values)
+        }
+      `,
+    },
+    // Wrapped in useMemo — fine.
+    {
+      code: `
+        function MyComponent({ values }) {
+          const ump = useMemo(() => umpire({ fields: { a: {} }, rules: [] }), [])
+          const { check } = useUmpire(ump, values)
+        }
+      `,
+    },
+    // Wrapped in React.useMemo — fine.
+    {
+      code: `
+        function MyComponent({ values }) {
+          const ump = React.useMemo(() => umpire({ fields: { a: {} }, rules: [] }), [])
+        }
+      `,
+    },
+    // Inside a hook, wrapped in useMemo — fine.
+    {
+      code: `
+        function useMyHook(values) {
+          const ump = useMemo(() => umpire({ fields: { a: {} }, rules: [] }), [])
+          return useUmpire(ump, values)
+        }
+      `,
+    },
+    // Regular lowercase function — not a component or hook, skip.
+    {
+      code: `
+        function buildConfig() {
+          return umpire({ fields: { a: {} }, rules: [] })
+        }
+      `,
+    },
+    // Arrow function assigned to lowercase name — skip.
+    {
+      code: `
+        const createUmp = () => umpire({ fields: { a: {} }, rules: [] })
+      `,
+    },
+  ],
+
+  invalid: [
+    // Direct call in function component body.
+    {
+      code: `
+        function MyForm({ values }) {
+          const ump = umpire({ fields: { a: {} }, rules: [] })
+          const { check } = useUmpire(ump, values)
+        }
+      `,
+      errors: [{ messageId: 'inlineInit' }],
+    },
+    // Arrow component.
+    {
+      code: `
+        const MyForm = ({ values }) => {
+          const ump = umpire({ fields: { a: {} }, rules: [] })
+        }
+      `,
+      errors: [{ messageId: 'inlineInit' }],
+    },
+    // Inside a custom hook body.
+    {
+      code: `
+        function useFormUmp(values) {
+          const ump = umpire({ fields: { a: {} }, rules: [] })
+          return useUmpire(ump, values)
+        }
+      `,
+      errors: [{ messageId: 'inlineInit' }],
+    },
+    // Arrow hook.
+    {
+      code: `
+        const useFormUmp = (values) => {
+          const ump = umpire({ fields: { a: {} }, rules: [] })
+          return useUmpire(ump, values)
+        }
+      `,
+      errors: [{ messageId: 'inlineInit' }],
+    },
+    // Nested inner function inside component — still fires.
+    {
+      code: `
+        function MyComponent({ values }) {
+          const getUmp = () => umpire({ fields: { a: {} }, rules: [] })
+        }
+      `,
+      errors: [{ messageId: 'inlineInit' }],
+    },
+  ],
+})

--- a/packages/eslint-plugin/__tests__/no-inline-umpire-init.test.ts
+++ b/packages/eslint-plugin/__tests__/no-inline-umpire-init.test.ts
@@ -107,5 +107,18 @@ tester.run('no-inline-umpire-init', rule, {
       `,
       errors: [{ messageId: 'inlineInit' }],
     },
+    // useMemo outside the component boundary does not protect the component.
+    {
+      code: `
+        const Outer = useMemo(() => {
+          function MyComponent() {
+            const ump = umpire({ fields: { a: {} }, rules: [] })
+          }
+
+          return MyComponent
+        }, [])
+      `,
+      errors: [{ messageId: 'inlineInit' }],
+    },
   ],
 })

--- a/packages/eslint-plugin/__tests__/no-self-disable.test.ts
+++ b/packages/eslint-plugin/__tests__/no-self-disable.test.ts
@@ -1,0 +1,44 @@
+import { RuleTester } from 'eslint'
+import rule from '../src/rules/no-self-disable.js'
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+tester.run('no-self-disable', rule, {
+  valid: [
+    // Source and targets are all different.
+    {
+      code: `disables('toggle', ['target', 'other'])`,
+    },
+    // Source is a predicate function — no string to compare.
+    {
+      code: `disables((v) => v.toggle, ['toggle'])`,
+    },
+    // Source is check() helper — string is inside, not the source arg itself.
+    {
+      code: `disables(check('toggle', (v) => !!v), ['target'])`,
+    },
+    // Empty targets array.
+    {
+      code: `disables('field', [])`,
+    },
+    // Not a disables() call — ignore.
+    {
+      code: `requires('a', 'b')`,
+    },
+  ],
+
+  invalid: [
+    // Source appears as the only target.
+    {
+      code: `disables('toggle', ['toggle'])`,
+      errors: [{ messageId: 'selfDisable', data: { field: 'toggle' } }],
+    },
+    // Source is one of multiple targets.
+    {
+      code: `disables('toggle', ['other', 'toggle'])`,
+      errors: [{ messageId: 'selfDisable', data: { field: 'toggle' } }],
+    },
+  ],
+})

--- a/packages/eslint-plugin/__tests__/no-unknown-fields.test.ts
+++ b/packages/eslint-plugin/__tests__/no-unknown-fields.test.ts
@@ -42,6 +42,20 @@ tester.run('no-unknown-fields', rule, {
         })
       `,
     },
+    // eitherOf with all declared fields.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [
+            eitherOf('grp', {
+              left: [requires('a', 'b')],
+              right: [],
+            }),
+          ],
+        })
+      `,
+    },
     // check() helper in disables source position.
     {
       code: `
@@ -142,6 +156,21 @@ tester.run('no-unknown-fields', rule, {
         const ump = umpire({
           fields: { a: {}, b: {} },
           rules: [anyOf(requires('a', 'c'), requires('a', 'b'))],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'c' } }],
+    },
+    // Unknown inside eitherOf -> nested requires.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [
+            eitherOf('grp', {
+              left: [requires('a', 'c')],
+              right: [],
+            }),
+          ],
         })
       `,
       errors: [{ messageId: 'unknownField', data: { field: 'c' } }],

--- a/packages/eslint-plugin/__tests__/no-unknown-fields.test.ts
+++ b/packages/eslint-plugin/__tests__/no-unknown-fields.test.ts
@@ -1,0 +1,193 @@
+import { RuleTester } from 'eslint'
+import rule from '../src/rules/no-unknown-fields.js'
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+tester.run('no-unknown-fields', rule, {
+  valid: [
+    // All fields referenced in rules are declared.
+    {
+      code: `
+        const ump = umpire({
+          fields: { username: {}, email: {}, password: {} },
+          rules: [
+            requires('email', 'username'),
+            disables('username', ['email', 'password']),
+            enabledWhen('password', (v) => !!v.email),
+          ],
+        })
+      `,
+    },
+    // oneOf branch fields are all declared.
+    {
+      code: `
+        const ump = umpire({
+          fields: { fast: {}, slow: {}, turbo: {} },
+          rules: [
+            oneOf('mode', { fast: ['fast', 'turbo'], slow: ['slow'] }),
+          ],
+        })
+      `,
+    },
+    // anyOf with all declared fields.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {}, c: {} },
+          rules: [
+            anyOf(requires('a', 'b'), requires('a', 'c')),
+          ],
+        })
+      `,
+    },
+    // check() helper in disables source position.
+    {
+      code: `
+        const ump = umpire({
+          fields: { toggle: {}, target: {} },
+          rules: [
+            disables(check('toggle', (v) => v.toggle === 'on'), ['target']),
+          ],
+        })
+      `,
+    },
+    // No rules array — nothing to check.
+    {
+      code: `
+        const ump = umpire({ fields: { a: {}, b: {} } })
+      `,
+    },
+    // Spread in fields — bail out to avoid false positives.
+    {
+      code: `
+        const ump = umpire({
+          fields: { ...baseFields, extra: {} },
+          rules: [requires('anything', 'unknown')],
+        })
+      `,
+    },
+    // Not an umpire() call — ignore.
+    {
+      code: `
+        const x = configure({ fields: { a: {} }, rules: [requires('nope', 'a')] })
+      `,
+    },
+    // fairWhen with a declared field.
+    {
+      code: `
+        const ump = umpire({
+          fields: { cpu: {}, motherboard: {} },
+          rules: [fairWhen('motherboard', (v) => v.cpu === v.motherboard)],
+        })
+      `,
+    },
+  ],
+
+  invalid: [
+    // Typo in requires target.
+    {
+      code: `
+        const ump = umpire({
+          fields: { username: {}, email: {} },
+          rules: [requires('usernme', 'email')],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'usernme' } }],
+    },
+    // Typo in requires dependency.
+    {
+      code: `
+        const ump = umpire({
+          fields: { username: {}, email: {} },
+          rules: [requires('username', 'emial')],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'emial' } }],
+    },
+    // Unknown field in disables source.
+    {
+      code: `
+        const ump = umpire({
+          fields: { toggle: {}, target: {} },
+          rules: [disables('toggl', ['target'])],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'toggl' } }],
+    },
+    // Unknown field in disables targets.
+    {
+      code: `
+        const ump = umpire({
+          fields: { toggle: {}, target: {} },
+          rules: [disables('toggle', ['taret'])],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'taret' } }],
+    },
+    // Unknown field inside oneOf branch.
+    {
+      code: `
+        const ump = umpire({
+          fields: { fast: {}, slow: {} },
+          rules: [oneOf('mode', { fast: ['fast'], slow: ['slwo'] })],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'slwo' } }],
+    },
+    // Unknown inside anyOf → nested requires.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [anyOf(requires('a', 'c'), requires('a', 'b'))],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'c' } }],
+    },
+    // Unknown field in check() helper inside disables.
+    {
+      code: `
+        const ump = umpire({
+          fields: { toggle: {}, target: {} },
+          rules: [disables(check('toogle', (v) => true), ['target'])],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'toogle' } }],
+    },
+    // Unknown field in enabledWhen target.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [enabledWhen('c', () => true)],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'c' } }],
+    },
+    // Unknown field in fairWhen target.
+    {
+      code: `
+        const ump = umpire({
+          fields: { cpu: {}, motherboard: {} },
+          rules: [fairWhen('mtoherboard', (v) => true)],
+        })
+      `,
+      errors: [{ messageId: 'unknownField', data: { field: 'mtoherboard' } }],
+    },
+    // Multiple errors in one umpire call.
+    {
+      code: `
+        const ump = umpire({
+          fields: { a: {}, b: {} },
+          rules: [requires('x', 'y')],
+        })
+      `,
+      errors: [
+        { messageId: 'unknownField', data: { field: 'x' } },
+        { messageId: 'unknownField', data: { field: 'y' } },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@umpire/eslint-plugin",
+  "version": "0.1.0-alpha.9",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist",
+    "AGENTS.md",
+    ".claude"
+  ],
+  "peerDependencies": {
+    "eslint": ">=9.0.0"
+  },
+  "devDependencies": {
+    "@types/estree": "^1.0.7",
+    "eslint": "^9.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "directory": "packages/eslint-plugin"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,4 +1,6 @@
 import type { Linter } from 'eslint'
+import noCircularRequires from './rules/no-circular-requires.js'
+import noContradictingRules from './rules/no-contradicting-rules.js'
 import noInlineUmpireInit from './rules/no-inline-umpire-init.js'
 import noSelfDisable from './rules/no-self-disable.js'
 import noUnknownFields from './rules/no-unknown-fields.js'
@@ -11,6 +13,8 @@ const plugin = {
     'no-unknown-fields': noUnknownFields,
     'no-inline-umpire-init': noInlineUmpireInit,
     'no-self-disable': noSelfDisable,
+    'no-contradicting-rules': noContradictingRules,
+    'no-circular-requires': noCircularRequires,
   },
   configs: {} as Record<string, Linter.Config>,
 }
@@ -22,6 +26,8 @@ plugin.configs.recommended = {
     '@umpire/no-unknown-fields': 'warn',
     '@umpire/no-inline-umpire-init': 'warn',
     '@umpire/no-self-disable': 'error',
+    '@umpire/no-contradicting-rules': 'error',
+    '@umpire/no-circular-requires': 'error',
   },
 }
 

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,28 @@
+import type { Linter } from 'eslint'
+import noInlineUmpireInit from './rules/no-inline-umpire-init.js'
+import noSelfDisable from './rules/no-self-disable.js'
+import noUnknownFields from './rules/no-unknown-fields.js'
+
+const plugin = {
+  meta: {
+    name: '@umpire/eslint-plugin',
+  },
+  rules: {
+    'no-unknown-fields': noUnknownFields,
+    'no-inline-umpire-init': noInlineUmpireInit,
+    'no-self-disable': noSelfDisable,
+  },
+  configs: {} as Record<string, Linter.Config>,
+}
+
+// Self-referential recommended config — standard ESLint flat config pattern.
+plugin.configs.recommended = {
+  plugins: { '@umpire': plugin },
+  rules: {
+    '@umpire/no-unknown-fields': 'warn',
+    '@umpire/no-inline-umpire-init': 'warn',
+    '@umpire/no-self-disable': 'error',
+  },
+}
+
+export default plugin

--- a/packages/eslint-plugin/src/rules/no-circular-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-circular-requires.ts
@@ -1,0 +1,175 @@
+import type { Rule } from 'eslint'
+import type * as estree from 'estree'
+import { getRulesArray, isUmpireCall } from '../utils.js'
+
+/**
+ * Detects cycles in the requires dependency graph within a single umpire() call.
+ *
+ * requires(A, B) + requires(B, A) → A and B mutually require each other;
+ * neither can ever be enabled.
+ *
+ * Handles cycles of any length (A→B→C→A, etc.) using DFS with gray/black
+ * coloring. Reports on the requires() call whose dep edge closes the cycle.
+ *
+ * Only checks top-level string-literal requires arguments. Rules nested inside
+ * anyOf/eitherOf have OR/branch semantics and are intentionally skipped.
+ */
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow circular requires dependencies between fields.',
+      recommended: true,
+    },
+    messages: {
+      circular:
+        'Circular requires: {{cycle}}. These fields mutually require each other and can never all be enabled.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node: estree.CallExpression) {
+        if (!isUmpireCall(node)) return
+
+        const rulesArray = getRulesArray(node)
+        if (!rulesArray) return
+
+        const edges: RequiresEdge[] = []
+
+        for (const el of rulesArray.elements) {
+          if (
+            !el ||
+            el.type !== 'CallExpression' ||
+            el.callee.type !== 'Identifier' ||
+            el.callee.name !== 'requires'
+          )
+            continue
+
+          const args = el.arguments.filter(
+            (a): a is estree.Expression => a.type !== 'SpreadElement',
+          )
+          const targetArg = args[0]
+          if (!targetArg || !isStringLit(targetArg)) continue
+          const target = targetArg.value
+
+          for (const depArg of args.slice(1)) {
+            if (isStringLit(depArg)) {
+              edges.push({ from: target, to: depArg.value, node: el })
+            }
+          }
+        }
+
+        for (const { cycle, closingNode } of findCycles(edges)) {
+          context.report({
+            node: closingNode as unknown as estree.Node,
+            messageId: 'circular',
+            data: { cycle: cycle.map((f) => `'${f}'`).join(' → ') },
+          })
+        }
+      },
+    }
+  },
+}
+
+export default rule
+
+// ---------------------------------------------------------------------------
+// Graph types and cycle detection
+// ---------------------------------------------------------------------------
+
+type RequiresEdge = {
+  from: string
+  to: string
+  node: estree.CallExpression
+}
+
+type CycleReport = {
+  /** Full cycle path, e.g. ['a', 'b', 'c', 'a'] */
+  cycle: string[]
+  /** The requires() call whose dep edge closes the cycle */
+  closingNode: estree.CallExpression
+}
+
+/**
+ * Finds all unique directed cycles in the requires graph using DFS with
+ * gray/black node coloring.
+ *
+ * - Gray: node is on the current DFS stack
+ * - Black: node is fully explored (all descendants processed)
+ *
+ * A back edge to a gray node indicates a cycle. Reports once per unique cycle
+ * (normalized by rotating to start at the lexicographically smallest field).
+ */
+function findCycles(edges: RequiresEdge[]): CycleReport[] {
+  if (edges.length === 0) return []
+
+  // Build adjacency list: from → outgoing edges
+  const adj = new Map<string, RequiresEdge[]>()
+  for (const e of edges) {
+    const list = adj.get(e.from) ?? []
+    list.push(e)
+    adj.set(e.from, list)
+  }
+
+  const allNodes = new Set(edges.flatMap((e) => [e.from, e.to]))
+  const state = new Map<string, 'white' | 'gray' | 'black'>()
+  for (const n of allNodes) state.set(n, 'white')
+
+  const results: CycleReport[] = []
+  const reportedKeys = new Set<string>()
+  const path: string[] = []
+
+  function visit(node: string): void {
+    state.set(node, 'gray')
+    path.push(node)
+
+    for (const edge of adj.get(node) ?? []) {
+      const nextState = state.get(edge.to)
+
+      if (nextState === 'gray') {
+        // Back edge — found a cycle. Slice the path from where `edge.to`
+        // first appears to get the participating nodes.
+        const cycleStart = path.indexOf(edge.to)
+        const cycle = path.slice(cycleStart)
+        const key = normalizeCycle(cycle)
+        if (!reportedKeys.has(key)) {
+          reportedKeys.add(key)
+          // `edge` is the closing edge; its requires() node is the report site.
+          results.push({ cycle: [...cycle, edge.to], closingNode: edge.node })
+        }
+      } else if (nextState === 'white') {
+        visit(edge.to)
+      }
+      // black: already fully explored, no new cycles reachable from here
+    }
+
+    path.pop()
+    state.set(node, 'black')
+  }
+
+  for (const n of allNodes) {
+    if (state.get(n) === 'white') visit(n)
+  }
+
+  return results
+}
+
+/**
+ * Rotates the cycle array to start at the lexicographically smallest element
+ * so that the same cycle detected from different entry points produces the
+ * same key.
+ */
+function normalizeCycle(cycle: string[]): string {
+  const min = [...cycle].sort()[0]
+  const minIdx = cycle.indexOf(min)
+  return [...cycle.slice(minIdx), ...cycle.slice(0, minIdx)].join('→')
+}
+
+function isStringLit(
+  node: estree.Node,
+): node is estree.Literal & { value: string } {
+  return node.type === 'Literal' && typeof node.value === 'string'
+}

--- a/packages/eslint-plugin/src/rules/no-circular-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-circular-requires.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint'
 import type * as estree from 'estree'
-import { getRulesArray, isUmpireCall } from '../utils.js'
+import { getRulesArray, isStringLiteral, isUmpireCall } from '../utils.js'
 
 /**
  * Detects cycles in the requires dependency graph within a single umpire() call.
@@ -52,11 +52,11 @@ const rule: Rule.RuleModule = {
             (a): a is estree.Expression => a.type !== 'SpreadElement',
           )
           const targetArg = args[0]
-          if (!targetArg || !isStringLit(targetArg)) continue
+          if (!targetArg || !isStringLiteral(targetArg)) continue
           const target = targetArg.value
 
           for (const depArg of args.slice(1)) {
-            if (isStringLit(depArg)) {
+            if (isStringLiteral(depArg)) {
               edges.push({ from: target, to: depArg.value, node: el })
             }
           }
@@ -166,10 +166,4 @@ function normalizeCycle(cycle: string[]): string {
   const min = [...cycle].sort()[0]
   const minIdx = cycle.indexOf(min)
   return [...cycle.slice(minIdx), ...cycle.slice(0, minIdx)].join('→')
-}
-
-function isStringLit(
-  node: estree.Node,
-): node is estree.Literal & { value: string } {
-  return node.type === 'Literal' && typeof node.value === 'string'
 }

--- a/packages/eslint-plugin/src/rules/no-contradicting-rules.ts
+++ b/packages/eslint-plugin/src/rules/no-contradicting-rules.ts
@@ -1,0 +1,132 @@
+import type { Rule } from 'eslint'
+import type * as estree from 'estree'
+import { getRulesArray, isUmpireCall } from '../utils.js'
+
+/**
+ * Detects pairs of rules that make a field permanently unavailable:
+ *
+ * Case A — dep disables the requiring field:
+ *   requires(X, Y) + disables(Y, [X, ...])
+ *   X needs Y to be available, but when Y is satisfied it disables X.
+ *
+ * Case B — field disables its own dep:
+ *   requires(X, Y) + disables(X, [Y, ...])
+ *   X needs Y to be available, but when X is satisfied it disables Y,
+ *   so X's own requirement can never hold while X has a value.
+ *
+ * Only checks top-level string-literal sources/targets. Rules nested inside
+ * anyOf/eitherOf have OR/branch semantics and are intentionally skipped.
+ */
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow requires/disables combinations that make a field permanently unavailable.',
+      recommended: true,
+    },
+    messages: {
+      contradiction:
+        "Contradicting rules: '{{target}}' requires '{{dep}}', but disables('{{disSource}}', ['{{disTarget}}', ...]) makes this impossible to satisfy.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node: estree.CallExpression) {
+        if (!isUmpireCall(node)) return
+
+        const rulesArray = getRulesArray(node)
+        if (!rulesArray) return
+
+        type RequiresEntry = { target: string; dep: string }
+        type DisablesEntry = {
+          source: string
+          targets: string[]
+          node: estree.CallExpression
+        }
+
+        const requiresList: RequiresEntry[] = []
+        const disablesList: DisablesEntry[] = []
+
+        for (const el of rulesArray.elements) {
+          if (
+            !el ||
+            el.type !== 'CallExpression' ||
+            el.callee.type !== 'Identifier'
+          )
+            continue
+
+          const name = el.callee.name
+          const args = el.arguments.filter(
+            (a): a is estree.Expression => a.type !== 'SpreadElement',
+          )
+
+          if (name === 'requires') {
+            const targetArg = args[0]
+            if (!targetArg || !isStringLit(targetArg)) continue
+            const target = targetArg.value
+            for (const depArg of args.slice(1)) {
+              if (isStringLit(depArg)) {
+                requiresList.push({ target, dep: depArg.value })
+              }
+            }
+          }
+
+          if (name === 'disables') {
+            const sourceArg = args[0]
+            if (!sourceArg || !isStringLit(sourceArg)) continue
+            const source = sourceArg.value
+            const targetsArg = args[1]
+            if (!targetsArg || targetsArg.type !== 'ArrayExpression') continue
+            const targets = targetsArg.elements
+              .filter(
+                (e): e is estree.Literal & { value: string } =>
+                  e?.type === 'Literal' && typeof e.value === 'string',
+              )
+              .map((e) => e.value)
+            if (targets.length > 0) {
+              disablesList.push({ source, targets, node: el })
+            }
+          }
+        }
+
+        for (const req of requiresList) {
+          for (const dis of disablesList) {
+            // Case A: dep disables the requiring field
+            // requires(X, Y) + disables(Y, [X]) → X can never be enabled
+            const caseA =
+              dis.source === req.dep && dis.targets.includes(req.target)
+
+            // Case B: field disables its own dep
+            // requires(X, Y) + disables(X, [Y]) → X's requirement can never hold
+            const caseB =
+              dis.source === req.target && dis.targets.includes(req.dep)
+
+            if (caseA || caseB) {
+              context.report({
+                node: dis.node as unknown as estree.Node,
+                messageId: 'contradiction',
+                data: {
+                  target: req.target,
+                  dep: req.dep,
+                  disSource: dis.source,
+                  disTarget: caseA ? req.target : req.dep,
+                },
+              })
+            }
+          }
+        }
+      },
+    }
+  },
+}
+
+export default rule
+
+function isStringLit(
+  node: estree.Node,
+): node is estree.Literal & { value: string } {
+  return node.type === 'Literal' && typeof node.value === 'string'
+}

--- a/packages/eslint-plugin/src/rules/no-contradicting-rules.ts
+++ b/packages/eslint-plugin/src/rules/no-contradicting-rules.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint'
 import type * as estree from 'estree'
-import { getRulesArray, isUmpireCall } from '../utils.js'
+import { getRulesArray, isStringLiteral, isUmpireCall } from '../utils.js'
 
 /**
  * Detects pairs of rules that make a field permanently unavailable:
@@ -65,10 +65,10 @@ const rule: Rule.RuleModule = {
 
           if (name === 'requires') {
             const targetArg = args[0]
-            if (!targetArg || !isStringLit(targetArg)) continue
+            if (!targetArg || !isStringLiteral(targetArg)) continue
             const target = targetArg.value
             for (const depArg of args.slice(1)) {
-              if (isStringLit(depArg)) {
+              if (isStringLiteral(depArg)) {
                 requiresList.push({ target, dep: depArg.value })
               }
             }
@@ -76,7 +76,7 @@ const rule: Rule.RuleModule = {
 
           if (name === 'disables') {
             const sourceArg = args[0]
-            if (!sourceArg || !isStringLit(sourceArg)) continue
+            if (!sourceArg || !isStringLiteral(sourceArg)) continue
             const source = sourceArg.value
             const targetsArg = args[1]
             if (!targetsArg || targetsArg.type !== 'ArrayExpression') continue
@@ -124,9 +124,3 @@ const rule: Rule.RuleModule = {
 }
 
 export default rule
-
-function isStringLit(
-  node: estree.Node,
-): node is estree.Literal & { value: string } {
-  return node.type === 'Literal' && typeof node.value === 'string'
-}

--- a/packages/eslint-plugin/src/rules/no-inline-umpire-init.ts
+++ b/packages/eslint-plugin/src/rules/no-inline-umpire-init.ts
@@ -1,0 +1,124 @@
+import type { Rule } from 'eslint'
+import type * as estree from 'estree'
+import { isUmpireCall } from '../utils.js'
+
+// Nodes augmented with the parent reference ESLint adds during traversal.
+type AugmentedNode = estree.Node & { parent?: AugmentedNode }
+
+const FUNCTION_TYPES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+])
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow calling umpire() inside React component or hook bodies without useMemo.',
+      recommended: true,
+    },
+    messages: {
+      inlineInit:
+        'umpire() creates a dependency graph on every call. Move this outside the component or wrap it in useMemo(() => umpire(...), []).',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node: estree.CallExpression) {
+        if (!isUmpireCall(node)) return
+
+        const ancestors: estree.Node[] =
+          context.sourceCode.getAncestors(node as estree.Node)
+
+        let enclosingReactFunction = false
+        let wrappedInUseMemo = false
+
+        for (let i = ancestors.length - 1; i >= 0; i--) {
+          const ancestor = ancestors[i]
+
+          // Track useMemo wrapping: look for a function node whose direct
+          // parent is a useMemo() call and that function is the first arg.
+          if (FUNCTION_TYPES.has(ancestor.type)) {
+            const parent = ancestors[i - 1]
+            if (
+              parent?.type === 'CallExpression' &&
+              isUseMemoCall(parent as estree.CallExpression) &&
+              (parent as estree.CallExpression).arguments[0] === ancestor
+            ) {
+              wrappedInUseMemo = true
+            }
+
+            // Check if this function looks like a React component or hook.
+            const name = resolveFunctionName(
+              ancestor as estree.Function,
+              ancestors[i - 1],
+            )
+            if (name && isReactName(name)) {
+              enclosingReactFunction = true
+            }
+          }
+        }
+
+        if (enclosingReactFunction && !wrappedInUseMemo) {
+          context.report({ node: node as unknown as estree.Node, messageId: 'inlineInit' })
+        }
+      },
+    }
+  },
+}
+
+export default rule
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isUseMemoCall(node: estree.CallExpression): boolean {
+  const { callee } = node
+  if (callee.type === 'Identifier') return callee.name === 'useMemo'
+  if (
+    callee.type === 'MemberExpression' &&
+    callee.property.type === 'Identifier'
+  ) {
+    return callee.property.name === 'useMemo'
+  }
+  return false
+}
+
+/**
+ * Returns the name of a function node, inspecting the parent node to handle
+ * `const MyComp = () => {}` and `const MyComp = function() {}` patterns.
+ */
+function resolveFunctionName(
+  fn: estree.Function,
+  parent: estree.Node | undefined,
+): string | null {
+  // function MyComp() {} or function* myGen() {}
+  if (
+    (fn.type === 'FunctionDeclaration' || fn.type === 'FunctionExpression') &&
+    fn.id
+  ) {
+    return fn.id.name
+  }
+  // const MyComp = () => {} or const MyComp = function() {}
+  if (parent?.type === 'VariableDeclarator' && parent.id.type === 'Identifier') {
+    return parent.id.name
+  }
+  // { render: function() {} } — named property
+  if (
+    parent?.type === 'Property' &&
+    !parent.computed &&
+    parent.key.type === 'Identifier'
+  ) {
+    return parent.key.name
+  }
+  return null
+}
+
+function isReactName(name: string): boolean {
+  return /^[A-Z]/.test(name) || name.startsWith('use')
+}

--- a/packages/eslint-plugin/src/rules/no-inline-umpire-init.ts
+++ b/packages/eslint-plugin/src/rules/no-inline-umpire-init.ts
@@ -34,36 +34,39 @@ const rule: Rule.RuleModule = {
         const ancestors: estree.Node[] =
           context.sourceCode.getAncestors(node as estree.Node)
 
-        let enclosingReactFunction = false
-        let wrappedInUseMemo = false
+        let reactFunctionDepth = -1
+        let useMemoDepth = -1
 
         for (let i = ancestors.length - 1; i >= 0; i--) {
           const ancestor = ancestors[i]
 
-          // Track useMemo wrapping: look for a function node whose direct
-          // parent is a useMemo() call and that function is the first arg.
-          if (FUNCTION_TYPES.has(ancestor.type)) {
-            const parent = ancestors[i - 1]
-            if (
-              parent?.type === 'CallExpression' &&
-              isUseMemoCall(parent as estree.CallExpression) &&
-              (parent as estree.CallExpression).arguments[0] === ancestor
-            ) {
-              wrappedInUseMemo = true
-            }
+          if (!FUNCTION_TYPES.has(ancestor.type)) continue
 
-            // Check if this function looks like a React component or hook.
-            const name = resolveFunctionName(
-              ancestor as estree.Function,
-              ancestors[i - 1],
-            )
-            if (name && isReactName(name)) {
-              enclosingReactFunction = true
-            }
+          const parent = ancestors[i - 1]
+          if (
+            parent?.type === 'CallExpression' &&
+            isUseMemoCall(parent as estree.CallExpression) &&
+            (parent as estree.CallExpression).arguments[0] === ancestor &&
+            useMemoDepth === -1
+          ) {
+            useMemoDepth = i
+          }
+
+          // Record the nearest React component or hook boundary so useMemo only
+          // suppresses when it sits inside that boundary.
+          const name = resolveFunctionName(
+            ancestor as estree.Function,
+            parent,
+          )
+          if (name && isReactName(name) && reactFunctionDepth === -1) {
+            reactFunctionDepth = i
           }
         }
 
-        if (enclosingReactFunction && !wrappedInUseMemo) {
+        const wrappedInUseMemo =
+          useMemoDepth !== -1 && useMemoDepth > reactFunctionDepth
+
+        if (reactFunctionDepth !== -1 && !wrappedInUseMemo) {
           context.report({ node: node as unknown as estree.Node, messageId: 'inlineInit' })
         }
       },

--- a/packages/eslint-plugin/src/rules/no-inline-umpire-init.ts
+++ b/packages/eslint-plugin/src/rules/no-inline-umpire-init.ts
@@ -2,9 +2,6 @@ import type { Rule } from 'eslint'
 import type * as estree from 'estree'
 import { isUmpireCall } from '../utils.js'
 
-// Nodes augmented with the parent reference ESLint adds during traversal.
-type AugmentedNode = estree.Node & { parent?: AugmentedNode }
-
 const FUNCTION_TYPES = new Set([
   'FunctionDeclaration',
   'FunctionExpression',

--- a/packages/eslint-plugin/src/rules/no-self-disable.ts
+++ b/packages/eslint-plugin/src/rules/no-self-disable.ts
@@ -1,5 +1,6 @@
 import type { Rule } from 'eslint'
 import type * as estree from 'estree'
+import { isStringLiteral } from '../utils.js'
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -31,7 +32,7 @@ const rule: Rule.RuleModule = {
         )
 
         const source = args[0]
-        if (!source || source.type !== 'Literal' || typeof source.value !== 'string') {
+        if (!source || !isStringLiteral(source)) {
           return
         }
         const sourceName = source.value
@@ -41,8 +42,8 @@ const rule: Rule.RuleModule = {
 
         for (const element of targets.elements) {
           if (
-            element?.type === 'Literal' &&
-            typeof element.value === 'string' &&
+            element &&
+            isStringLiteral(element) &&
             element.value === sourceName
           ) {
             context.report({

--- a/packages/eslint-plugin/src/rules/no-self-disable.ts
+++ b/packages/eslint-plugin/src/rules/no-self-disable.ts
@@ -1,0 +1,60 @@
+import type { Rule } from 'eslint'
+import type * as estree from 'estree'
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a field from appearing as both the source and a target in disables().',
+      recommended: true,
+    },
+    messages: {
+      selfDisable:
+        "'{{field}}' is listed as both the source and a target of disables(). A field cannot disable itself.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node: estree.CallExpression) {
+        if (
+          node.callee.type !== 'Identifier' ||
+          node.callee.name !== 'disables'
+        ) {
+          return
+        }
+
+        const args = node.arguments.filter(
+          (a): a is estree.Expression => a.type !== 'SpreadElement',
+        )
+
+        const source = args[0]
+        if (!source || source.type !== 'Literal' || typeof source.value !== 'string') {
+          return
+        }
+        const sourceName = source.value
+
+        const targets = args[1]
+        if (!targets || targets.type !== 'ArrayExpression') return
+
+        for (const element of targets.elements) {
+          if (
+            element?.type === 'Literal' &&
+            typeof element.value === 'string' &&
+            element.value === sourceName
+          ) {
+            context.report({
+              node: element as unknown as estree.Node,
+              messageId: 'selfDisable',
+              data: { field: sourceName },
+            })
+          }
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin/src/rules/no-unknown-fields.ts
+++ b/packages/eslint-plugin/src/rules/no-unknown-fields.ts
@@ -1,0 +1,56 @@
+import type { Rule } from 'eslint'
+import type * as estree from 'estree'
+import {
+  extractFieldRefs,
+  getFieldNames,
+  getFieldsConfig,
+  getRulesArray,
+  isUmpireCall,
+} from '../utils.js'
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow field names in umpire rules that are not declared in the fields config.',
+      recommended: true,
+    },
+    messages: {
+      unknownField:
+        "Field '{{field}}' is not declared in this umpire fields config.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node: estree.CallExpression) {
+        if (!isUmpireCall(node)) return
+
+        const fieldsNode = getFieldsConfig(node)
+        // If fields can't be statically enumerated (e.g. has spreads), skip.
+        if (!fieldsNode) return
+
+        const knownFields = getFieldNames(fieldsNode)
+        const rulesArray = getRulesArray(node)
+        if (!rulesArray) return
+
+        for (const element of rulesArray.elements) {
+          if (!element || element.type !== 'CallExpression') continue
+          for (const ref of extractFieldRefs(element)) {
+            if (!knownFields.has(ref.value)) {
+              context.report({
+                node: ref.node as unknown as estree.Node,
+                messageId: 'unknownField',
+                data: { field: ref.value },
+              })
+            }
+          }
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -198,10 +198,10 @@ export function extractFieldRefs(node: estree.CallExpression): FieldRef[] {
 }
 
 // ---------------------------------------------------------------------------
-// Internal helpers
+// Shared helpers
 // ---------------------------------------------------------------------------
 
-function isStringLiteral(
+export function isStringLiteral(
   node: estree.Node,
 ): node is estree.Literal & { value: string } {
   return node.type === 'Literal' && typeof node.value === 'string'

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -1,0 +1,218 @@
+import type * as estree from 'estree'
+
+export type FieldRef = {
+  node: estree.Literal & { value: string }
+  value: string
+}
+
+/**
+ * Returns true when a CallExpression is `umpire({ ... })`.
+ */
+export function isUmpireCall(node: estree.CallExpression): boolean {
+  return (
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'umpire' &&
+    node.arguments.length >= 1 &&
+    node.arguments[0].type === 'ObjectExpression'
+  )
+}
+
+/**
+ * Returns the `fields` ObjectExpression from an `umpire()` config argument,
+ * or null if it can't be statically enumerated (e.g. contains spread elements).
+ */
+export function getFieldsConfig(
+  callNode: estree.CallExpression,
+): estree.ObjectExpression | null {
+  const config = callNode.arguments[0]
+  if (config.type !== 'ObjectExpression') return null
+
+  const fieldsProp = config.properties.find(
+    (p): p is estree.Property =>
+      p.type === 'Property' &&
+      !p.computed &&
+      ((p.key.type === 'Identifier' && p.key.name === 'fields') ||
+        (p.key.type === 'Literal' && p.key.value === 'fields')),
+  )
+
+  if (!fieldsProp || fieldsProp.value.type !== 'ObjectExpression') return null
+
+  const fieldsObj = fieldsProp.value
+  // If there are spreads we can't enumerate all field names — bail out to
+  // avoid false positives.
+  if (fieldsObj.properties.some((p) => p.type === 'SpreadElement')) return null
+
+  return fieldsObj
+}
+
+/**
+ * Returns the set of statically known field names from a `fields` object.
+ */
+export function getFieldNames(fieldsNode: estree.ObjectExpression): Set<string> {
+  const names = new Set<string>()
+  for (const prop of fieldsNode.properties) {
+    if (prop.type !== 'Property' || prop.computed) continue
+    if (prop.key.type === 'Identifier') {
+      names.add(prop.key.name)
+    } else if (
+      prop.key.type === 'Literal' &&
+      typeof prop.key.value === 'string'
+    ) {
+      names.add(prop.key.value)
+    }
+  }
+  return names
+}
+
+/**
+ * Returns the `rules` ArrayExpression from an `umpire()` config, or null.
+ */
+export function getRulesArray(
+  callNode: estree.CallExpression,
+): estree.ArrayExpression | null {
+  const config = callNode.arguments[0]
+  if (config.type !== 'ObjectExpression') return null
+
+  const rulesProp = config.properties.find(
+    (p): p is estree.Property =>
+      p.type === 'Property' &&
+      !p.computed &&
+      ((p.key.type === 'Identifier' && p.key.name === 'rules') ||
+        (p.key.type === 'Literal' && p.key.value === 'rules')),
+  )
+
+  if (!rulesProp || rulesProp.value.type !== 'ArrayExpression') return null
+  return rulesProp.value
+}
+
+/**
+ * Extracts all field-name string literals referenced in a rule factory call.
+ *
+ * Understands: enabledWhen, fairWhen, requires, disables, oneOf, anyOf, eitherOf.
+ * Recurses into anyOf/eitherOf. Handles the `check(field, pred)` helper inside
+ * disables source position.
+ */
+export function extractFieldRefs(node: estree.CallExpression): FieldRef[] {
+  if (node.callee.type !== 'Identifier') return []
+
+  const fn = node.callee.name
+  const args = node.arguments.filter(
+    (a): a is estree.Expression => a.type !== 'SpreadElement',
+  )
+
+  switch (fn) {
+    case 'enabledWhen':
+    case 'fairWhen':
+      // enabledWhen(target, predicate, options?)
+      return stringLiterals([args[0]])
+
+    case 'requires':
+      // requires(target, dep1, dep2, ..., options?)
+      // All string-literal args are field names regardless of position.
+      return stringLiterals(args)
+
+    case 'disables': {
+      // disables(source, targets, options?)
+      const refs: FieldRef[] = []
+      const source = args[0]
+      if (source) {
+        if (isStringLiteral(source)) {
+          refs.push({ node: source, value: source.value })
+        } else if (
+          source.type === 'CallExpression' &&
+          source.callee.type === 'Identifier' &&
+          source.callee.name === 'check'
+        ) {
+          // check(fieldName, predicate) — first arg is a field name
+          const checkField = source.arguments[0]
+          if (checkField && isStringLiteral(checkField)) {
+            refs.push({ node: checkField, value: checkField.value })
+          }
+        }
+      }
+      const targets = args[1]
+      if (targets?.type === 'ArrayExpression') {
+        refs.push(
+          ...stringLiterals(
+            targets.elements.filter(
+              (e): e is estree.Expression =>
+                e !== null && e.type !== 'SpreadElement',
+            ),
+          ),
+        )
+      }
+      return refs
+    }
+
+    case 'oneOf': {
+      // oneOf(groupName, { branchName: [field1, field2] }, options?)
+      // arg[0] is the mutex group name — not a field name, skip it.
+      // arg[1] property values are arrays of field name strings.
+      const branches = args[1]
+      if (branches?.type !== 'ObjectExpression') return []
+      const refs: FieldRef[] = []
+      for (const prop of branches.properties) {
+        if (prop.type !== 'Property') continue
+        if (prop.value.type === 'ArrayExpression') {
+          refs.push(
+            ...stringLiterals(
+              prop.value.elements.filter(
+                (e): e is estree.Expression =>
+                  e !== null && e.type !== 'SpreadElement',
+              ),
+            ),
+          )
+        }
+      }
+      return refs
+    }
+
+    case 'anyOf':
+      // anyOf(rule1, rule2, ...) — each arg is a rule call, recurse.
+      return args.flatMap((arg) =>
+        arg.type === 'CallExpression' ? extractFieldRefs(arg) : [],
+      )
+
+    case 'eitherOf': {
+      // eitherOf(groupName, { branchName: [rule1, rule2] })
+      // Branch values are arrays of rule calls — recurse into each.
+      const branches = args[1]
+      if (branches?.type !== 'ObjectExpression') return []
+      const refs: FieldRef[] = []
+      for (const prop of branches.properties) {
+        if (prop.type !== 'Property') continue
+        if (prop.value.type === 'ArrayExpression') {
+          for (const el of prop.value.elements) {
+            if (el?.type === 'CallExpression') {
+              refs.push(...extractFieldRefs(el))
+            }
+          }
+        }
+      }
+      return refs
+    }
+
+    default:
+      return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function isStringLiteral(
+  node: estree.Node,
+): node is estree.Literal & { value: string } {
+  return node.type === 'Literal' && typeof node.value === 'string'
+}
+
+function stringLiterals(nodes: (estree.Node | null | undefined)[]): FieldRef[] {
+  const refs: FieldRef[] = []
+  for (const node of nodes) {
+    if (node && isStringLiteral(node)) {
+      refs.push({ node, value: node.value })
+    }
+  }
+  return refs
+}

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,6 +651,94 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/eslint-utils@npm:^4.8.0":
+  version: 4.9.1
+  resolution: "@eslint-community/eslint-utils@npm:4.9.1"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10c0/dc4ab5e3e364ef27e33666b11f4b86e1a6c1d7cbf16f0c6ff87b1619b3562335e9201a3d6ce806221887ff780ec9d828962a290bb910759fd40a674686503f02
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.12.1":
+  version: 4.12.2
+  resolution: "@eslint-community/regexpp@npm:4.12.2"
+  checksum: 10c0/fddcbc66851b308478d04e302a4d771d6917a0b3740dc351513c0da9ca2eab8a1adf99f5e0aa7ab8b13fa0df005c81adeee7e63a92f3effd7d367a163b721c2d
+  languageName: node
+  linkType: hard
+
+"@eslint/config-array@npm:^0.21.2":
+  version: 0.21.2
+  resolution: "@eslint/config-array@npm:0.21.2"
+  dependencies:
+    "@eslint/object-schema": "npm:^2.1.7"
+    debug: "npm:^4.3.1"
+    minimatch: "npm:^3.1.5"
+  checksum: 10c0/89dfe815d18456177c0a1f238daf4593107fd20298b3598e0103054360d3b8d09d967defd8318f031185d68df1f95cfa68becf1390a9c5c6887665f1475142e3
+  languageName: node
+  linkType: hard
+
+"@eslint/config-helpers@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "@eslint/config-helpers@npm:0.4.2"
+  dependencies:
+    "@eslint/core": "npm:^0.17.0"
+  checksum: 10c0/92efd7a527b2d17eb1a148409d71d80f9ac160b565ac73ee092252e8bf08ecd08670699f46b306b94f13d22e88ac88a612120e7847570dd7cdc72f234d50dcb4
+  languageName: node
+  linkType: hard
+
+"@eslint/core@npm:^0.17.0":
+  version: 0.17.0
+  resolution: "@eslint/core@npm:0.17.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/9a580f2246633bc752298e7440dd942ec421860d1946d0801f0423830e67887e4aeba10ab9a23d281727a978eb93d053d1922a587d502942a713607f40ed704e
+  languageName: node
+  linkType: hard
+
+"@eslint/eslintrc@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "@eslint/eslintrc@npm:3.3.5"
+  dependencies:
+    ajv: "npm:^6.14.0"
+    debug: "npm:^4.3.2"
+    espree: "npm:^10.0.1"
+    globals: "npm:^14.0.0"
+    ignore: "npm:^5.2.0"
+    import-fresh: "npm:^3.2.1"
+    js-yaml: "npm:^4.1.1"
+    minimatch: "npm:^3.1.5"
+    strip-json-comments: "npm:^3.1.1"
+  checksum: 10c0/9fb9f1ca65e46d6173966e3aaa5bd353e3a65d7f1f582bebf77f578fab7d7960a399fac1ecfb1e7d52bd61f5cefd6531087ca52a3a3c388f2e1b4f1ebd3da8b7
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:9.39.4":
+  version: 9.39.4
+  resolution: "@eslint/js@npm:9.39.4"
+  checksum: 10c0/5aa7dea2cbc5decf7f5e3b0c6f86a084ccee0f792d288ca8e839f8bc1b64e03e227068968e49b26096e6f71fd857ab6e42691d1b993826b9a3883f1bdd7a0e46
+  languageName: node
+  linkType: hard
+
+"@eslint/object-schema@npm:^2.1.7":
+  version: 2.1.7
+  resolution: "@eslint/object-schema@npm:2.1.7"
+  checksum: 10c0/936b6e499853d1335803f556d526c86f5fe2259ed241bc665000e1d6353828edd913feed43120d150adb75570cae162cf000b5b0dfc9596726761c36b82f4e87
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@eslint/plugin-kit@npm:0.4.1"
+  dependencies:
+    "@eslint/core": "npm:^0.17.0"
+    levn: "npm:^0.4.1"
+  checksum: 10c0/51600f78b798f172a9915dffb295e2ffb44840d583427bc732baf12ecb963eb841b253300e657da91d890f4b323d10a1bd12934bf293e3018d8bb66fdce5217b
+  languageName: node
+  linkType: hard
+
 "@gar/promise-retry@npm:^1.0.0":
   version: 1.0.3
   resolution: "@gar/promise-retry@npm:1.0.3"
@@ -665,6 +753,37 @@ __metadata:
     "@types/node": "npm:>=20.0.0"
     happy-dom: "npm:^20.8.9"
   checksum: 10c0/4ffa8ed8e467c6ba6eb2ebf10e45f03602bf473f0fcc2b2a7f1543b597720ba674f87c8a9ce11f7aced814b623e7d80a52fd582ac3f60cc6caf6fee5ba420d19
+  languageName: node
+  linkType: hard
+
+"@humanfs/core@npm:^0.19.1":
+  version: 0.19.1
+  resolution: "@humanfs/core@npm:0.19.1"
+  checksum: 10c0/aa4e0152171c07879b458d0e8a704b8c3a89a8c0541726c6b65b81e84fd8b7564b5d6c633feadc6598307d34564bd53294b533491424e8e313d7ab6c7bc5dc67
+  languageName: node
+  linkType: hard
+
+"@humanfs/node@npm:^0.16.6":
+  version: 0.16.7
+  resolution: "@humanfs/node@npm:0.16.7"
+  dependencies:
+    "@humanfs/core": "npm:^0.19.1"
+    "@humanwhocodes/retry": "npm:^0.4.0"
+  checksum: 10c0/9f83d3cf2cfa37383e01e3cdaead11cd426208e04c44adcdd291aa983aaf72d7d3598844d2fe9ce54896bb1bf8bd4b56883376611c8905a19c44684642823f30
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/module-importer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@humanwhocodes/module-importer@npm:1.0.1"
+  checksum: 10c0/909b69c3b86d482c26b3359db16e46a32e0fb30bd306a3c176b8313b9e7313dba0f37f519de6aa8b0a1921349e505f259d19475e123182416a506d7f87e7f529
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/retry@npm:^0.4.0, @humanwhocodes/retry@npm:^0.4.2":
+  version: 0.4.3
+  resolution: "@humanwhocodes/retry@npm:0.4.3"
+  checksum: 10c0/3775bb30087d4440b3f7406d5a057777d90e4b9f435af488a4923ef249e93615fb78565a85f173a186a076c7706a81d0d57d563a2624e4de2c5c9c66c486ce42
   languageName: node
   linkType: hard
 
@@ -1270,7 +1389,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0":
+"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.7":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -1281,6 +1400,13 @@ __metadata:
   version: 2.5.1
   resolution: "@types/jsesc@npm:2.5.1"
   checksum: 10c0/12ba7bf5968aeeb36408269f4b5a39718efc6411fa197cf0f5e967ba36ad7b7d555b78787fc480db43ce63ebe6ab0ffe5fd9f64b1ea3b0d073877f0747491b30
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.15":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
   languageName: node
   linkType: hard
 
@@ -1368,6 +1494,17 @@ __metadata:
   peerDependenciesMeta:
     preact:
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"@umpire/eslint-plugin@workspace:packages/eslint-plugin":
+  version: 0.0.0-use.local
+  resolution: "@umpire/eslint-plugin@workspace:packages/eslint-plugin"
+  dependencies:
+    "@types/estree": "npm:^1.0.7"
+    eslint: "npm:^9.0.0"
+  peerDependencies:
+    eslint: ">=9.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1664,7 +1801,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.16.0":
+"acorn-jsx@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "acorn-jsx@npm:5.3.2"
+  peerDependencies:
+    acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/4c54868fbef3b8d58927d5e33f0a4de35f59012fe7b12cf9dfbb345fb8f46607709e1c4431be869a23fb63c151033d84c4198fa9f79385cec34fcb1dd53974c1
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.15.0, acorn@npm:^8.16.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -1677,6 +1823,18 @@ __metadata:
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
   checksum: 10c0/c2c9ab7599692d594b6a161559ada307b7a624fa4c7b03e3afdb5a5e31cd0e53269115b620fcab024c5ac6a6f37fa5eb2e004f076ad30f5f7e6b8b671f7b35fe
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.14.0":
+  version: 6.14.0
+  resolution: "ajv@npm:6.14.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.1"
+    fast-json-stable-stringify: "npm:^2.0.0"
+    json-schema-traverse: "npm:^0.4.1"
+    uri-js: "npm:^4.2.2"
+  checksum: 10c0/a2bc39b0555dc9802c899f86990eb8eed6e366cddbf65be43d5aa7e4f3c4e1a199d5460fd7ca4fb3d864000dbbc049253b72faa83b3b30e641ca52cb29a68c22
   languageName: node
   linkType: hard
 
@@ -1809,6 +1967,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "balanced-match@npm:1.0.2"
+  checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -1845,6 +2010,16 @@ __metadata:
   version: 4.0.0
   resolution: "birpc@npm:4.0.0"
   checksum: 10c0/61f4e893ff4c5948b2c587c971c04883af0d8b2658d4632c8e77073db9f9e8b040402f985d56308021890b2ad32ef8392e36a8335cab1e3771d99e1b025d1af6
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^1.1.7":
+  version: 1.1.14
+  resolution: "brace-expansion@npm:1.1.14"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
+  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
   languageName: node
   linkType: hard
 
@@ -1956,6 +2131,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"callsites@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "callsites@npm:3.1.0"
+  checksum: 10c0/fff92277400eb06c3079f9e74f3af120db9f8ea03bad0e84d9aede54bbe2d44a56cccb5f6cf12211f93f52306df87077ecec5b712794c5a9b5dac6d615a3f301
+  languageName: node
+  linkType: hard
+
 "caniuse-lite@npm:^1.0.30001782":
   version: 1.0.30001787
   resolution: "caniuse-lite@npm:1.0.30001787"
@@ -1963,7 +2145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -2019,6 +2201,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"concat-map@npm:0.0.1":
+  version: 0.0.1
+  resolution: "concat-map@npm:0.0.1"
+  checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
+  languageName: node
+  linkType: hard
+
 "confbox@npm:^0.1.8":
   version: 0.1.8
   resolution: "confbox@npm:0.1.8"
@@ -2049,7 +2238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.5":
+"cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -2067,7 +2256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.4.0":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -2102,6 +2291,13 @@ __metadata:
     which-collection: "npm:^1.0.1"
     which-typed-array: "npm:^1.1.13"
   checksum: 10c0/a48244f90fa989f63ff5ef0cc6de1e4916b48ea0220a9c89a378561960814794a5800c600254482a2c8fd2e49d6c2e196131dc983976adb024c94a42dfe4949f
+  languageName: node
+  linkType: hard
+
+"deep-is@npm:^0.1.3":
+  version: 0.1.4
+  resolution: "deep-is@npm:0.1.4"
+  checksum: 10c0/7f0ee496e0dff14a573dc6127f14c95061b448b87b995fc96c017ce0a1e66af1675e73f1d6064407975bc4ea6ab679497a29fff7b5b9c4e99cb10797c1ad0b4c
   languageName: node
   linkType: hard
 
@@ -2361,6 +2557,97 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: 10c0/9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "eslint-scope@npm:8.4.0"
+  dependencies:
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^3.4.3":
+  version: 3.4.3
+  resolution: "eslint-visitor-keys@npm:3.4.3"
+  checksum: 10c0/92708e882c0a5ffd88c23c0b404ac1628cf20104a108c745f240a13c332a11aac54f49a22d5762efbffc18ecbc9a580d1b7ad034bf5f3cc3307e5cbff2ec9820
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "eslint-visitor-keys@npm:4.2.1"
+  checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^9.0.0":
+  version: 9.39.4
+  resolution: "eslint@npm:9.39.4"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.8.0"
+    "@eslint-community/regexpp": "npm:^4.12.1"
+    "@eslint/config-array": "npm:^0.21.2"
+    "@eslint/config-helpers": "npm:^0.4.2"
+    "@eslint/core": "npm:^0.17.0"
+    "@eslint/eslintrc": "npm:^3.3.5"
+    "@eslint/js": "npm:9.39.4"
+    "@eslint/plugin-kit": "npm:^0.4.1"
+    "@humanfs/node": "npm:^0.16.6"
+    "@humanwhocodes/module-importer": "npm:^1.0.1"
+    "@humanwhocodes/retry": "npm:^0.4.2"
+    "@types/estree": "npm:^1.0.6"
+    ajv: "npm:^6.14.0"
+    chalk: "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.6"
+    debug: "npm:^4.3.2"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^8.4.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+    espree: "npm:^10.4.0"
+    esquery: "npm:^1.5.0"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^8.0.0"
+    find-up: "npm:^5.0.0"
+    glob-parent: "npm:^6.0.2"
+    ignore: "npm:^5.2.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    lodash.merge: "npm:^4.6.2"
+    minimatch: "npm:^3.1.5"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.3"
+  peerDependencies:
+    jiti: "*"
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+  bin:
+    eslint: bin/eslint.js
+  checksum: 10c0/1955067c2d991f0c84f4c4abfafe31bb47fa3b717a7fd3e43fe1e511c6f859d7700cbca969f85661dc4c130f7aeced5e5444884314198a54428f5e5141db9337
+  languageName: node
+  linkType: hard
+
+"espree@npm:^10.0.1, espree@npm:^10.4.0":
+  version: 10.4.0
+  resolution: "espree@npm:10.4.0"
+  dependencies:
+    acorn: "npm:^8.15.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10c0/c63fe06131c26c8157b4083313cb02a9a54720a08e21543300e55288c40e06c3fc284bdecf108d3a1372c5934a0a88644c98714f38b6ae8ed272b40d9ea08d6b
+  languageName: node
+  linkType: hard
+
 "esprima@npm:^4.0.0":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
@@ -2368,6 +2655,31 @@ __metadata:
     esparse: ./bin/esparse.js
     esvalidate: ./bin/esvalidate.js
   checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
+  languageName: node
+  linkType: hard
+
+"esquery@npm:^1.5.0":
+  version: 1.7.0
+  resolution: "esquery@npm:1.7.0"
+  dependencies:
+    estraverse: "npm:^5.1.0"
+  checksum: 10c0/77d5173db450b66f3bc685d11af4c90cffeedb340f34a39af96d43509a335ce39c894fd79233df32d38f5e4e219fa0f7076f6ec90bae8320170ba082c0db4793
+  languageName: node
+  linkType: hard
+
+"esrecurse@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "esrecurse@npm:4.3.0"
+  dependencies:
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/81a37116d1408ded88ada45b9fb16dbd26fba3aadc369ce50fcaf82a0bac12772ebd7b24cd7b91fc66786bf2c1ac7b5f196bc990a473efff972f5cb338877cf5
+  languageName: node
+  linkType: hard
+
+"estraverse@npm:^5.1.0, estraverse@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "estraverse@npm:5.3.0"
+  checksum: 10c0/1ff9447b96263dec95d6d67431c5e0771eb9776427421260a3e2f0fdd5d6bd4f8e37a7338f5ad2880c9f143450c9b1e4fc2069060724570a49cf9cf0312bd107
   languageName: node
   linkType: hard
 
@@ -2387,6 +2699,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esutils@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "esutils@npm:2.0.3"
+  checksum: 10c0/9a2fe69a41bfdade834ba7c42de4723c97ec776e40656919c62cbd13607c45e127a003f05f724a1ea55e5029a4cf2de444b13009f2af71271e42d93a637137c7
+  languageName: node
+  linkType: hard
+
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
@@ -2401,6 +2720,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-deep-equal@npm:3.1.3"
+  checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:^3.2.9":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
@@ -2411,6 +2737,20 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.8"
   checksum: 10c0/f6aaa141d0d3384cf73cbcdfc52f475ed293f6d5b65bfc5def368b09163a9f7e5ec2b3014d80f733c405f58e470ee0cc451c2937685045cddcdeaa24199c43fe
+  languageName: node
+  linkType: hard
+
+"fast-json-stable-stringify@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "fast-json-stable-stringify@npm:2.1.0"
+  checksum: 10c0/7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
+  languageName: node
+  linkType: hard
+
+"fast-levenshtein@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "fast-levenshtein@npm:2.0.6"
+  checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
   languageName: node
   linkType: hard
 
@@ -2435,6 +2775,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-entry-cache@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "file-entry-cache@npm:8.0.0"
+  dependencies:
+    flat-cache: "npm:^4.0.0"
+  checksum: 10c0/9e2b5938b1cd9b6d7e3612bdc533afd4ac17b2fc646569e9a8abbf2eb48e5eb8e316bc38815a3ef6a1b456f4107f0d0f055a614ca613e75db6bf9ff4d72c1638
+  languageName: node
+  linkType: hard
+
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
@@ -2454,6 +2803,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "find-up@npm:5.0.0"
+  dependencies:
+    locate-path: "npm:^6.0.0"
+    path-exists: "npm:^4.0.0"
+  checksum: 10c0/062c5a83a9c02f53cdd6d175a37ecf8f87ea5bbff1fdfb828f04bfa021441bc7583e8ebc0872a4c1baab96221fb8a8a275a19809fb93fbc40bd69ec35634069a
+  languageName: node
+  linkType: hard
+
 "fix-dts-default-cjs-exports@npm:^1.0.0":
   version: 1.0.1
   resolution: "fix-dts-default-cjs-exports@npm:1.0.1"
@@ -2462,6 +2821,23 @@ __metadata:
     mlly: "npm:^1.7.4"
     rollup: "npm:^4.34.8"
   checksum: 10c0/61a3cbe32b6c29df495ef3aded78199fe9dbb52e2801c899fe76d9ca413d3c8c51f79986bac83f8b4b2094ebde883ddcfe47b68ce469806ba13ca6ed4e7cd362
+  languageName: node
+  linkType: hard
+
+"flat-cache@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "flat-cache@npm:4.0.1"
+  dependencies:
+    flatted: "npm:^3.2.9"
+    keyv: "npm:^4.5.4"
+  checksum: 10c0/2c59d93e9faa2523e4fda6b4ada749bed432cfa28c8e251f33b25795e426a1c6dbada777afb1f74fcfff33934fdbdea921ee738fcc33e71adc9d6eca984a1cfc
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.2.9":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 
@@ -2601,6 +2977,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-parent@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "glob-parent@npm:6.0.2"
+  dependencies:
+    is-glob: "npm:^4.0.3"
+  checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
+  languageName: node
+  linkType: hard
+
 "glob@npm:^13.0.0":
   version: 13.0.6
   resolution: "glob@npm:13.0.6"
@@ -2609,6 +2994,13 @@ __metadata:
     minipass: "npm:^7.1.3"
     path-scurry: "npm:^2.0.2"
   checksum: 10c0/269c236f11a9b50357fe7a8c6aadac667e01deb5242b19c84975628f05f4438d8ee1354bb62c5d6c10f37fd59911b54d7799730633a2786660d8c69f1d18120a
+  languageName: node
+  linkType: hard
+
+"globals@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "globals@npm:14.0.0"
+  checksum: 10c0/b96ff42620c9231ad468d4c58ff42afee7777ee1c963013ff8aabe095a451d0ceeb8dcd8ef4cbd64d2538cef45f787a78ba3a9574f4a634438963e334471302d
   languageName: node
   linkType: hard
 
@@ -2775,10 +3167,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-fresh@npm:^3.2.1":
+  version: 3.3.1
+  resolution: "import-fresh@npm:3.3.1"
+  dependencies:
+    parent-module: "npm:^1.0.0"
+    resolve-from: "npm:^4.0.0"
+  checksum: 10c0/bf8cc494872fef783249709385ae883b447e3eb09db0ebd15dcead7d9afe7224dad7bd7591c6b73b0b19b3c0f9640eb8ee884f01cfaf2887ab995b0b36a0cbec
+  languageName: node
+  linkType: hard
+
 "import-without-cache@npm:^0.2.5":
   version: 0.2.5
   resolution: "import-without-cache@npm:0.2.5"
   checksum: 10c0/5cf7a00e317a23569f16c87391170270277c073cba498c913bf043af56c56118d023c8d041046535566135c34503c90a9320483448b070a4ab4ae29949547a71
+  languageName: node
+  linkType: hard
+
+"imurmurhash@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "imurmurhash@npm:0.1.4"
+  checksum: 10c0/8b51313850dd33605c6c9d3fd9638b714f4c4c40250cff658209f30d40da60f78992fb2df5dabee4acf589a6a82bbc79ad5486550754bd9ec4e3fc0d4a57d6a6
   languageName: node
   linkType: hard
 
@@ -2864,7 +3273,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.1":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -3094,6 +3503,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-buffer@npm:3.0.1":
+  version: 3.0.1
+  resolution: "json-buffer@npm:3.0.1"
+  checksum: 10c0/0d1c91569d9588e7eef2b49b59851f297f3ab93c7b35c7c221e288099322be6b562767d11e4821da500f3219542b9afd2e54c5dc573107c1126ed1080f8e96d7
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "json-schema-traverse@npm:0.4.1"
+  checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
+  languageName: node
+  linkType: hard
+
+"json-stable-stringify-without-jsonify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
+  checksum: 10c0/cb168b61fd4de83e58d09aaa6425ef71001bae30d260e2c57e7d09a5fd82223e2f22a042dedaab8db23b7d9ae46854b08bb1f91675a8be11c5cffebef5fb66a5
+  languageName: node
+  linkType: hard
+
 "json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
@@ -3112,6 +3542,25 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 10c0/7dc94b628d57a66b71fb1b79510d460d662eb975b5f876d723f81549c2e9cd316d58a2ddf742b2b93a4fa6b17b2accaf1a738a0e2ea114bdfb13a32e5377e480
+  languageName: node
+  linkType: hard
+
+"keyv@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "keyv@npm:4.5.4"
+  dependencies:
+    json-buffer: "npm:3.0.1"
+  checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
+"levn@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "levn@npm:0.4.1"
+  dependencies:
+    prelude-ls: "npm:^1.2.1"
+    type-check: "npm:~0.4.0"
+  checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
   languageName: node
   linkType: hard
 
@@ -3142,6 +3591,22 @@ __metadata:
   dependencies:
     p-locate: "npm:^4.1.0"
   checksum: 10c0/33a1c5247e87e022f9713e6213a744557a3e9ec32c5d0b5efb10aa3a38177615bf90221a5592674857039c1a0fd2063b82f285702d37b792d973e9e72ace6c59
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "locate-path@npm:6.0.0"
+  dependencies:
+    p-locate: "npm:^5.0.0"
+  checksum: 10c0/d3972ab70dfe58ce620e64265f90162d247e87159b6126b01314dd67be43d50e96a50b517bce2d9452a79409c7614054c277b5232377de50416564a77ac7aad3
+  languageName: node
+  linkType: hard
+
+"lodash.merge@npm:^4.6.2":
+  version: 4.6.2
+  resolution: "lodash.merge@npm:4.6.2"
+  checksum: 10c0/402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
   languageName: node
   linkType: hard
 
@@ -3245,6 +3710,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^5.0.5"
   checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
+  dependencies:
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
@@ -3377,6 +3851,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"natural-compare@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "natural-compare@npm:1.4.0"
+  checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
+  languageName: node
+  linkType: hard
+
 "negotiator@npm:^1.0.0":
   version: 1.0.0
   resolution: "negotiator@npm:1.0.0"
@@ -3474,6 +3955,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"optionator@npm:^0.9.3":
+  version: 0.9.4
+  resolution: "optionator@npm:0.9.4"
+  dependencies:
+    deep-is: "npm:^0.1.3"
+    fast-levenshtein: "npm:^2.0.6"
+    levn: "npm:^0.4.1"
+    prelude-ls: "npm:^1.2.1"
+    type-check: "npm:^0.4.0"
+    word-wrap: "npm:^1.2.5"
+  checksum: 10c0/4afb687a059ee65b61df74dfe87d8d6815cd6883cb8b3d5883a910df72d0f5d029821f37025e4bccf4048873dbdb09acc6d303d27b8f76b1a80dd5a7d5334675
+  languageName: node
+  linkType: hard
+
 "outdent@npm:^0.5.0":
   version: 0.5.0
   resolution: "outdent@npm:0.5.0"
@@ -3499,12 +3994,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "p-limit@npm:3.1.0"
+  dependencies:
+    yocto-queue: "npm:^0.1.0"
+  checksum: 10c0/9db675949dbdc9c3763c89e748d0ef8bdad0afbb24d49ceaf4c46c02c77d30db4e0652ed36d0a0a7a95154335fab810d95c86153105bb73b3a90448e2bb14e1a
+  languageName: node
+  linkType: hard
+
 "p-locate@npm:^4.1.0":
   version: 4.1.0
   resolution: "p-locate@npm:4.1.0"
   dependencies:
     p-limit: "npm:^2.2.0"
   checksum: 10c0/1b476ad69ad7f6059744f343b26d51ce091508935c1dbb80c4e0a2f397ffce0ca3a1f9f5cd3c7ce19d7929a09719d5c65fe70d8ee289c3f267cd36f2881813e9
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "p-locate@npm:5.0.0"
+  dependencies:
+    p-limit: "npm:^3.0.2"
+  checksum: 10c0/2290d627ab7903b8b70d11d384fee714b797f6040d9278932754a6860845c4d3190603a0772a663c8cb5a7b21d1b16acb3a6487ebcafa9773094edc3dfe6009a
   languageName: node
   linkType: hard
 
@@ -3535,6 +4048,15 @@ __metadata:
   dependencies:
     quansync: "npm:^0.2.7"
   checksum: 10c0/247991de461b9e731f3463b7dae9ce187e53095b7b94d7d96eec039abf418b61ccf74464bec1d0c11d97311f33472e77baccd4c5898f77358da4b5b33395e0b1
+  languageName: node
+  linkType: hard
+
+"parent-module@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "parent-module@npm:1.0.1"
+  dependencies:
+    callsites: "npm:^3.0.0"
+  checksum: 10c0/c63d6e80000d4babd11978e0d3fee386ca7752a02b035fd2435960ffaa7219dc42146f07069fb65e6e8bf1caef89daf9af7535a39bddf354d78bf50d8294f556
   languageName: node
   linkType: hard
 
@@ -3692,6 +4214,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prelude-ls@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "prelude-ls@npm:1.2.1"
+  checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^2.7.1":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
@@ -3716,6 +4245,13 @@ __metadata:
   version: 6.1.0
   resolution: "proc-log@npm:6.1.0"
   checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
   languageName: node
   linkType: hard
 
@@ -3802,6 +4338,13 @@ __metadata:
     gopd: "npm:^1.2.0"
     set-function-name: "npm:^2.0.2"
   checksum: 10c0/83b88e6115b4af1c537f8dabf5c3744032cb875d63bc05c288b1b8c0ef37cbe55353f95d8ca817e8843806e3e150b118bc624e4279b24b4776b4198232735a77
+  languageName: node
+  linkType: hard
+
+"resolve-from@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "resolve-from@npm:4.0.0"
+  checksum: 10c0/8408eec31a3112ef96e3746c37be7d64020cda07c03a920f5024e77290a218ea758b26ca9529fd7b1ad283947f34b2291c1c0f6aa0ed34acfdda9c6014c8d190
   languageName: node
   linkType: hard
 
@@ -4271,6 +4814,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-json-comments@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "strip-json-comments@npm:3.1.1"
+  checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
+  languageName: node
+  linkType: hard
+
 "sucrase@npm:^3.35.0":
   version: 3.35.1
   resolution: "sucrase@npm:3.35.1"
@@ -4531,6 +5081,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-check@npm:^0.4.0, type-check@npm:~0.4.0":
+  version: 0.4.0
+  resolution: "type-check@npm:0.4.0"
+  dependencies:
+    prelude-ls: "npm:^1.2.1"
+  checksum: 10c0/7b3fd0ed43891e2080bf0c5c504b418fbb3e5c7b9708d3d015037ba2e6323a28152ec163bcb65212741fa5d2022e3075ac3c76440dbd344c9035f818e8ecee58
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.8.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
@@ -4634,6 +5193,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uri-js@npm:^4.2.2":
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
+  dependencies:
+    punycode: "npm:^2.1.0"
+  checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
 "vue@npm:^3.5.32":
   version: 3.5.32
   resolution: "vue@npm:3.5.32"
@@ -4732,6 +5300,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"word-wrap@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "word-wrap@npm:1.2.5"
+  checksum: 10c0/e0e4a1ca27599c92a6ca4c32260e8a92e8a44f4ef6ef93f803f8ed823f486e0889fc0b93be4db59c8d51b3064951d25e43d434e95dc8c960cc3a63d65d00ba20
+  languageName: node
+  linkType: hard
+
 "ws@npm:^8.18.3":
   version: 8.20.0
   resolution: "ws@npm:8.20.0"
@@ -4765,6 +5340,13 @@ __metadata:
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
   checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "yocto-queue@npm:0.1.0"
+  checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds `packages/eslint-plugin` as a new published workspace package (`@umpire/eslint-plugin`) with five lint rules that catch umpire misuse TypeScript and runtime cannot.

**The core insight:** ESLint analyzes *declarations* (the config object structure) before any values flow through. Runtime only knows about *executions*, so it silently produces always-disabled fields, invisible perf regressions, and zero errors for several classes of bugs.

## Rules

### `no-unknown-fields` — `warn`
Cross-references every field-name string literal in rule factories (`requires`, `disables`, `oneOf`, `anyOf`, `eitherOf`, `enabledWhen`, `fairWhen`) against the declared `fields` keys in the same `umpire()` call. A typo like `requires('usernme', 'email')` produces a field that is silently never enabled — no runtime error, no TypeScript error.

Handles the `check('field', pred)` helper in `disables` source position and recurses into `anyOf`/`eitherOf`. Bails out when `fields` contains spread elements to avoid false positives.

### `no-inline-umpire-init` — `warn`
Reports `umpire()` calls inside React component or hook bodies (name starts with uppercase or `use`) that are not wrapped in `useMemo`. Building the full dependency graph on every render is an invisible performance regression — no runtime error is thrown, it just silently rebuilds on every render.

Wrapping with `useMemo(() => umpire(...), [])` suppresses the warning.

### `no-self-disable` — `error`
Reports when the source string in `disables('field', [...])` also appears in its own targets array. A field cannot disable itself.

### `no-contradicting-rules` — `error`
Detects `requires`/`disables` pairs that make a field permanently unavailable. Two patterns:

- **Case A:** `requires(X, Y)` + `disables(Y, [X])` — Y satisfies and disables X, but X needs Y → X can never be enabled
- **Case B:** `requires(X, Y)` + `disables(X, [Y])` — X satisfies and disables Y, but X needs Y → X's own requirement can never hold

Both produce fields that are always disabled at runtime with no warning or error.

### `no-circular-requires` — `error`
Detects cycles in the `requires` dependency graph using DFS with gray/black coloring. Handles any cycle length, self-cycles (`requires('a', 'a')`), and multiple independent cycles in one config. Reports on the `requires()` call that closes the cycle with the full path in the message (e.g. `'a' → 'b' → 'a'`).

## Usage

```js
// eslint.config.js
import umpire from '@umpire/eslint-plugin'

export default [umpire.configs.recommended]
```

Or selectively:

```js
import umpire from '@umpire/eslint-plugin'

export default [
  {
    plugins: { '@umpire': umpire },
    rules: {
      '@umpire/no-unknown-fields': 'warn',
      '@umpire/no-contradicting-rules': 'error',
      '@umpire/no-circular-requires': 'error',
    },
  },
]
```

## Notes

- Matches calls by function name (`umpire`, `requires`, `disables`, etc.) — no import tracking. This keeps the rules fast and zero-config.
- `no-contradicting-rules` and `no-circular-requires` only inspect top-level rules in the `rules` array; rules nested inside `anyOf`/`eitherOf` have OR/branch semantics and are intentionally skipped to avoid false positives.
- Rules with predicate sources in `disables` are skipped by the graph-analysis rules since their runtime behavior can't be determined statically.

## Test plan

- [x] 55 tests pass across all 5 rule files (`bun test` in `packages/eslint-plugin`)
- [x] `tsc --noEmit` clean under strict mode
- [x] Valid cases cover: spread fields bailout, predicate sources, non-umpire calls, `anyOf`/`eitherOf` nesting, `useMemo` wrapping, linear/diamond dep chains
- [x] Invalid cases cover: typos in all rule factory positions, both contradiction patterns (A and B), 2-node/3-node/self cycles, multiple independent errors per config

https://claude.ai/code/session_016ZuZgFVvc37SSn1bKDPW8b