### PR TITLE
Move Zod docs from Integrations into Adapters → Validation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -148,14 +148,9 @@ export default defineConfig({
               { label: 'TanStack Store', slug: 'adapters/tanstack-store' },
               { label: 'Vuex', slug: 'adapters/vuex' },
             ] },
-          ],
-        },
-        {
-          label: 'Integrations',
-          items: [
-            { label: 'Validators', collapsed: false, items: [
-              { label: 'Overview', slug: 'integrations/validators' },
-              { label: 'Zod', slug: 'integrations/zod' },
+            { label: 'Validation', collapsed: false, items: [
+              { label: 'Overview', slug: 'adapters/validation' },
+              { label: 'Zod', slug: 'adapters/validation/zod' },
             ] },
           ],
         },

--- a/docs/src/content/docs/adapters/validation/index.md
+++ b/docs/src/content/docs/adapters/validation/index.md
@@ -86,6 +86,6 @@ Each library's "always-fail with message" primitive:
 
 ## See also
 
-- [`@umpire/zod`](/umpire/integrations/zod/) — reference implementation
+- [`@umpire/zod`](/umpire/adapters/validation/zod/) — reference implementation
 - [Composing with Validation](/umpire/concepts/validation/) — manual patterns and the `check()` bridge
 - [`fairWhen()`](/umpire/api/rules/fair-when/) — the rule that produces `fair: false`

--- a/docs/src/content/docs/adapters/validation/zod.md
+++ b/docs/src/content/docs/adapters/validation/zod.md
@@ -138,6 +138,6 @@ If `confirmPassword` is disabled, `deriveSchema` excludes it and the refinement 
 
 ## See also
 
-- [Validator Integrations](/umpire/integrations/validators/) — the general contract and how it extends to other libraries
+- [Validator Integrations](/umpire/adapters/validation/) — the general contract and how it extends to other libraries
 - [Composing with Validation](/umpire/concepts/validation/) — conceptual boundary and manual patterns
 - [Signup Form + Zod](/umpire/examples/signup/) — full walkthrough with `deriveSchema`, the render loop, and foul handling

--- a/docs/src/content/docs/concepts/satisfaction.md
+++ b/docs/src/content/docs/concepts/satisfaction.md
@@ -145,4 +145,4 @@ const loginUmp = umpire({
 
 `requires()` handles presence. `check()` bridges into richer validation logic when you need it.
 
-For full validation composition — building dynamic Zod schemas from availability, filtering errors to enabled fields, gating submit on both layers — see the [Signup Form + Zod](/umpire/examples/signup/) example and the [`@umpire/zod`](/umpire/integrations/zod/) integration.
+For full validation composition — building dynamic Zod schemas from availability, filtering errors to enabled fields, gating submit on both layers — see the [Signup Form + Zod](/umpire/examples/signup/) example and the [`@umpire/zod`](/umpire/adapters/validation/zod/) integration.

--- a/docs/src/content/docs/concepts/validation.md
+++ b/docs/src/content/docs/concepts/validation.md
@@ -5,7 +5,7 @@ description: Umpire handles availability. Validation libraries handle correctnes
 
 Umpire decides whether a field is **available**. It does not decide whether a value is **correct**. But the two are often entangled — a field might need to be *valid* before a dependent field becomes available, or you might only want to validate fields that are currently *enabled*.
 
-For the common case — building a schema that reflects current availability and filtering errors to active fields — [`@umpire/zod`](/umpire/integrations/zod/) handles the wiring. This page covers the conceptual boundary and the `check()` bridge that makes composition work regardless of which library you use.
+For the common case — building a schema that reflects current availability and filtering errors to active fields — [`@umpire/zod`](/umpire/adapters/validation/zod/) handles the wiring. This page covers the conceptual boundary and the `check()` bridge that makes composition work regardless of which library you use.
 
 ## The boundary
 
@@ -125,7 +125,7 @@ if (!result.success) {
 }
 ```
 
-This is exactly what `deriveSchema` and `deriveErrors` do. See [Validator Integrations](/umpire/integrations/validators/) for the general pattern and how it extends to other libraries.
+This is exactly what `deriveSchema` and `deriveErrors` do. See [Validator Integrations](/umpire/adapters/validation/) for the general pattern and how it extends to other libraries.
 
 ## What stays in userspace
 
@@ -140,8 +140,8 @@ These are all form-framework concerns. Umpire's job ends at "is this field avail
 
 ## See also
 
-- [Validator Integrations](/umpire/integrations/validators/) — the integration contract and how it applies to any library
-- [`@umpire/zod`](/umpire/integrations/zod/) — first-class Zod integration with `deriveSchema` and `deriveErrors`
+- [Validator Integrations](/umpire/adapters/validation/) — the integration contract and how it applies to any library
+- [`@umpire/zod`](/umpire/adapters/validation/zod/) — first-class Zod integration with `deriveSchema` and `deriveErrors`
 - [Satisfaction semantics](/umpire/concepts/satisfaction/) — how Umpire defines "present"
 - [`check()` in the rules API](/umpire/api/rules/check/) — full signature and validator shapes
 - [`@umpire/json`](/umpire/adapters/json/) — portable schemas, named checks, and `excluded`


### PR DESCRIPTION
## Summary

- Removes the top-level "Integrations" nav section from the sidebar — it was a misplaced heading for what is clearly an adapter
- Moves the Validator Overview and `@umpire/zod` pages under **Adapters → Validation**, alongside the other adapter subsections (UI, State)
- Updates all internal cross-links in `concepts/validation.md`, `concepts/satisfaction.md`, and the moved files to reflect the new `/adapters/validation/` paths

## Test plan

- [ ] `cd docs && yarn build` passes with no broken link warnings
- [ ] Sidebar shows Adapters → Validation → Overview / Zod (no top-level Integrations heading)
- [ ] `/adapters/validation/` and `/adapters/validation/zod/` resolve correctly
- [ ] All "See also" cross-links in the validation and satisfaction concept pages point to the right destinations

https://claude.ai/code/session_015HsnVL6REdBEQVijRTfu2N