### PR TITLE
🔨 Destructive Breaking Zod API Rename!

### DIFF
--- a/.changeset/zod-derive-adapter.md
+++ b/.changeset/zod-derive-adapter.md
@@ -1,0 +1,9 @@
+---
+"@umpire/zod": minor
+---
+
+- Rename `activeSchema()` to `deriveSchema()` for clearer naming consistency with the rest of the `@umpire/zod` surface.
+- Rename `activeErrors()` to `deriveErrors()`.
+- Rename `createZodValidation()` to `createZodAdapter()`, matching the existing adapter-oriented type naming.
+- Rename the exported adapter types to `CreateZodAdapterOptions`, `ZodAdapter`, and `ZodAdapterRunResult`.
+- Update the `@umpire/zod` docs, examples, and devtools copy to use the new derived-schema terminology consistently.

--- a/docs/src/components/SignupDemo.tsx
+++ b/docs/src/components/SignupDemo.tsx
@@ -5,7 +5,7 @@ import type { FieldValues } from '@umpire/core'
 // useUmpireWithDevtools powers the named instance in the optional panel on this page.
 // Swap back to: import { useUmpire } from '@umpire/react'  (remove leading id arg)
 import { useUmpireWithDevtools } from '@umpire/devtools/react'
-import { createZodValidation } from '@umpire/zod'
+import { createZodAdapter } from '@umpire/zod'
 import { zodValidationExtension } from '@umpire/zod/devtools'
 
 // ── Known SSO domains ─────────────────────────────────────────────────────────
@@ -53,7 +53,7 @@ const fieldSchemas = z.object({
   companySize: z.string().regex(/^\d+$/, 'Must be a number'),
 })
 
-const signupValidation = createZodValidation({
+const signupValidation = createZodAdapter({
   schemas: fieldSchemas.shape,
   build(baseSchema) {
     // Keep the schema-level refinement too: Umpire owns availability and

--- a/docs/src/content/docs/concepts/validation.md
+++ b/docs/src/content/docs/concepts/validation.md
@@ -98,7 +98,7 @@ Two rules apply at the boundary between Umpire and your validation library:
 
 **`required` follows Umpire's output, not your static schema.** A field can be declared `required: true` in the engine config but report `required: false` when disabled. Your validation layer should respect this — `status.required` is the authoritative signal.
 
-`@umpire/zod`'s `activeSchema` and `activeErrors` encode both rules directly. If you need the manual version — for a library without a first-class integration, or to understand what's happening under the hood:
+`@umpire/zod`'s `deriveSchema` and `deriveErrors` encode both rules directly. If you need the manual version — for a library without a first-class integration, or to understand what's happening under the hood:
 
 ```ts
 const availability = ump.check(values, conditions)
@@ -114,18 +114,18 @@ const schema = z.object(shape)
 const result = schema.safeParse(values)
 
 // Filter errors to enabled fields only
-const activeErrors: Record<string, string> = {}
+const derivedErrors: Record<string, string> = {}
 if (!result.success) {
   for (const issue of result.error.issues) {
     const field = issue.path[0] as string
     if (availability[field]?.enabled) {
-      activeErrors[field] = issue.message
+      derivedErrors[field] = issue.message
     }
   }
 }
 ```
 
-This is exactly what `activeSchema` and `activeErrors` do. See [Validator Integrations](/umpire/integrations/validators/) for the general pattern and how it extends to other libraries.
+This is exactly what `deriveSchema` and `deriveErrors` do. See [Validator Integrations](/umpire/integrations/validators/) for the general pattern and how it extends to other libraries.
 
 ## What stays in userspace
 
@@ -141,7 +141,7 @@ These are all form-framework concerns. Umpire's job ends at "is this field avail
 ## See also
 
 - [Validator Integrations](/umpire/integrations/validators/) — the integration contract and how it applies to any library
-- [`@umpire/zod`](/umpire/integrations/zod/) — first-class Zod integration with `activeSchema` and `activeErrors`
+- [`@umpire/zod`](/umpire/integrations/zod/) — first-class Zod integration with `deriveSchema` and `deriveErrors`
 - [Satisfaction semantics](/umpire/concepts/satisfaction/) — how Umpire defines "present"
 - [`check()` in the rules API](/umpire/api/rules/check/) — full signature and validator shapes
 - [`@umpire/json`](/umpire/adapters/json/) — portable schemas, named checks, and `excluded`

--- a/docs/src/content/docs/examples/signup.mdx
+++ b/docs/src/content/docs/examples/signup.mdx
@@ -142,14 +142,14 @@ These are value-shape checks — is the email well-formed, is the password long 
 ## Composing Them
 
 ```ts
-import { activeSchema, activeErrors, zodErrors } from '@umpire/zod'
+import { deriveErrors, deriveSchema, zodErrors } from '@umpire/zod'
 
 const availability = signupUmp.check(values, { plan, sso })
 
 // Build a Zod schema that only validates enabled fields.
 // Enabled + required → base schema. Enabled + optional → .optional().
 // Disabled → excluded entirely.
-const schema = activeSchema(availability, fieldSchemas.shape)
+const schema = deriveSchema(availability, fieldSchemas.shape)
   .refine(
     (data) => !data.confirmPassword || !data.password
       || data.confirmPassword === data.password,
@@ -160,7 +160,7 @@ const result = schema.safeParse(values)
 
 if (!result.success) {
   // Filter to enabled fields only — disabled fields produce no errors
-  const errors = activeErrors(availability, zodErrors(result.error))
+  const errors = deriveErrors(availability, zodErrors(result.error))
   // errors.email → 'Enter a valid email'
   // errors.companyName → undefined (disabled on personal plan)
 }
@@ -168,11 +168,11 @@ if (!result.success) {
 
 Three functions from `@umpire/zod`:
 
-- **`activeSchema`** builds a Zod object from availability. Disabled fields are excluded. Required/optional follows Umpire's output. Pass `fieldSchemas.shape` (not the `z.object()` directly).
+- **`deriveSchema`** builds a Zod object from availability. Disabled fields are excluded. Required/optional follows Umpire's output. Pass `fieldSchemas.shape` (not the `z.object()` directly).
 - **`zodErrors`** normalizes Zod's issue array into `{ field, message }` pairs.
-- **`activeErrors`** filters those pairs to only include enabled fields.
+- **`deriveErrors`** filters those pairs to only include enabled fields.
 
-Cross-field refinements (like password matching) chain normally on the result of `activeSchema`. The refinement references `confirmPassword` — if that field is disabled (SSO active, or no password yet), `activeSchema` excludes it and the refinement sees `undefined`, which the guard handles.
+Cross-field refinements (like password matching) chain normally on the result of `deriveSchema`. The refinement references `confirmPassword` — if that field is disabled (SSO active, or no password yet), `deriveSchema` excludes it and the refinement sees `undefined`, which the guard handles.
 
 ## The Render Loop
 

--- a/docs/src/content/docs/integrations/validators.md
+++ b/docs/src/content/docs/integrations/validators.md
@@ -15,7 +15,7 @@ A validator integration does three things:
 
 ## Client vs server usage
 
-On the **client**, you call `engine.check(values)` during the render cycle and pass the resulting availability map to your validator. The active schema changes as the user changes fields.
+On the **client**, you call `engine.check(values)` during the render cycle and pass the resulting availability map to your validator. The derived schema changes as the user changes fields.
 
 On the **server**, the same pattern acts as a guard. The incoming request body drives `engine.check()`, which returns the same availability map the client would have produced for that data. Any inconsistency — a required field missing, a foul value present — fails validation.
 
@@ -27,11 +27,11 @@ export const schemas = { /* per-field schemas */ }
 // Server handler
 const body = await req.json()
 const availability = engine.check(body)
-const schema = activeSchema(availability, schemas, { rejectFoul: true })
+const schema = deriveSchema(availability, schemas, { rejectFoul: true })
 const result = schema.safeParse(body)
 ```
 
-`engine.check()` is deterministic: the same values produce the same availability map. If the client and server share the engine definition, they will always agree on which fields are active and required.
+`engine.check()` is deterministic: the same values produce the same availability map. If the client and server share the engine definition, they will always agree on which fields are enabled and required.
 
 ## Foul values and server guards
 
@@ -41,10 +41,10 @@ The `rejectFoul` option handles this:
 
 ```ts
 // Without rejectFoul (default) — foul values pass base schema, behave like fair fields
-activeSchema(availability, schemas)
+deriveSchema(availability, schemas)
 
 // With rejectFoul — foul fields get an always-failing refinement
-activeSchema(availability, schemas, { rejectFoul: true })
+deriveSchema(availability, schemas, { rejectFoul: true })
 ```
 
 When `rejectFoul: true`:

--- a/docs/src/content/docs/integrations/zod.md
+++ b/docs/src/content/docs/integrations/zod.md
@@ -15,7 +15,7 @@ yarn add @umpire/core @umpire/zod zod
 
 ## API
 
-### `activeSchema(availability, shape, options?)`
+### `deriveSchema(availability, shape, options?)`
 
 Builds a `z.object()` from the availability map:
 
@@ -26,7 +26,7 @@ Builds a `z.object()` from the availability map:
 
 ```ts
 import { z } from 'zod'
-import { activeSchema } from '@umpire/zod'
+import { deriveSchema } from '@umpire/zod'
 
 const fieldSchemas = {
   email:       z.string().email('Enter a valid email'),
@@ -35,7 +35,7 @@ const fieldSchemas = {
 }
 
 const availability = ump.check(values, conditions)
-const schema = activeSchema(availability, fieldSchemas)
+const schema = deriveSchema(availability, fieldSchemas)
 const result = schema.safeParse(values)
 ```
 
@@ -47,14 +47,14 @@ const myFormSchema = z.object({
   companyName: z.string().min(1),
 })
 
-// ✗ Wrong — activeSchema expects a shape, not a z.object()
-activeSchema(availability, myFormSchema)
+// ✗ Wrong — deriveSchema expects a shape, not a z.object()
+deriveSchema(availability, myFormSchema)
 
 // ✓ Correct
-activeSchema(availability, myFormSchema.shape)
+deriveSchema(availability, myFormSchema.shape)
 ```
 
-`activeSchema` throws a descriptive error if it detects a Zod object was passed instead of its shape.
+`deriveSchema` throws a descriptive error if it detects a Zod object was passed instead of its shape.
 
 #### `rejectFoul` option
 
@@ -63,7 +63,7 @@ Fields where `fair: false` hold values that were once valid but are now contextu
 ```ts
 // Server handler — rejects any submission containing a foul value
 const availability = engine.check(body)
-const schema = activeSchema(availability, fieldSchemas, { rejectFoul: true })
+const schema = deriveSchema(availability, fieldSchemas, { rejectFoul: true })
 const result = schema.safeParse(body)
 ```
 
@@ -81,12 +81,12 @@ if (!result.success) {
 }
 ```
 
-### `activeErrors(availability, errors)`
+### `deriveErrors(availability, errors)`
 
 Filters normalized error pairs to only include enabled fields. Returns `Partial<Record<string, string>>`.
 
 ```ts
-const errors = activeErrors(availability, zodErrors(result.error))
+const errors = deriveErrors(availability, zodErrors(result.error))
 // { email: 'Enter a valid email' }
 // companyName omitted if disabled on the current plan
 ```
@@ -108,7 +108,7 @@ const ump = umpire({
     email: { required: true, isEmpty: isEmptyString },
   },
   rules: [],
-  validators: createZodValidation({
+  validators: createZodAdapter({
     schemas: { email: z.string().email('Enter a valid email') },
   }).validators,
 })
@@ -119,10 +119,10 @@ actually satisfied under your chosen emptiness rule.
 
 ## Chaining refinements
 
-Cross-field refinements chain normally on the result of `activeSchema`:
+Cross-field refinements chain normally on the result of `deriveSchema`:
 
 ```ts
-const schema = activeSchema(availability, fieldSchemas)
+const schema = deriveSchema(availability, fieldSchemas)
   .refine(
     (data) => !data.confirmPassword || !data.password
       || data.confirmPassword === data.password,
@@ -130,7 +130,7 @@ const schema = activeSchema(availability, fieldSchemas)
   )
 ```
 
-If `confirmPassword` is disabled, `activeSchema` excludes it and the refinement sees `undefined`. Guard against that — `!data.confirmPassword` in the predicate covers it.
+If `confirmPassword` is disabled, `deriveSchema` excludes it and the refinement sees `undefined`. Guard against that — `!data.confirmPassword` in the predicate covers it.
 
 ## When to use the manual pattern instead
 
@@ -140,4 +140,4 @@ If `confirmPassword` is disabled, `activeSchema` excludes it and the refinement 
 
 - [Validator Integrations](/umpire/integrations/validators/) — the general contract and how it extends to other libraries
 - [Composing with Validation](/umpire/concepts/validation/) — conceptual boundary and manual patterns
-- [Signup Form + Zod](/umpire/examples/signup/) — full walkthrough with `activeSchema`, the render loop, and foul handling
+- [Signup Form + Zod](/umpire/examples/signup/) — full walkthrough with `deriveSchema`, the render loop, and foul handling

--- a/docs/src/content/docs/integrations/zod.md
+++ b/docs/src/content/docs/integrations/zod.md
@@ -71,7 +71,7 @@ When `rejectFoul: true`, a foul field with a present value fails with the field'
 
 ### `zodErrors(error)`
 
-Normalizes a `ZodError` into `{ field, message }[]` pairs. Only the first error per field is kept.
+Normalizes a `ZodError` into `{ field, message }[]` pairs.
 
 ```ts
 const result = schema.safeParse(values)

--- a/docs/src/content/docs/integrations/zod.md
+++ b/docs/src/content/docs/integrations/zod.md
@@ -83,7 +83,7 @@ if (!result.success) {
 
 ### `deriveErrors(availability, errors)`
 
-Filters normalized error pairs to only include enabled fields. Returns `Partial<Record<string, string>>`.
+Filters normalized error pairs to only include enabled fields and keeps the first message per field. Returns `Partial<Record<string, string>>`.
 
 ```ts
 const errors = deriveErrors(availability, zodErrors(result.error))

--- a/packages/zod/AGENTS.md
+++ b/packages/zod/AGENTS.md
@@ -1,6 +1,6 @@
 # @umpire/zod
 
-- Use `activeSchema(availability, fieldSchemas)` with a field-schema shape, not a `z.object()` instance.
-- Disabled fields are excluded from the active schema. Enabled but optional fields get `.optional()`.
-- Normalize parse issues with `zodErrors(error)`, then filter them with `activeErrors(availability, errors)`.
+- Use `deriveSchema(availability, fieldSchemas)` with a field-schema shape, not a `z.object()` instance.
+- Disabled fields are excluded from the derived schema. Enabled but optional fields get `.optional()`.
+- Normalize parse issues with `zodErrors(error)`, then filter them with `deriveErrors(availability, errors)`.
 - This package is availability-aware validation glue; keep availability logic in `@umpire/core`, not inside Zod refinements.

--- a/packages/zod/CHANGELOG.md
+++ b/packages/zod/CHANGELOG.md
@@ -21,6 +21,6 @@ _Version skipped (internal)_
 ### Minor Changes
 
 - Initial release: availability-aware Zod validation helpers
-- `activeSchema()` — builds a Zod schema from only the currently-enabled fields
+- Schema derivation from only the currently-enabled fields
 - Detects `z.object()` passed instead of `.shape` with a helpful error
 - `reactive foul()` integration for live validation feedback

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -83,7 +83,7 @@ Throws if you accidentally pass a `z.object()` instead of its `.shape` — the e
 
 ### `deriveErrors(availability, errors)`
 
-Filters normalized field errors to only include enabled fields. Returns `Partial<Record<field, message>>`.
+Filters normalized field errors to only include enabled fields and keeps the first message per field. Returns `Partial<Record<field, message>>`.
 
 ### `zodErrors(error)`
 

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -17,7 +17,7 @@ npm install @umpire/core @umpire/zod zod
 ```ts
 import { z } from 'zod'
 import { umpire, enabledWhen, requires } from '@umpire/core'
-import { activeSchema, activeErrors, createZodValidation, zodErrors } from '@umpire/zod'
+import { createZodAdapter, deriveErrors, deriveSchema, zodErrors } from '@umpire/zod'
 
 // 1. Define availability rules
 const ump = umpire({
@@ -41,16 +41,16 @@ const fieldSchemas = {
 // 3. Compose at render time
 const availability = ump.check(values, { plan })
 
-const schema = activeSchema(availability, fieldSchemas)
+const schema = deriveSchema(availability, fieldSchemas)
 const result = schema.safeParse(values)
 
 if (!result.success) {
-  const errors = activeErrors(availability, zodErrors(result.error))
+  const errors = deriveErrors(availability, zodErrors(result.error))
   // errors.email → 'Enter a valid email' (only if email is enabled)
   // errors.companyName → undefined (disabled on personal plan)
 }
 
-const validation = createZodValidation({
+const validation = createZodAdapter({
   schemas: fieldSchemas,
 })
 
@@ -70,7 +70,7 @@ const umpWithValidation = umpire({
 
 ## API
 
-### `activeSchema(availability, schemas)`
+### `deriveSchema(availability, schemas)`
 
 Builds a `z.object()` from the availability map:
 - **Disabled fields** are excluded entirely
@@ -81,21 +81,21 @@ Pass per-field schemas directly, or use `formSchema.shape` to extract from an ex
 
 Throws if you accidentally pass a `z.object()` instead of its `.shape` — the error message tells you what to do.
 
-### `activeErrors(availability, errors)`
+### `deriveErrors(availability, errors)`
 
 Filters normalized field errors to only include enabled fields. Returns `Partial<Record<field, message>>`.
 
 ### `zodErrors(error)`
 
-Normalizes a Zod error's `issues` array into `{ field, message }[]` pairs for use with `activeErrors`.
+Normalizes a Zod error's `issues` array into `{ field, message }[]` pairs for use with `deriveErrors`.
 
-### `createZodValidation({ schemas, build? })`
+### `createZodAdapter({ schemas, build? })`
 
 Creates a convenience adapter with:
 - `validators` for `umpire({ validators })`, surfacing the first field-level Zod issue as `error`
-- `run(availability, values)` for the full `activeSchema() -> safeParse() -> activeErrors()` flow
+- `run(availability, values)` for the full `deriveSchema() -> safeParse() -> deriveErrors()` flow
 
-If you need every issue or deeper control, you can still use `activeSchema()` and `safeParse()` directly.
+If you need every issue or deeper control, you can still use `deriveSchema()` and `safeParse()` directly.
 
 ### Blank strings and `isEmpty`
 
@@ -109,7 +109,7 @@ For form-style inputs, define an explicit empty-state rule:
 ```ts
 import { isEmptyString, umpire } from '@umpire/core'
 
-const validation = createZodValidation({
+const validation = createZodAdapter({
   schemas: {
     email: z.string().email('Enter a valid email'),
   },
@@ -135,7 +135,7 @@ If you use `@umpire/devtools`, `@umpire/zod/devtools` can expose validation stat
 import { useUmpireWithDevtools } from '@umpire/devtools/react'
 import { zodValidationExtension } from '@umpire/zod/devtools'
 
-const validation = createZodValidation({
+const validation = createZodAdapter({
   schemas: fieldSchemas,
   build(baseSchema) {
     return baseSchema.refine(
@@ -162,8 +162,8 @@ The first pass shows:
 - valid/invalid
 - surfaced error count
 - suppressed and unmapped issue counts
-- the active error map after availability filtering
-- optional active schema field names
+- the derived error map after availability filtering
+- optional derived schema field names
 
 It does not currently detect skipped `refine()`/`superRefine()` execution on its own. If we want that, we will likely need richer validation instrumentation than a plain `safeParse()` result exposes.
 

--- a/packages/zod/__tests__/adapter.test.ts
+++ b/packages/zod/__tests__/adapter.test.ts
@@ -1,10 +1,10 @@
 import { enabledWhen, fairWhen, umpire } from '@umpire/core'
 import { z } from 'zod'
-import { createZodValidation } from '../src/validation.js'
+import { createZodAdapter } from '../src/adapter.js'
 
-describe('createZodValidation', () => {
+describe('createZodAdapter', () => {
   test('creates core validators that surface the first Zod issue', () => {
-    const validation = createZodValidation({
+    const validation = createZodAdapter({
       schemas: {
         email: z.string().email('Enter a valid email'),
       },
@@ -27,7 +27,7 @@ describe('createZodValidation', () => {
     })
   })
 
-  test('runs active schema validation and returns filtered field errors', () => {
+  test('runs derived schema validation and returns filtered field errors', () => {
     const fields = {
       email: { required: true, isEmpty: (value: unknown) => !value },
       password: { required: true, isEmpty: (value: unknown) => !value },
@@ -35,7 +35,7 @@ describe('createZodValidation', () => {
       companyName: { required: true, isEmpty: (value: unknown) => !value },
     }
 
-    const validation = createZodValidation({
+    const validation = createZodAdapter({
       schemas: {
         email: z.string().email('Enter a valid email'),
         password: z.string().min(8, 'At least 8 characters'),
@@ -79,20 +79,20 @@ describe('createZodValidation', () => {
   })
 
   test('throws if given a z.object instead of per-field schemas', () => {
-    expect(() => createZodValidation({
+    expect(() => createZodAdapter({
       schemas: z.object({
         email: z.string().email(),
       }) as never,
     })).toThrow(
-      'createZodValidation() expects per-field schemas, not a z.object(). ' +
+      'createZodAdapter() expects per-field schemas, not a z.object(). ' +
       'Pass formSchema.shape instead of formSchema.',
     )
   })
 
   test('throws if given a non-object instead of per-field schemas', () => {
-    expect(() => createZodValidation({
+    expect(() => createZodAdapter({
       schemas: undefined as never,
-    })).toThrow('createZodValidation() expects a per-field schema map object.')
+    })).toThrow('createZodAdapter() expects a per-field schema map object.')
   })
 
   test('rejects foul field values when rejectFoul is true', () => {
@@ -101,7 +101,7 @@ describe('createZodValidation', () => {
       vehicleType: {},
     }
 
-    const validation = createZodValidation({
+    const validation = createZodAdapter({
       schemas: {
         spotType: z.enum(['electric', 'standard']),
         vehicleType: z.enum(['electric', 'gas']),

--- a/packages/zod/__tests__/derive-errors.test.ts
+++ b/packages/zod/__tests__/derive-errors.test.ts
@@ -1,6 +1,6 @@
 import type { AvailabilityMap } from '@umpire/core'
 import { z } from 'zod'
-import { activeErrors, zodErrors } from '../src/active-errors.js'
+import { deriveErrors, zodErrors } from '../src/derive-errors.js'
 
 type TestFields = {
   name: {}
@@ -34,10 +34,10 @@ function createAvailability(
   }
 }
 
-describe('activeErrors', () => {
+describe('deriveErrors', () => {
   test('filters out errors for disabled fields', () => {
     expect(
-      activeErrors(createAvailability(), [
+      deriveErrors(createAvailability(), [
         { field: 'inviteCode', message: 'Invite code is invalid' },
         { field: 'name', message: 'Name is required' },
       ]),
@@ -48,7 +48,7 @@ describe('activeErrors', () => {
 
   test('passes through errors for enabled fields', () => {
     expect(
-      activeErrors(createAvailability(), [
+      deriveErrors(createAvailability(), [
         { field: 'name', message: 'Name is required' },
         { field: 'notes', message: 'Notes are too long' },
       ]),
@@ -60,7 +60,7 @@ describe('activeErrors', () => {
 
   test('keeps the first error per field', () => {
     expect(
-      activeErrors(createAvailability(), [
+      deriveErrors(createAvailability(), [
         { field: 'name', message: 'Name is required' },
         { field: 'name', message: 'Name must be at least 2 characters' },
       ]),
@@ -95,6 +95,6 @@ describe('activeErrors', () => {
   })
 
   test('returns an empty object when no errors are provided', () => {
-    expect(activeErrors(createAvailability(), [])).toEqual({})
+    expect(deriveErrors(createAvailability(), [])).toEqual({})
   })
 })

--- a/packages/zod/__tests__/derive-schema.test.ts
+++ b/packages/zod/__tests__/derive-schema.test.ts
@@ -1,6 +1,6 @@
 import type { AvailabilityMap } from '@umpire/core'
 import { z } from 'zod'
-import { activeSchema } from '../src/active-schema.js'
+import { deriveSchema } from '../src/derive-schema.js'
 
 type TestFields = {
   requiredName: {}
@@ -43,9 +43,9 @@ function createAvailability(
   }
 }
 
-describe('activeSchema', () => {
+describe('deriveSchema', () => {
   test('omits disabled fields from the schema', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailability(),
       {
         requiredName: z.string(),
@@ -58,7 +58,7 @@ describe('activeSchema', () => {
   })
 
   test('keeps enabled required fields required', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailability(),
       {
         requiredName: z.string(),
@@ -70,7 +70,7 @@ describe('activeSchema', () => {
   })
 
   test('makes enabled non-required fields optional', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailability(),
       {
         optionalNickname: z.string(),
@@ -82,14 +82,14 @@ describe('activeSchema', () => {
   })
 
   test('returns an empty object schema for empty availability', () => {
-    const schema = activeSchema({} as AvailabilityMap<EmptyFields>, {})
+    const schema = deriveSchema({} as AvailabilityMap<EmptyFields>, {})
 
     expect(Object.keys(schema.shape)).toEqual([])
     expect(schema.safeParse({}).success).toBe(true)
   })
 
   test('skips enabled fields that do not have a matching schema', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailability(),
       {
         requiredName: z.string(),
@@ -101,19 +101,19 @@ describe('activeSchema', () => {
   })
 
   test('throws if given a z.object instead of per-field schemas', () => {
-    expect(() => activeSchema(
+    expect(() => deriveSchema(
       createAvailability(),
       z.object({
         requiredName: z.string(),
       }) as never,
     )).toThrow(
-      'activeSchema() expects per-field schemas, not a z.object(). ' +
+      'deriveSchema() expects per-field schemas, not a z.object(). ' +
       'Pass formSchema.shape instead of formSchema.',
     )
   })
 })
 
-describe('activeSchema rejectFoul', () => {
+describe('deriveSchema rejectFoul', () => {
   function createAvailabilityWithFoul(
     overrides: Partial<AvailabilityMap<TestFields>> = {},
   ): AvailabilityMap<TestFields> {
@@ -151,7 +151,7 @@ describe('activeSchema rejectFoul', () => {
   }
 
   test('rejects a foul field value when rejectFoul is true', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailabilityWithFoul({
         optionalNickname: {
           enabled: true,
@@ -175,7 +175,7 @@ describe('activeSchema rejectFoul', () => {
   })
 
   test('uses a fallback message when reason is null', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailabilityWithFoul({
         optionalNickname: {
           enabled: true,
@@ -199,7 +199,7 @@ describe('activeSchema rejectFoul', () => {
   })
 
   test('passes through foul fields without error when rejectFoul is false', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailabilityWithFoul({
         optionalNickname: {
           enabled: true,
@@ -216,7 +216,7 @@ describe('activeSchema rejectFoul', () => {
   })
 
   test('omitting a foul optional field passes when rejectFoul is true', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailabilityWithFoul({
         optionalNickname: {
           enabled: true,
@@ -237,7 +237,7 @@ describe('activeSchema rejectFoul', () => {
   })
 
   test('fair fields are unaffected when rejectFoul is true', () => {
-    const schema = activeSchema(
+    const schema = deriveSchema(
       createAvailabilityWithFoul(),
       { requiredName: z.string() },
       { rejectFoul: true },

--- a/packages/zod/__tests__/devtools.test.ts
+++ b/packages/zod/__tests__/devtools.test.ts
@@ -1,7 +1,7 @@
 import type { AvailabilityMap } from '@umpire/core'
 import { enabledWhen, umpire } from '@umpire/core'
 import { z } from 'zod'
-import { activeSchema } from '../src/active-schema.js'
+import { deriveSchema } from '../src/derive-schema.js'
 import { zodValidationExtension } from '../src/devtools.js'
 
 type TestFields = {
@@ -97,12 +97,12 @@ describe('zodValidationExtension', () => {
       ]),
     })
 
-    expect(view?.sections[1]?.title).toBe('Active Error Map')
-    expect(view?.sections[2]?.title).toBe('Active Schema')
+    expect(view?.sections[1]?.title).toBe('Derived Error Map')
+    expect(view?.sections[2]?.title).toBe('Derived Schema')
 
     expect(view?.sections).toContainEqual({
       kind: 'rows',
-      title: 'Active Error Map',
+      title: 'Derived Error Map',
       rows: [
         { label: 'email', value: 'Enter a valid email' },
         { label: 'companySize', value: 'Company size is required' },
@@ -210,10 +210,10 @@ describe('zodValidationExtension', () => {
       ]),
     })
 
-    expect(view?.sections.find((section) => section.title === 'Active Error Map')).toBeUndefined()
+    expect(view?.sections.find((section) => section.title === 'Derived Error Map')).toBeUndefined()
     expect(view?.sections).toContainEqual({
       kind: 'rows',
-      title: 'Active Schema',
+      title: 'Derived Schema',
       rows: [
         { label: 'field count', value: 3 },
         { label: 'fields', value: 'email, companyName, companySize' },
@@ -245,7 +245,7 @@ describe('zodValidationExtension', () => {
 
     const extension = zodValidationExtension({
       resolve({ scorecard, values }) {
-        const baseSchema = activeSchema(scorecard.check, {
+        const baseSchema = deriveSchema(scorecard.check, {
           email: z.string().email('Enter a valid email'),
           companyName: z.string().min(1, 'Company name is required'),
         })
@@ -278,7 +278,7 @@ describe('zodValidationExtension', () => {
 
     expect(view?.sections).toContainEqual({
       kind: 'rows',
-      title: 'Active Error Map',
+      title: 'Derived Error Map',
       rows: [
         { label: 'email', value: 'Enter a valid email' },
       ],
@@ -286,7 +286,7 @@ describe('zodValidationExtension', () => {
 
     expect(view?.sections).toContainEqual({
       kind: 'rows',
-      title: 'Active Schema',
+      title: 'Derived Schema',
       rows: [
         { label: 'field count', value: 1 },
         { label: 'fields', value: 'email' },

--- a/packages/zod/src/adapter.ts
+++ b/packages/zod/src/adapter.ts
@@ -5,8 +5,8 @@ import type {
   ValidationMap,
 } from '@umpire/core'
 import type { z } from 'zod'
-import { activeErrors, zodErrors, type NormalizedFieldError } from './active-errors.js'
-import { activeSchema, type ActiveSchemaOptions } from './active-schema.js'
+import { deriveErrors, zodErrors, type NormalizedFieldError } from './derive-errors.js'
+import { deriveSchema, type DeriveSchemaOptions } from './derive-schema.js'
 import { assertFieldSchemas, isRecord } from './schema-guards.js'
 
 type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
@@ -30,23 +30,23 @@ type ZodSchemaLike = {
   safeParse(value: unknown): ZodSafeParseResultLike
 }
 
-export type CreateZodValidationOptions<F extends Record<string, FieldDef>> = {
+export type CreateZodAdapterOptions<F extends Record<string, FieldDef>> = {
   schemas: FieldSchemas<F>
   build?(schema: z.ZodObject<Record<string, z.ZodTypeAny>>): ZodSchemaLike
-} & ActiveSchemaOptions
+} & DeriveSchemaOptions
 
-export type ZodValidationRunResult<F extends Record<string, FieldDef>> = {
+export type ZodAdapterRunResult<F extends Record<string, FieldDef>> = {
   errors: Partial<Record<keyof F & string, string>>
   normalizedErrors: NormalizedFieldError[]
   result: ZodSafeParseResultLike
   schemaFields: Array<keyof F & string>
 }
 
-export type ZodValidationAdapter<F extends Record<string, FieldDef>> = {
+export type ZodAdapter<F extends Record<string, FieldDef>> = {
   run(
     availability: AvailabilityMap<F>,
     values: InputValues<F>,
-  ): ZodValidationRunResult<F>
+  ): ZodAdapterRunResult<F>
   validators: ValidationMap<F>
 }
 
@@ -61,10 +61,10 @@ function isFailedParseResult(result: unknown): result is Extract<ZodSafeParseRes
     Array.isArray(result.error.issues)
 }
 
-export function createZodValidation<F extends Record<string, FieldDef>>(
-  options: CreateZodValidationOptions<F>,
-): ZodValidationAdapter<F> {
-  assertFieldSchemas(options.schemas, 'createZodValidation')
+export function createZodAdapter<F extends Record<string, FieldDef>>(
+  options: CreateZodAdapterOptions<F>,
+): ZodAdapter<F> {
+  assertFieldSchemas(options.schemas, 'createZodAdapter')
 
   const {
     schemas,
@@ -96,13 +96,13 @@ export function createZodValidation<F extends Record<string, FieldDef>>(
   return {
     validators,
     run(availability, values) {
-      const baseSchema = activeSchema(availability, schemas, { rejectFoul })
+      const baseSchema = deriveSchema(availability, schemas, { rejectFoul })
       const schema = build ? build(baseSchema) : baseSchema
       const result = schema.safeParse(values)
       const normalizedErrors = isFailedParseResult(result) ? zodErrors(result.error) : []
 
       return {
-        errors: activeErrors(availability, normalizedErrors),
+        errors: deriveErrors(availability, normalizedErrors),
         normalizedErrors,
         result,
         schemaFields: Object.keys(baseSchema.shape) as Array<keyof F & string>,

--- a/packages/zod/src/derive-errors.ts
+++ b/packages/zod/src/derive-errors.ts
@@ -14,7 +14,7 @@ type ZodErrorLike = {
   issues: readonly ZodIssueLike[]
 }
 
-export function activeErrors<F extends Record<string, FieldDef>>(
+export function deriveErrors<F extends Record<string, FieldDef>>(
   availability: AvailabilityMap<F>,
   errors: NormalizedFieldError[],
 ): Partial<Record<keyof F & string, string>> {

--- a/packages/zod/src/derive-schema.ts
+++ b/packages/zod/src/derive-schema.ts
@@ -6,7 +6,7 @@ type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
   Record<keyof F & string, z.ZodTypeAny>
 >
 
-export type ActiveSchemaOptions = {
+export type DeriveSchemaOptions = {
   /**
    * When true, enabled fields whose value is foul (`fair: false`) are
    * included in the schema with a refinement that always fails, using the
@@ -25,21 +25,21 @@ export type ActiveSchemaOptions = {
  *
  * ```ts
  * // Per-field
- * activeSchema(availability, { email: z.string().email() })
+ * deriveSchema(availability, { email: z.string().email() })
  *
  * // From an existing z.object()
- * activeSchema(availability, formSchema.shape)
+ * deriveSchema(availability, formSchema.shape)
  *
  * // Server guard — reject foul values outright
- * activeSchema(availability, schemas, { rejectFoul: true })
+ * deriveSchema(availability, schemas, { rejectFoul: true })
  * ```
  */
-export function activeSchema<F extends Record<string, FieldDef>>(
+export function deriveSchema<F extends Record<string, FieldDef>>(
   availability: AvailabilityMap<F>,
   schemas: FieldSchemas<F>,
-  options?: ActiveSchemaOptions,
+  options?: DeriveSchemaOptions,
 ): z.ZodObject<Record<string, z.ZodTypeAny>> {
-  assertFieldSchemas(schemas, 'activeSchema')
+  assertFieldSchemas(schemas, 'deriveSchema')
 
   const fieldSchemas = schemas
   const rejectFoul = options?.rejectFoul ?? false

--- a/packages/zod/src/devtools.ts
+++ b/packages/zod/src/devtools.ts
@@ -6,8 +6,8 @@ import type {
   Snapshot,
   Umpire,
 } from '@umpire/core'
-import { activeErrors, zodErrors } from './active-errors.js'
-import type { NormalizedFieldError } from './active-errors.js'
+import { deriveErrors, zodErrors } from './derive-errors.js'
+import type { NormalizedFieldError } from './derive-errors.js'
 
 type ZodIssueLike = {
   path: readonly (string | number)[]
@@ -173,9 +173,9 @@ export function zodValidationExtension<
       const availability = resolved.availability ?? context.scorecard.check
       const normalizedErrors = resolved.normalizedErrors ??
         (resolved.result.success ? [] : zodErrors(resolved.result.error))
-      const activeErrorMap = activeErrors(availability, normalizedErrors)
-      const activeFieldCount = Object.values(availability).filter((field) => field.enabled).length
-      const activeErrorCount = Object.keys(activeErrorMap).length
+      const derivedErrorMap = deriveErrors(availability, normalizedErrors)
+      const enabledFieldCount = Object.values(availability).filter((field) => field.enabled).length
+      const derivedErrorCount = Object.keys(derivedErrorMap).length
       const { suppressedIssues, unknownIssues } = sectionRows(availability, normalizedErrors)
       const sections: ValidationExtensionSection[] = [{
         kind: 'badges',
@@ -187,7 +187,7 @@ export function zodValidationExtension<
           },
           {
             tone: 'accent',
-            value: `errors ${activeErrorCount}`,
+            value: `errors ${derivedErrorCount}`,
           },
           {
             tone: 'muted',
@@ -199,16 +199,16 @@ export function zodValidationExtension<
           },
           {
             tone: 'fair',
-            value: `fields ${activeFieldCount}`,
+            value: `fields ${enabledFieldCount}`,
           },
         ],
       }]
 
-      if (Object.keys(activeErrorMap).length > 0) {
+      if (Object.keys(derivedErrorMap).length > 0) {
         sections.push({
           kind: 'rows',
-          title: 'Active Error Map',
-          rows: Object.entries(activeErrorMap).map(([field, message]) => ({
+          title: 'Derived Error Map',
+          rows: Object.entries(derivedErrorMap).map(([field, message]) => ({
             label: field,
             value: message,
           })),
@@ -218,7 +218,7 @@ export function zodValidationExtension<
       if (resolved.schemaFields && resolved.schemaFields.length > 0) {
         sections.push({
           kind: 'rows',
-          title: 'Active Schema',
+          title: 'Derived Schema',
           rows: [
             { label: 'field count', value: resolved.schemaFields.length },
             { label: 'fields', value: resolved.schemaFields.join(', ') },

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,10 +1,10 @@
-export { activeSchema } from './active-schema.js'
-export type { ActiveSchemaOptions } from './active-schema.js'
-export { activeErrors, zodErrors } from './active-errors.js'
-export type { NormalizedFieldError } from './active-errors.js'
-export { createZodValidation } from './validation.js'
+export { deriveSchema } from './derive-schema.js'
+export type { DeriveSchemaOptions } from './derive-schema.js'
+export { deriveErrors, zodErrors } from './derive-errors.js'
+export type { NormalizedFieldError } from './derive-errors.js'
+export { createZodAdapter } from './adapter.js'
 export type {
-  CreateZodValidationOptions,
-  ZodValidationAdapter,
-  ZodValidationRunResult,
-} from './validation.js'
+  CreateZodAdapterOptions,
+  ZodAdapter,
+  ZodAdapterRunResult,
+} from './adapter.js'

--- a/packages/zod/src/schema-guards.ts
+++ b/packages/zod/src/schema-guards.ts
@@ -8,7 +8,7 @@ export function isZodObjectSchema(value: unknown): boolean {
 
 export function assertFieldSchemas(
   schemas: unknown,
-  caller: 'activeSchema' | 'createZodValidation',
+  caller: 'deriveSchema' | 'createZodAdapter',
 ): asserts schemas is Record<string, unknown> {
   if (isZodObjectSchema(schemas)) {
     throw new Error(


### PR DESCRIPTION
## Summary

Rename the `@umpire/zod` helper surface for better naming consistency while the package is still in alpha.

This changes:

- `activeSchema` -> `deriveSchema`
- `activeErrors` -> `deriveErrors`
- `createZodValidation` -> `createZodAdapter`

## Changes

- Renames the public `@umpire/zod` exports to the new `derive*` / `adapter` names
- Renames the related exported types to match:
  - `CreateZodAdapterOptions`
  - `ZodAdapter`
  - `ZodAdapterRunResult`
- Renames the underlying source and test files to match the new API
- Updates assertion/error messages to reference the new function names
- Updates `@umpire/zod/devtools` copy from “Active Schema / Active Error Map” to “Derived Schema / Derived Error Map”
- Refreshes the package README, docs pages, examples, and signup demo to use the new terminology
- Adds a changeset for the `@umpire/zod` release

## Breaking Change

This is a source-level rename for `@umpire/zod` consumers. Existing imports and usages of the old names need to be updated.

## Testing

- `yarn turbo run test build typecheck --filter=@umpire/zod`
- `yarn build` (in `docs/`)
