### PR TITLE
🥏 Add @umpire/solid adapter package

### DIFF
--- a/.changeset/smart-poems-nail.md
+++ b/.changeset/smart-poems-nail.md
@@ -1,0 +1,8 @@
+---
+"@umpire/solid": minor
+"@umpire/signals": patch
+---
+
+- Add `@umpire/solid` as a first-class Solid adapter package with `useUmpire()` for component-local state and `fromSolidStore()` for shared store or context state.
+- Add Solid adapter docs, examples, tests, and repo wiring so the package is discoverable and validated alongside the existing adapters.
+- Fix the `@umpire/signals/solid` adapter typing so the package builds cleanly when `solid-js` types are installed.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ const fouls = signupUmp.play(
 | --- | --- |
 | [`@umpire/core`](./packages/core/README.md) | Pure logic engine with zero runtime dependencies |
 | [`@umpire/react`](./packages/react/README.md) | `useUmpire()` hook for React |
+| [`@umpire/solid`](./packages/solid/README.md) | `useUmpire()` hook for Solid |
 | [`@umpire/signals`](./packages/signals/README.md) | Signal adapter via `SignalProtocol` (Jotai, Preact, Alien Signals, TC39) |
 | [`@umpire/store`](./packages/store/README.md) | Generic store adapter — bring your own `getState()` + `subscribe(next, prev)` |
 | [`@umpire/zustand`](./packages/zustand/README.md) | Zustand adapter (satisfies the store contract natively) |
@@ -94,7 +95,7 @@ const fouls = signupUmp.play(
 - Pure logic, zero dependencies.
 - Declarative rules: `requires`, `disables`, `enabledWhen`, `fairWhen`, `oneOf`.
 - Recommendations, not mutations: `play()` suggests resets, you decide when to apply them.
-- Adapters for React, Zustand, Redux, TanStack Store, Pinia, Vuex, and signals.
+- Adapters for React, Solid, Zustand, Redux, TanStack Store, Pinia, Vuex, and signals.
 - Debuggable: `challenge()` traces why any field was ruled out, `@umpire/devtools` surfaces it visually.
 
 ## Install

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -132,6 +132,7 @@ export default defineConfig({
           items: [
             { label: 'UI', collapsed: false, items: [
               { label: 'React', slug: 'adapters/react' },
+              { label: 'Solid', slug: 'adapters/solid' },
               { label: 'Signals', collapsed: true, items: [
                 { label: 'Overview', slug: 'adapters/signals' },
                 { label: 'Preact', slug: 'adapters/signals/preact' },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -133,14 +133,14 @@ export default defineConfig({
             { label: 'UI', collapsed: false, items: [
               { label: 'React', slug: 'adapters/react' },
               { label: 'Solid', slug: 'adapters/solid' },
-              { label: 'Signals', collapsed: true, items: [
-                { label: 'Overview', slug: 'adapters/signals' },
-                { label: 'Preact', slug: 'adapters/signals/preact' },
-                { label: 'Vue', slug: 'adapters/signals/vue' },
-                { label: 'Solid', slug: 'adapters/signals/solid' },
-                { label: 'alien-signals', slug: 'adapters/signals/alien' },
-                { label: 'TC39', slug: 'adapters/signals/tc39' },
-              ] },
+            ] },
+            { label: 'Signals', collapsed: false, items: [
+              { label: 'Overview', slug: 'adapters/signals' },
+              { label: 'Preact', slug: 'adapters/signals/preact' },
+              { label: 'Vue', slug: 'adapters/signals/vue' },
+              { label: 'Solid', slug: 'adapters/signals/solid' },
+              { label: 'alien-signals', slug: 'adapters/signals/alien' },
+              { label: 'TC39', slug: 'adapters/signals/tc39' },
             ] },
             { label: 'State', collapsed: false, items: [
               { label: 'Store', slug: 'adapters/store' },

--- a/docs/src/content/docs/adapters/signals/index.mdx
+++ b/docs/src/content/docs/adapters/signals/index.mdx
@@ -47,6 +47,8 @@ When `reactive.field(field).enabled` changes, only this component re-renders. Th
 
 If you'd collapse all signals into one blob and re-render everything anyway, just use `useUmpire` — it's simpler and does exactly that.
 
+Solid supports both styles: [`@umpire/solid`](/umpire/adapters/solid/) gives you `useUmpire()` plus `fromSolidStore()`, while `@umpire/signals/solid` exposes the raw signal adapter.
+
 ---
 
 ## Install

--- a/docs/src/content/docs/adapters/signals/index.mdx
+++ b/docs/src/content/docs/adapters/signals/index.mdx
@@ -47,7 +47,7 @@ When `reactive.field(field).enabled` changes, only this component re-renders. Th
 
 If you'd collapse all signals into one blob and re-render everything anyway, just use `useUmpire` — it's simpler and does exactly that.
 
-Solid supports both styles: [`@umpire/solid`](/umpire/adapters/solid/) gives you `useUmpire()` plus `fromSolidStore()`, while `@umpire/signals/solid` exposes the raw signal adapter.
+Solid also has [`@umpire/solid`](/umpire/adapters/solid/) if you'd rather start with `useUmpire()` or `fromSolidStore()` instead of `reactiveUmp()`.
 
 ---
 

--- a/docs/src/content/docs/adapters/signals/solid.mdx
+++ b/docs/src/content/docs/adapters/signals/solid.mdx
@@ -3,6 +3,8 @@ title: 'Signals — Solid'
 description: Using @umpire/signals with SolidJS.
 ---
 
+If you want a Solid-specific wrapper package with `useUmpire()` and `fromSolidStore()`, see [`@umpire/solid`](/umpire/adapters/solid/). This page is about the lower-level signal adapter.
+
 ## Install
 
 ```bash
@@ -40,6 +42,8 @@ function FieldControl(props) {
 ```
 
 Solid tracks reactive reads during render automatically — no explicit subscriptions needed.
+
+This is the right layer when you want the raw `reactiveUmp()` surface. If your app would rather work with a Solid-focused package API, `@umpire/solid` wraps this adapter for you.
 
 ## Reactive root
 

--- a/docs/src/content/docs/adapters/signals/solid.mdx
+++ b/docs/src/content/docs/adapters/signals/solid.mdx
@@ -3,7 +3,7 @@ title: 'Signals — Solid'
 description: Using @umpire/signals with SolidJS.
 ---
 
-If you want a Solid-specific wrapper package with `useUmpire()` and `fromSolidStore()`, see [`@umpire/solid`](/umpire/adapters/solid/). This page is about the lower-level signal adapter.
+If you want the Solid package with `useUmpire()` and `fromSolidStore()`, see [`@umpire/solid`](/umpire/adapters/solid/). Use this page when you want `reactiveUmp()` directly.
 
 ## Install
 
@@ -43,7 +43,7 @@ function FieldControl(props) {
 
 Solid tracks reactive reads during render automatically — no explicit subscriptions needed.
 
-This is the right layer when you want the raw `reactiveUmp()` surface. If your app would rather work with a Solid-focused package API, `@umpire/solid` wraps this adapter for you.
+Use this layer when you want to wire `reactiveUmp()` into Solid yourself. If you just want the Solid adapter package, use `@umpire/solid`.
 
 ## Reactive root
 

--- a/docs/src/content/docs/adapters/solid.mdx
+++ b/docs/src/content/docs/adapters/solid.mdx
@@ -1,0 +1,234 @@
+---
+title: '@umpire/solid'
+description: Solid adapters for both component-local and shared-store Umpire integrations.
+---
+
+`@umpire/solid` gives Solid apps two integration styles:
+
+- `useUmpire()` for component-local state when one values accessor drives one component subtree
+- `fromSolidStore()` for shared store or context state when many children should read from one Umpire instance
+
+If you want fine-grained field subscriptions without the Solid-specific convenience layer, see [Signals — Solid](/umpire/adapters/signals/solid/).
+
+## Install
+
+```bash
+yarn add @umpire/core @umpire/solid solid-js
+```
+
+## `useUmpire()`
+
+Use `useUmpire()` when your component already owns a single reactive values object and just needs derived availability plus fouls.
+
+```ts
+import type { Accessor } from 'solid-js'
+import { useUmpire } from '@umpire/solid'
+
+function useUmpire<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  ump: Umpire<F, C>,
+  values: Accessor<InputValues<F>>,
+  conditions?: Accessor<C>,
+): {
+  check: Accessor<AvailabilityMap<F>>
+  fouls: Accessor<Foul<F>[]>
+}
+```
+
+### Example
+
+```tsx
+import { createStore } from 'solid-js/store'
+import { enabledWhen, requires, umpire } from '@umpire/core'
+import { useUmpire } from '@umpire/solid'
+
+const signupUmp = umpire({
+  fields: {
+    email:           { required: true, isEmpty: (v: unknown) => !v },
+    password:        { required: true, isEmpty: (v: unknown) => !v },
+    confirmPassword: { required: true, isEmpty: (v: unknown) => !v },
+    companyName:     { isEmpty: (v: unknown) => !v },
+    companySize:     { isEmpty: (v: unknown) => !v },
+  },
+  rules: [
+    requires('confirmPassword', 'password'),
+    enabledWhen('companyName', (_v, conditions) => conditions.plan === 'business', {
+      reason: 'business plan required',
+    }),
+    enabledWhen('companySize', (_v, conditions) => conditions.plan === 'business', {
+      reason: 'business plan required',
+    }),
+    requires('companySize', 'companyName'),
+  ],
+})
+
+type SignupConditions = { plan: 'personal' | 'business' }
+
+function SignupForm(props: { plan: Accessor<SignupConditions['plan']> }) {
+  const [values, setValues] = createStore(signupUmp.init())
+
+  const { check, fouls } = useUmpire(
+    signupUmp,
+    () => values,
+    () => ({ plan: props.plan() }),
+  )
+
+  function applyResets() {
+    for (const foul of fouls()) {
+      setValues(foul.field, foul.suggestedValue as never)
+    }
+  }
+
+  return (
+    <form>
+      <input
+        value={String(values.password ?? '')}
+        onInput={(e) => setValues('password', e.currentTarget.value)}
+      />
+
+      <input
+        value={String(values.confirmPassword ?? '')}
+        disabled={!check().confirmPassword.enabled}
+        onInput={(e) => setValues('confirmPassword', e.currentTarget.value)}
+      />
+
+      {!check().companyName.enabled && <p>{check().companyName.reason}</p>}
+
+      {fouls().length > 0 && (
+        <button type="button" onClick={applyResets}>Apply resets</button>
+      )}
+    </form>
+  )
+}
+```
+
+### Behavior
+
+- `values` and `conditions` are accessors.
+- `check()` and `fouls()` are accessors.
+- The hook tracks the previous snapshot internally.
+- There is no `createEffect()` requirement in consumer code.
+
+This is the closest Solid equivalent to `@umpire/react`.
+
+## `fromSolidStore()`
+
+Use `fromSolidStore()` when one shared Solid store or provider should back a single Umpire instance for many child components.
+
+It is built on top of `@umpire/signals` internally, but the API is shaped for Solid stores and context rather than generic signal plumbing.
+
+```ts
+import type { Accessor } from 'solid-js'
+import { fromSolidStore } from '@umpire/solid'
+
+function fromSolidStore<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  ump: Umpire<F, C>,
+  options: {
+    values: InputValues<F>
+    set(name: keyof F & string, value: unknown): void
+    conditions?: Partial<{ [K in keyof C & string]: Accessor<C[K]> }>
+  },
+): SolidStoreUmpire<F>
+```
+
+### Example
+
+```tsx
+import { createContext, useContext, createSignal } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { enabledWhen, umpire } from '@umpire/core'
+import { fromSolidStore, type SolidStoreUmpire } from '@umpire/solid'
+
+const eventUmp = umpire({
+  fields: {
+    allDay: { default: false },
+    startTime: { default: '' },
+    endTime: { default: '' },
+  },
+  rules: [
+    enabledWhen('startTime', (values) => !values.allDay, { reason: 'all-day events do not use times' }),
+    enabledWhen('endTime', (values) => !values.allDay, { reason: 'all-day events do not use times' }),
+  ],
+})
+
+type EventFields = typeof eventUmp extends Umpire<infer F, any> ? F : never
+
+const EventFormContext = createContext<{
+  values: { allDay: boolean; startTime: string; endTime: string }
+  set(name: keyof EventFields & string, value: unknown): void
+  form: SolidStoreUmpire<EventFields>
+}>()
+
+function EventFormProvider(props: { children: JSX.Element }) {
+  const [values, setValues] = createStore({
+    allDay: false,
+    startTime: '09:00',
+    endTime: '10:00',
+  })
+  const [tier] = createSignal<'free' | 'pro'>('pro')
+
+  const form = fromSolidStore(eventUmp, {
+    values,
+    set: (name, value) => setValues(name, value as never),
+    conditions: {
+      tier,
+    },
+  })
+
+  return (
+    <EventFormContext.Provider value={{ values, set: (name, value) => setValues(name, value as never), form }}>
+      {props.children}
+    </EventFormContext.Provider>
+  )
+}
+
+function EndTimeField() {
+  const ctx = useContext(EventFormContext)!
+  const status = () => ctx.form.field('endTime')
+
+  return (
+    <input
+      value={ctx.values.endTime}
+      disabled={!status().enabled}
+      onInput={(e) => ctx.set('endTime', e.currentTarget.value)}
+    />
+  )
+}
+```
+
+### Return surface
+
+```ts
+type SolidStoreUmpire<F extends Record<string, FieldDef>> = {
+  field(name: keyof F & string): {
+    readonly enabled: boolean
+    readonly fair: boolean
+    readonly required: boolean
+    readonly reason: string | null
+    readonly reasons: string[]
+  }
+  foul(name: keyof F & string): Foul<F> | undefined
+  set(name: keyof F & string, value: unknown): void
+  update(partial: Partial<Record<keyof F & string, unknown>>): void
+  readonly values: Record<keyof F & string, unknown>
+  readonly fouls: Foul<F>[]
+  dispose(): void
+}
+```
+
+### When to pick which
+
+- Choose `useUmpire()` when one component owns the form state and wants snapshot-style derivation.
+- Choose `fromSolidStore()` when many child components should read from one shared Umpire instance.
+- Choose [`@umpire/signals/solid`](/umpire/adapters/signals/solid/) when you want the raw signal adapter surface without the Solid-specific wrapper package.
+
+## Notes
+
+- `@umpire/solid` does not use `@umpire/store`; Solid stores are a different integration shape.
+- `fromSolidStore()` uses `@umpire/signals` internally so field reads stay fine-grained.
+- Call `dispose()` for long-lived shared instances you create outside component cleanup.

--- a/docs/src/content/docs/adapters/solid.mdx
+++ b/docs/src/content/docs/adapters/solid.mdx
@@ -1,14 +1,14 @@
 ---
 title: '@umpire/solid'
-description: Solid adapters for both component-local and shared-store Umpire integrations.
+description: Solid helpers for component-local and shared Umpire state.
 ---
 
-`@umpire/solid` gives Solid apps two integration styles:
+`@umpire/solid` gives Solid apps two small APIs.
 
-- `useUmpire()` for component-local state when one values accessor drives one component subtree
-- `fromSolidStore()` for shared store or context state when many children should read from one Umpire instance
+- `useUmpire()` when a component owns the values
+- `fromSolidStore()` when one shared store or context should back the form
 
-If you want fine-grained field subscriptions without the Solid-specific convenience layer, see [Signals — Solid](/umpire/adapters/signals/solid/).
+If you want to use `reactiveUmp()` directly, see [Signals — Solid](/umpire/adapters/signals/solid/).
 
 ## Install
 
@@ -18,7 +18,7 @@ yarn add @umpire/core @umpire/solid solid-js
 
 ## `useUmpire()`
 
-Use `useUmpire()` when your component already owns a single reactive values object and just needs derived availability plus fouls.
+Use `useUmpire()` when your component already owns the values and just wants derived availability plus fouls.
 
 ```ts
 import type { Accessor } from 'solid-js'
@@ -108,16 +108,13 @@ function SignupForm(props: { plan: Accessor<SignupConditions['plan']> }) {
 
 - `values` and `conditions` are accessors.
 - `check()` and `fouls()` are accessors.
-- The hook tracks the previous snapshot internally.
-- There is no `createEffect()` requirement in consumer code.
+- Previous values are tracked internally.
 
-This is the closest Solid equivalent to `@umpire/react`.
+Like `@umpire/react`, the hook stays focused on derivation. You decide when to act on fouls.
 
 ## `fromSolidStore()`
 
-Use `fromSolidStore()` when one shared Solid store or provider should back a single Umpire instance for many child components.
-
-It is built on top of `@umpire/signals` internally, but the API is shaped for Solid stores and context rather than generic signal plumbing.
+Use `fromSolidStore()` when the form lives in shared Solid state and child components should read from the same Umpire instance.
 
 ```ts
 import type { Accessor } from 'solid-js'
@@ -139,7 +136,7 @@ function fromSolidStore<
 ### Example
 
 ```tsx
-import { createContext, useContext, createSignal } from 'solid-js'
+import { createContext, useContext } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { enabledWhen, umpire } from '@umpire/core'
 import { fromSolidStore, type SolidStoreUmpire } from '@umpire/solid'
@@ -170,14 +167,10 @@ function EventFormProvider(props: { children: JSX.Element }) {
     startTime: '09:00',
     endTime: '10:00',
   })
-  const [tier] = createSignal<'free' | 'pro'>('pro')
 
   const form = fromSolidStore(eventUmp, {
     values,
     set: (name, value) => setValues(name, value as never),
-    conditions: {
-      tier,
-    },
   })
 
   return (
@@ -201,34 +194,14 @@ function EndTimeField() {
 }
 ```
 
-### Return surface
-
-```ts
-type SolidStoreUmpire<F extends Record<string, FieldDef>> = {
-  field(name: keyof F & string): {
-    readonly enabled: boolean
-    readonly fair: boolean
-    readonly required: boolean
-    readonly reason: string | null
-    readonly reasons: string[]
-  }
-  foul(name: keyof F & string): Foul<F> | undefined
-  set(name: keyof F & string, value: unknown): void
-  update(partial: Partial<Record<keyof F & string, unknown>>): void
-  readonly values: Record<keyof F & string, unknown>
-  readonly fouls: Foul<F>[]
-  dispose(): void
-}
-```
+The returned object gives you `field()`, `foul()`, `set()`, `update()`, `values`, `fouls`, and `dispose()`.
 
 ### When to pick which
 
-- Choose `useUmpire()` when one component owns the form state and wants snapshot-style derivation.
-- Choose `fromSolidStore()` when many child components should read from one shared Umpire instance.
-- Choose [`@umpire/signals/solid`](/umpire/adapters/signals/solid/) when you want the raw signal adapter surface without the Solid-specific wrapper package.
+- Choose `useUmpire()` when one component owns the values and just needs derived availability.
+- Choose `fromSolidStore()` when several children should read from one shared form state.
+- Choose [`@umpire/signals/solid`](/umpire/adapters/signals/solid/) when you want to work with `reactiveUmp()` directly.
 
 ## Notes
 
-- `@umpire/solid` does not use `@umpire/store`; Solid stores are a different integration shape.
-- `fromSolidStore()` uses `@umpire/signals` internally so field reads stay fine-grained.
-- Call `dispose()` for long-lived shared instances you create outside component cleanup.
+- If you create a long-lived shared instance outside component scope, call `dispose()` when you're done.

--- a/docs/src/content/docs/adapters/store.mdx
+++ b/docs/src/content/docs/adapters/store.mdx
@@ -64,4 +64,8 @@ See [Selection](/umpire/concepts/selection/) for the full breakdown of patterns.
 
 ## Signal-Based Stores
 
-Signal-first libraries like Jotai, Valtio, MobX, and Preact signals are not covered by this package. They do not expose the same `getState()/subscribe()` surface, so they belong in a different bridge layer alongside `@umpire/signals`.
+Signal-first libraries are not covered by this package because they do not expose the same `getState()/subscribe()` surface.
+
+- Solid has first-class shared-store support in [`@umpire/solid`](/umpire/adapters/solid/#fromsolidstore) via `fromSolidStore()`, which uses `@umpire/signals` under the hood.
+- Other signal-first libraries like Jotai, Valtio, MobX, and Preact signals usually fit best as thin adapters built on `@umpire/signals`, not as `@umpire/store` shims.
+- If you'd like to add one, a pull request is welcome.

--- a/docs/src/content/docs/concepts/availability.md
+++ b/docs/src/content/docs/concepts/availability.md
@@ -150,6 +150,7 @@ You still want live `check()` calls for interactions *within* a printer's option
 The adapter packages layer reactivity on top:
 
 - `@umpire/react` — a `useUmpire` hook that memoizes `check()` and tracks `prev` via `useRef`
+- `@umpire/solid` — `useUmpire()` for Solid components plus `fromSolidStore()` for shared Solid store/context state
 - `@umpire/signals` — signal-backed availability with fine-grained proxy tracking
 - `@umpire/store` — strict store adapter foundation for `getState()` + `subscribe((next, prev) => ...)`
 - `@umpire/zustand` — zero-shim entry point over `@umpire/store`

--- a/docs/src/content/docs/concepts/availability.md
+++ b/docs/src/content/docs/concepts/availability.md
@@ -150,7 +150,7 @@ You still want live `check()` calls for interactions *within* a printer's option
 The adapter packages layer reactivity on top:
 
 - `@umpire/react` — a `useUmpire` hook that memoizes `check()` and tracks `prev` via `useRef`
-- `@umpire/solid` — `useUmpire()` for Solid components plus `fromSolidStore()` for shared Solid store/context state
+- `@umpire/solid` — Solid adapter for component-local state or shared store-backed state
 - `@umpire/signals` — signal-backed availability with fine-grained proxy tracking
 - `@umpire/store` — strict store adapter foundation for `getState()` + `subscribe((next, prev) => ...)`
 - `@umpire/zustand` — zero-shim entry point over `@umpire/store`

--- a/docs/src/content/docs/droid-first.md
+++ b/docs/src/content/docs/droid-first.md
@@ -42,6 +42,17 @@ And `@umpire/react`:
   previous snapshot; the hook tracks that internally.
 ```
 
+And `@umpire/solid`:
+
+```
+- Use useUmpire(ump, values, conditions?) inside Solid
+  components when one reactive values object drives one subtree.
+- Use fromSolidStore(ump, { values, set, conditions? }) when
+  a shared Solid store or context should back one Umpire instance.
+- check() and fouls() are accessors; do not mirror them into
+  another store or recompute them in createEffect.
+```
+
 No prompt engineering required. Agents that look for `AGENTS.md` get the canonical file. Claude-oriented tooling still finds the compatibility rule file.
 
 ## What this means in practice
@@ -61,6 +72,7 @@ These are the exact mistakes that are easy to make and hard to debug. The packag
 | --- | --- | --- |
 | `@umpire/core` | `AGENTS.md` | Satisfaction semantics, `requires` vs `disables`, `check()` vs `play()` vs `challenge()` |
 | `@umpire/react` | `AGENTS.md` | `useUmpire()`, derived render-time availability, internal previous-snapshot tracking |
+| `@umpire/solid` | `AGENTS.md` | `useUmpire()`, `fromSolidStore()`, accessor-based reads, shared Solid-store integration |
 | `@umpire/signals` | `AGENTS.md` | `reactiveUmp()`, fine-grained reads, `effect()` requirement for fouls |
 | `@umpire/store` | `AGENTS.md` | Strict `fromStore()` contract, `select()` as the aggregation point |
 | `@umpire/zustand` | `AGENTS.md` | Native `fromStore()` fit, no manual previous-state bookkeeping |

--- a/docs/src/content/docs/droid-first.md
+++ b/docs/src/content/docs/droid-first.md
@@ -46,11 +46,11 @@ And `@umpire/solid`:
 
 ```
 - Use useUmpire(ump, values, conditions?) inside Solid
-  components when one reactive values object drives one subtree.
+  components for local state.
 - Use fromSolidStore(ump, { values, set, conditions? }) when
-  a shared Solid store or context should back one Umpire instance.
-- check() and fouls() are accessors; do not mirror them into
-  another store or recompute them in createEffect.
+  the form lives in shared store or context state.
+- check() and fouls() are accessors; read them directly instead
+  of mirroring them into other state.
 ```
 
 No prompt engineering required. Agents that look for `AGENTS.md` get the canonical file. Claude-oriented tooling still finds the compatibility rule file.
@@ -72,7 +72,7 @@ These are the exact mistakes that are easy to make and hard to debug. The packag
 | --- | --- | --- |
 | `@umpire/core` | `AGENTS.md` | Satisfaction semantics, `requires` vs `disables`, `check()` vs `play()` vs `challenge()` |
 | `@umpire/react` | `AGENTS.md` | `useUmpire()`, derived render-time availability, internal previous-snapshot tracking |
-| `@umpire/solid` | `AGENTS.md` | `useUmpire()`, `fromSolidStore()`, accessor-based reads, shared Solid-store integration |
+| `@umpire/solid` | `AGENTS.md` | `useUmpire()`, `fromSolidStore()`, direct accessor reads, shared store integration |
 | `@umpire/signals` | `AGENTS.md` | `reactiveUmp()`, fine-grained reads, `effect()` requirement for fouls |
 | `@umpire/store` | `AGENTS.md` | Strict `fromStore()` contract, `select()` as the aggregation point |
 | `@umpire/zustand` | `AGENTS.md` | Native `fromStore()` fit, no manual previous-state bookkeeping |

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -235,7 +235,7 @@ Umpire is intentionally small — it handles availability so you can handle ever
 npm install @umpire/core
 ```
 
-Use `@umpire/core` when you just need pure availability logic. Add `@umpire/react`, `@umpire/signals`, `@umpire/store`, or a store-specific entry point like `@umpire/zustand`, `@umpire/redux`, `@umpire/pinia`, `@umpire/tanstack-store`, or `@umpire/vuex` when you want an adapter on top.
+Use `@umpire/core` when you just need pure availability logic. Add `@umpire/react`, `@umpire/solid`, `@umpire/signals`, `@umpire/store`, or a store-specific entry point like `@umpire/zustand`, `@umpire/redux`, `@umpire/pinia`, `@umpire/tanstack-store`, or `@umpire/vuex` when you want an adapter on top.
 
 <div class="umpire-divider"></div>
 

--- a/docs/src/content/docs/learn.mdx
+++ b/docs/src/content/docs/learn.mdx
@@ -20,7 +20,7 @@ This page teaches one Umpire primitive at a time. Each section shows the smalles
 yarn add @umpire/core
 ```
 
-Add `@umpire/react` when you want the snapshot-tracking hook used in the final `play()` example.
+Add `@umpire/react` or `@umpire/solid` when you want a UI adapter on top of the pure core. The final `play()` example on this page uses React, but the same snapshot-style pattern exists in Solid.
 
 **No bundler?** Both packages ship browser-ready IIFE and ESM builds. Load them via CDN and the globals are ready to use:
 

--- a/docs/src/content/docs/learn.mdx
+++ b/docs/src/content/docs/learn.mdx
@@ -20,7 +20,7 @@ This page teaches one Umpire primitive at a time. Each section shows the smalles
 yarn add @umpire/core
 ```
 
-Add `@umpire/react` or `@umpire/solid` when you want a UI adapter on top of the pure core. The final `play()` example on this page uses React, but the same snapshot-style pattern exists in Solid.
+Add `@umpire/react` or `@umpire/solid` when you want a UI adapter on top of the pure core.
 
 **No bundler?** Both packages ship browser-ready IIFE and ESM builds. Load them via CDN and the globals are ready to use:
 

--- a/packages/signals/src/adapters/solid.ts
+++ b/packages/signals/src/adapters/solid.ts
@@ -7,11 +7,11 @@ import type { SignalProtocol } from '../protocol.js'
 import { createSignal, createMemo, createEffect, createRoot, onCleanup, batch } from 'solid-js'
 
 export const solidAdapter: SignalProtocol = {
-  signal(initial) {
-    const [get, set] = createSignal(initial)
+  signal<T>(initial: T) {
+    const [get, set] = createSignal<T>(initial)
     return {
       get,
-      set: (v: unknown) => set(() => v),
+      set: (value: T) => set(() => value),
     }
   },
   computed(fn) {

--- a/packages/solid/.claude/rules/umpire-solid.md
+++ b/packages/solid/.claude/rules/umpire-solid.md
@@ -1,0 +1,7 @@
+# @umpire/solid
+
+- Use `useUmpire(ump, values, conditions?)` to derive availability inside Solid components.
+- `values` and `conditions` are accessors.
+- The hook returns `{ check, fouls }`, and both are accessors.
+- `check()` is derived reactively; do not mirror it into store state or recompute it in `createEffect`.
+- `fouls()` are transition-time recommendations from the previous snapshot; the hook handles snapshot tracking internally.

--- a/packages/solid/.claude/rules/umpire-solid.md
+++ b/packages/solid/.claude/rules/umpire-solid.md
@@ -1,6 +1,7 @@
 # @umpire/solid
 
 - Use `useUmpire(ump, values, conditions?)` to derive availability inside Solid components.
+- Use `fromSolidStore(ump, { values, set, conditions? })` when a shared Solid store/context should back one Umpire instance for many children.
 - `values` and `conditions` are accessors.
 - The hook returns `{ check, fouls }`, and both are accessors.
 - `check()` is derived reactively; do not mirror it into store state or recompute it in `createEffect`.

--- a/packages/solid/AGENTS.md
+++ b/packages/solid/AGENTS.md
@@ -1,0 +1,7 @@
+# @umpire/solid
+
+- Use `useUmpire(ump, values, conditions?)` to derive availability inside Solid components.
+- `values` and `conditions` are accessors.
+- The hook returns `{ check, fouls }`, and both are accessors.
+- `check()` is derived reactively; do not mirror it into store state or recompute it in `createEffect`.
+- `fouls()` are transition-time recommendations from the previous snapshot; the hook handles snapshot tracking internally.

--- a/packages/solid/AGENTS.md
+++ b/packages/solid/AGENTS.md
@@ -1,6 +1,7 @@
 # @umpire/solid
 
 - Use `useUmpire(ump, values, conditions?)` to derive availability inside Solid components.
+- Use `fromSolidStore(ump, { values, set, conditions? })` when a shared Solid store/context should back one Umpire instance for many children.
 - `values` and `conditions` are accessors.
 - The hook returns `{ check, fouls }`, and both are accessors.
 - `check()` is derived reactively; do not mirror it into store state or recompute it in `createEffect`.

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### Minor Changes
 
 - Initial release: `useUmpire()` hook for Solid with accessor-based inputs and outputs
+- Added `fromSolidStore()` for shared Solid store/context integrations

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @umpire/solid
+
+## 0.1.0-alpha.9
+
+### Minor Changes
+
+- Initial release: `useUmpire()` hook for Solid with accessor-based inputs and outputs

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,6 +1,6 @@
 # @umpire/solid
 
-Solid component adapter for deriving Umpire availability and reset recommendations from reactive state.
+Solid adapter package for deriving Umpire availability from reactive state, whether the state is local to one component or shared through a Solid store/context boundary.
 
 [Docs](https://sdougbrown.github.io/umpire/)
 
@@ -10,7 +10,7 @@ Solid component adapter for deriving Umpire availability and reset recommendatio
 npm install @umpire/solid @umpire/core solid-js
 ```
 
-## Usage
+## `useUmpire()`
 
 ```ts
 import { createStore } from 'solid-js/store'
@@ -58,6 +58,52 @@ function SignupForm() {
 
 `useUmpire()` stays deliberately thin. It reads values through accessors, derives `check()` and `fouls()` together, and tracks the previous snapshot internally so consumers do not need their own `createEffect` bookkeeping.
 
+## `fromSolidStore()`
+
+Use `fromSolidStore()` when one shared Solid store should back a single Umpire instance for many children.
+
+```ts
+import { createSignal } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { enabledWhen, umpire } from '@umpire/core'
+import { fromSolidStore } from '@umpire/solid'
+
+const eventUmp = umpire({
+  fields: {
+    allDay: { default: false },
+    startTime: { default: '' },
+    endTime: { default: '' },
+  },
+  rules: [
+    enabledWhen('startTime', (values) => !values.allDay),
+    enabledWhen('endTime', (values) => !values.allDay),
+  ],
+})
+
+const [values, setValues] = createStore({
+  allDay: false,
+  startTime: '09:00',
+  endTime: '10:00',
+})
+
+const [tier] = createSignal<'free' | 'pro'>('pro')
+
+const form = fromSolidStore(eventUmp, {
+  values,
+  set: (name, value) => setValues(name, value),
+  conditions: {
+    tier,
+  },
+})
+
+form.field('startTime').enabled
+form.fouls
+form.set('allDay', true)
+form.update({ startTime: '', endTime: '' })
+```
+
+`fromSolidStore()` is the shared-form option. It builds on the signal adapter internally, so child components can read `field(name)` without each mounting their own snapshot hook.
+
 ## Returned Shape
 
 ```ts
@@ -68,12 +114,23 @@ const { check, fouls } = useUmpire(ump, values, conditions)
 // fouls(): Foul[]
 ```
 
+```ts
+const form = fromSolidStore(ump, { values, set, conditions })
+// form.field('fieldName').enabled
+// form.foul('fieldName')
+// form.values
+// form.fouls
+// form.set('fieldName', nextValue)
+// form.update({ fieldName: nextValue })
+// form.dispose()
+```
+
 ## Notes
 
 - `values` and `conditions` are accessors, not plain objects.
 - `check()` and `fouls()` are accessors, not plain values.
 - Do not mirror `check()` into another store or recompute Umpire inside `createEffect`.
-- Use `@umpire/signals` when you want fine-grained field-level reactive reads rather than a component-level snapshot adapter.
+- Use `fromSolidStore()` when a shared Solid store or context should drive one Umpire instance for many children.
 
 ## Docs
 

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,80 @@
+# @umpire/solid
+
+Solid component adapter for deriving Umpire availability and reset recommendations from reactive state.
+
+[Docs](https://sdougbrown.github.io/umpire/)
+
+## Install
+
+```bash
+npm install @umpire/solid @umpire/core solid-js
+```
+
+## Usage
+
+```ts
+import { createStore } from 'solid-js/store'
+import { enabledWhen, requires, umpire } from '@umpire/core'
+import { useUmpire } from '@umpire/solid'
+
+const signupUmp = umpire({
+  fields: {
+    email:           { required: true, isEmpty: (v) => !v },
+    password:        { required: true, isEmpty: (v) => !v },
+    confirmPassword: { required: true, isEmpty: (v) => !v },
+    companyName:     {},
+    companySize:     {},
+  },
+  rules: [
+    requires('confirmPassword', 'password'),
+    enabledWhen('companyName', (_values, conditions) => conditions.plan === 'business', {
+      reason: 'business plan required',
+    }),
+    enabledWhen('companySize', (_values, conditions) => conditions.plan === 'business', {
+      reason: 'business plan required',
+    }),
+    requires('companySize', 'companyName'),
+  ],
+})
+
+function SignupForm() {
+  const [values] = createStore({
+    email: '',
+    password: '',
+    confirmPassword: '',
+    companyName: '',
+    companySize: '',
+  })
+
+  const { check, fouls } = useUmpire(signupUmp, () => values, () => ({ plan: 'business' as const }))
+
+  check().companyName.enabled
+  check().companyName.reason
+  fouls()
+
+  return null
+}
+```
+
+`useUmpire()` stays deliberately thin. It reads values through accessors, derives `check()` and `fouls()` together, and tracks the previous snapshot internally so consumers do not need their own `createEffect` bookkeeping.
+
+## Returned Shape
+
+```ts
+const { check, fouls } = useUmpire(ump, values, conditions)
+// check().fieldName.enabled
+// check().fieldName.fair
+// check().fieldName.reason
+// fouls(): Foul[]
+```
+
+## Notes
+
+- `values` and `conditions` are accessors, not plain objects.
+- `check()` and `fouls()` are accessors, not plain values.
+- Do not mirror `check()` into another store or recompute Umpire inside `createEffect`.
+- Use `@umpire/signals` when you want fine-grained field-level reactive reads rather than a component-level snapshot adapter.
+
+## Docs
+
+https://sdougbrown.github.io/umpire/

--- a/packages/solid/__tests__/fromSolidStore.test.ts
+++ b/packages/solid/__tests__/fromSolidStore.test.ts
@@ -1,6 +1,7 @@
 import { createRoot, createSignal } from 'solid-js'
 import { enabledWhen, umpire } from '@umpire/core'
 import type { FieldDef } from '@umpire/core'
+import { solidAdapter } from '@umpire/signals/solid'
 import { fromSolidStore } from '../src/fromSolidStore.js'
 
 function withRoot<T>(run: () => T) {
@@ -73,9 +74,72 @@ describe('fromSolidStore', () => {
       value.setName('')
 
       expect(value.form.field('phone').enabled).toBe(false)
+    } finally {
+      value.form.dispose()
+      dispose()
+    }
+  })
+
+  it('tracks foul transitions from shared reactive values', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [name, setName] = createSignal('Alice')
+      const [email, setEmail] = createSignal('')
+      const [phone, setPhone] = createSignal('555-1234')
+
+      const values = {
+        get name() {
+          return name()
+        },
+        get email() {
+          return email()
+        },
+        get phone() {
+          return phone()
+        },
+      }
+
+      const set = (field: keyof typeof fields & string, next: unknown) => {
+        switch (field) {
+          case 'name':
+            setName(String(next))
+            return
+          case 'email':
+            setEmail(String(next))
+            return
+          case 'phone':
+            setPhone(String(next))
+            return
+        }
+      }
+
+      return {
+        setName,
+        form: fromSolidStore(ump, { values, set }),
+      }
+    })
+
+    try {
+      expect(value.form.fouls).toEqual([])
+
+      value.setName('')
+
+      expect(value.form.field('phone').enabled).toBe(false)
       expect(value.form.fouls).toHaveLength(1)
       expect(value.form.fouls[0].field).toBe('phone')
-      expect(value.form.foul('phone')?.field).toBe('phone')
+      expect(value.form.foul('phone')?.suggestedValue).toBe('')
+
+      value.setName('Alice')
+
+      expect(value.form.field('phone').enabled).toBe(true)
+      expect(value.form.fouls).toEqual([])
+      expect(value.form.foul('phone')).toBeUndefined()
     } finally {
       value.form.dispose()
       dispose()
@@ -205,6 +269,81 @@ describe('fromSolidStore', () => {
     } finally {
       value.form.dispose()
       dispose()
+    }
+  })
+
+  it('dispose() cleans up Solid effect tracking once', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+
+    const originalEffect = solidAdapter.effect
+    if (!originalEffect) {
+      throw new Error('solidAdapter.effect is required for this test')
+    }
+
+    let disposeCalls = 0
+    solidAdapter.effect = (fn) => {
+      const disposeEffect = originalEffect(fn)
+      return () => {
+        disposeCalls += 1
+        disposeEffect()
+      }
+    }
+
+    try {
+      const { value, dispose } = withRoot(() => {
+        const [name, setName] = createSignal('Alice')
+        const [email, setEmail] = createSignal('')
+        const [phone, setPhone] = createSignal('555-1234')
+
+        const values = {
+          get name() {
+            return name()
+          },
+          get email() {
+            return email()
+          },
+          get phone() {
+            return phone()
+          },
+        }
+
+        const set = (field: keyof typeof fields & string, next: unknown) => {
+          switch (field) {
+            case 'name':
+              setName(String(next))
+              return
+            case 'email':
+              setEmail(String(next))
+              return
+            case 'phone':
+              setPhone(String(next))
+              return
+          }
+        }
+
+        return {
+          setName,
+          form: fromSolidStore(ump, { values, set }),
+        }
+      })
+
+      try {
+        value.form.dispose()
+        value.form.dispose()
+        value.setName('')
+
+        expect(disposeCalls).toBe(1)
+        expect(value.form.field('phone').enabled).toBe(false)
+      } finally {
+        dispose()
+      }
+    } finally {
+      solidAdapter.effect = originalEffect
     }
   })
 })

--- a/packages/solid/__tests__/fromSolidStore.test.ts
+++ b/packages/solid/__tests__/fromSolidStore.test.ts
@@ -1,0 +1,210 @@
+import { createRoot, createSignal } from 'solid-js'
+import { enabledWhen, umpire } from '@umpire/core'
+import type { FieldDef } from '@umpire/core'
+import { fromSolidStore } from '../src/fromSolidStore.js'
+
+function withRoot<T>(run: () => T) {
+  let value!: T
+  let dispose!: () => void
+
+  createRoot((rootDispose) => {
+    dispose = rootDispose
+    value = run()
+  })
+
+  return { value, dispose }
+}
+
+const fields = {
+  name: { default: '' },
+  email: { default: '' },
+  phone: { default: '' },
+} satisfies Record<string, FieldDef>
+
+describe('fromSolidStore', () => {
+  it('derives field availability from shared reactive values', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [name, setName] = createSignal('Alice')
+      const [email, setEmail] = createSignal('')
+      const [phone, setPhone] = createSignal('555-1234')
+
+      const values = {
+        get name() {
+          return name()
+        },
+        get email() {
+          return email()
+        },
+        get phone() {
+          return phone()
+        },
+      }
+
+      const set = (field: keyof typeof fields & string, next: unknown) => {
+        switch (field) {
+          case 'name':
+            setName(String(next))
+            return
+          case 'email':
+            setEmail(String(next))
+            return
+          case 'phone':
+            setPhone(String(next))
+            return
+        }
+      }
+
+      return {
+        setName,
+        form: fromSolidStore(ump, { values, set }),
+      }
+    })
+
+    try {
+      expect(value.form.field('phone').enabled).toBe(true)
+
+      value.setName('')
+
+      expect(value.form.field('phone').enabled).toBe(false)
+      expect(value.form.fouls).toHaveLength(1)
+      expect(value.form.fouls[0].field).toBe('phone')
+      expect(value.form.foul('phone')?.field).toBe('phone')
+    } finally {
+      value.form.dispose()
+      dispose()
+    }
+  })
+
+  it('writes back through set() and update()', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [name, setName] = createSignal('Alice')
+      const [email, setEmail] = createSignal('')
+      const [phone, setPhone] = createSignal('')
+
+      const values = {
+        get name() {
+          return name()
+        },
+        get email() {
+          return email()
+        },
+        get phone() {
+          return phone()
+        },
+      }
+
+      const set = (field: keyof typeof fields & string, next: unknown) => {
+        switch (field) {
+          case 'name':
+            setName(String(next))
+            return
+          case 'email':
+            setEmail(String(next))
+            return
+          case 'phone':
+            setPhone(String(next))
+            return
+        }
+      }
+
+      return {
+        name,
+        email,
+        phone,
+        form: fromSolidStore(ump, { values, set }),
+      }
+    })
+
+    try {
+      value.form.set('name', 'Bob')
+      value.form.update({ email: 'bob@example.com', phone: '555-0000' })
+
+      expect(value.name()).toBe('Bob')
+      expect(value.email()).toBe('bob@example.com')
+      expect(value.phone()).toBe('555-0000')
+      expect(value.form.values.name).toBe('Bob')
+      expect(value.form.values.email).toBe('bob@example.com')
+    } finally {
+      value.form.dispose()
+      dispose()
+    }
+  })
+
+  it('supports fine-grained condition accessors', () => {
+    type Conditions = { premium: boolean }
+
+    const premiumFields = {
+      advanced: { default: '' },
+      basic: { default: '' },
+    } satisfies Record<string, FieldDef>
+
+    const ump = umpire<typeof premiumFields, Conditions>({
+      fields: premiumFields,
+      rules: [
+        enabledWhen('advanced', (_values, conditions) => conditions.premium),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [advanced, setAdvanced] = createSignal('')
+      const [basic, setBasic] = createSignal('')
+      const [premium, setPremium] = createSignal(false)
+
+      const values = {
+        get advanced() {
+          return advanced()
+        },
+        get basic() {
+          return basic()
+        },
+      }
+
+      const set = (field: keyof typeof premiumFields & string, next: unknown) => {
+        switch (field) {
+          case 'advanced':
+            setAdvanced(String(next))
+            return
+          case 'basic':
+            setBasic(String(next))
+            return
+        }
+      }
+
+      return {
+        setPremium,
+        form: fromSolidStore(ump, {
+          values,
+          set,
+          conditions: {
+            premium,
+          },
+        }),
+      }
+    })
+
+    try {
+      expect(value.form.field('advanced').enabled).toBe(false)
+
+      value.setPremium(true)
+
+      expect(value.form.field('advanced').enabled).toBe(true)
+    } finally {
+      value.form.dispose()
+      dispose()
+    }
+  })
+})

--- a/packages/solid/__tests__/snapshot.test.ts
+++ b/packages/solid/__tests__/snapshot.test.ts
@@ -1,0 +1,39 @@
+import { snapshotRecord } from '../src/snapshot.js'
+
+describe('snapshotRecord', () => {
+  it('clones nested arrays and objects', () => {
+    const original = {
+      settings: {
+        weekdays: ['Mon', 'Wed'],
+      },
+    }
+
+    const snapshot = snapshotRecord(original)
+
+    original.settings.weekdays.push('Fri')
+
+    expect(snapshot).toEqual({
+      settings: {
+        weekdays: ['Mon', 'Wed'],
+      },
+    })
+  })
+
+  it('clones maps, sets, and dates', () => {
+    const original = {
+      seen: new Set(['a', 'b']),
+      lookup: new Map([['mode', 'weekly']]),
+      start: new Date('2025-01-01T00:00:00.000Z'),
+    }
+
+    const snapshot = snapshotRecord(original)
+
+    original.seen.add('c')
+    original.lookup.set('mode', 'monthly')
+    original.start.setUTCDate(2)
+
+    expect(Array.from(snapshot.seen)).toEqual(['a', 'b'])
+    expect(Array.from(snapshot.lookup.entries())).toEqual([['mode', 'weekly']])
+    expect(snapshot.start.toISOString()).toBe('2025-01-01T00:00:00.000Z')
+  })
+})

--- a/packages/solid/__tests__/useUmpire.test.ts
+++ b/packages/solid/__tests__/useUmpire.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, spyOn } from 'bun:test'
 import { createRoot, createSignal } from 'solid-js'
 import { enabledWhen, oneOf, requires, umpire } from '@umpire/core'
 import type { FieldDef } from '@umpire/core'
@@ -89,6 +90,29 @@ describe('useUmpire', () => {
 
     try {
       expect(value.fouls()).toEqual([])
+    } finally {
+      dispose()
+    }
+  })
+
+  it('computes check once on mount', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+    const checkSpy = spyOn(ump, 'check')
+
+    const { value, dispose } = withRoot(() => {
+      const [values] = createSignal({ name: 'Alice', email: '', phone: '' })
+      return useUmpire(ump, values)
+    })
+
+    try {
+      expect(checkSpy).toHaveBeenCalledTimes(1)
+      expect(value.check().phone.enabled).toBe(true)
+      expect(checkSpy).toHaveBeenCalledTimes(1)
     } finally {
       dispose()
     }

--- a/packages/solid/__tests__/useUmpire.test.ts
+++ b/packages/solid/__tests__/useUmpire.test.ts
@@ -1,0 +1,231 @@
+import { createRoot, createSignal } from 'solid-js'
+import { enabledWhen, oneOf, requires, umpire } from '@umpire/core'
+import type { FieldDef } from '@umpire/core'
+import { useUmpire } from '../src/useUmpire.js'
+
+function withRoot<T>(run: () => T) {
+  let value!: T
+  let dispose!: () => void
+
+  createRoot((rootDispose) => {
+    dispose = rootDispose
+    value = run()
+  })
+
+  return {
+    value,
+    dispose,
+  }
+}
+
+const fields = {
+  name: { default: '' },
+  email: { default: '' },
+  phone: { default: '' },
+} satisfies Record<string, FieldDef>
+
+describe('useUmpire', () => {
+  it('returns check with correct availability', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [values] = createSignal({ name: 'Alice', email: '', phone: '' })
+      return useUmpire(ump, values)
+    })
+
+    try {
+      expect(value.check().phone.enabled).toBe(true)
+      expect(value.check().name.enabled).toBe(true)
+      expect(value.check().email.enabled).toBe(true)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('recomputes check when values change', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [values, setValues] = createSignal({ name: '', email: '', phone: '' })
+      return {
+        setValues,
+        ...useUmpire(ump, values),
+      }
+    })
+
+    try {
+      expect(value.check().phone.enabled).toBe(false)
+
+      value.setValues({ name: 'Alice', email: '', phone: '' })
+
+      expect(value.check().phone.enabled).toBe(true)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('returns empty fouls on first read', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [values] = createSignal({ name: 'Alice', email: '', phone: '555-1234' })
+      return useUmpire(ump, values)
+    })
+
+    try {
+      expect(value.fouls()).toEqual([])
+    } finally {
+      dispose()
+    }
+  })
+
+  it('returns fouls when a field transitions from enabled to disabled', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [values, setValues] = createSignal({ name: 'Alice', email: '', phone: '555-1234' })
+      return {
+        setValues,
+        ...useUmpire(ump, values),
+      }
+    })
+
+    try {
+      expect(value.fouls()).toEqual([])
+
+      value.setValues({ name: '', email: '', phone: '555-1234' })
+
+      expect(value.fouls()).toHaveLength(1)
+      expect(value.fouls()[0].field).toBe('phone')
+    } finally {
+      dispose()
+    }
+  })
+
+  it('passes conditions to check', () => {
+    type Conditions = { premium: boolean }
+
+    const premiumFields = {
+      advanced: { default: '' },
+      basic: { default: '' },
+    } satisfies Record<string, FieldDef>
+
+    const ump = umpire<typeof premiumFields, Conditions>({
+      fields: premiumFields,
+      rules: [
+        enabledWhen('advanced', (_values, conditions) => conditions.premium),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [values] = createSignal({ advanced: '', basic: '' })
+      const [conditions, setConditions] = createSignal<Conditions>({ premium: false })
+      return {
+        setConditions,
+        ...useUmpire(ump, values, conditions),
+      }
+    })
+
+    try {
+      expect(value.check().advanced.enabled).toBe(false)
+
+      value.setConditions({ premium: true })
+
+      expect(value.check().advanced.enabled).toBe(true)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('passes previous values to check for oneOf resolution', () => {
+    const isEmpty = (value: unknown) => value === '' || value === undefined || value === null
+    const oneOfFields = {
+      date: { default: '', isEmpty },
+      time: { default: '', isEmpty },
+      weekday: { default: '', isEmpty },
+    } satisfies Record<string, FieldDef>
+
+    const ump = umpire({
+      fields: oneOfFields,
+      rules: [
+        oneOf('schedule', {
+          specific: ['date', 'time'],
+          recurring: ['weekday'],
+        }),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [values, setValues] = createSignal({ date: '', time: '', weekday: '' })
+      return {
+        setValues,
+        ...useUmpire(ump, values),
+      }
+    })
+
+    try {
+      expect(value.check().date.enabled).toBe(true)
+      expect(value.check().time.enabled).toBe(true)
+      expect(value.check().weekday.enabled).toBe(true)
+
+      value.setValues({ date: '2025-01-01', time: '', weekday: '' })
+
+      expect(value.check().date.enabled).toBe(true)
+      expect(value.check().time.enabled).toBe(true)
+      expect(value.check().weekday.enabled).toBe(false)
+
+      value.setValues({ date: '', time: '', weekday: 'Monday' })
+
+      expect(value.check().weekday.enabled).toBe(true)
+      expect(value.check().date.enabled).toBe(false)
+      expect(value.check().time.enabled).toBe(false)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('keeps foul reads stable when nothing changes', () => {
+    const ump = umpire({
+      fields,
+      rules: [
+        enabledWhen('phone', (values) => !!values.name),
+        requires('email', 'name'),
+      ],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [values] = createSignal({ name: 'Alice', email: '', phone: '' })
+      return useUmpire(ump, values)
+    })
+
+    try {
+      const first = value.fouls()
+      const second = value.fouls()
+
+      expect(first).toBe(second)
+      expect(second).toEqual([])
+    } finally {
+      dispose()
+    }
+  })
+})

--- a/packages/solid/bunfig.toml
+++ b/packages/solid/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+preload = ["../../test/preload-workspace-aliases.ts", "./test-setup.ts"]
+coverageSkipTestFiles = true

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -25,8 +25,7 @@
     ".claude"
   ],
   "dependencies": {
-    "@umpire/core": "workspace:^",
-    "@umpire/signals": "workspace:^"
+    "@umpire/core": "workspace:^"
   },
   "peerDependencies": {
     "solid-js": "^1.0.0"
@@ -40,6 +39,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@umpire/signals": "workspace:^",
     "solid-js": "^1.0.0",
     "tsdown": "^0.21.7"
   }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@umpire/solid",
+  "version": "0.1.0-alpha.9",
+  "description": "Solid component adapter for @umpire/core",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "browser": "./dist/index.browser.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "browser": "./dist/index.browser.js",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc && tsdown",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist",
+    "AGENTS.md",
+    ".claude"
+  ],
+  "dependencies": {
+    "@umpire/core": "workspace:^"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "directory": "packages/solid"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "solid-js": "^1.0.0",
+    "tsdown": "^0.21.7"
+  }
+}

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -25,7 +25,8 @@
     ".claude"
   ],
   "dependencies": {
-    "@umpire/core": "workspace:^"
+    "@umpire/core": "workspace:^",
+    "@umpire/signals": "workspace:^"
   },
   "peerDependencies": {
     "solid-js": "^1.0.0"

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -25,7 +25,8 @@
     ".claude"
   ],
   "dependencies": {
-    "@umpire/core": "workspace:^"
+    "@umpire/core": "workspace:^",
+    "@umpire/signals": "workspace:^"
   },
   "peerDependencies": {
     "solid-js": "^1.0.0"
@@ -39,7 +40,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@umpire/signals": "workspace:^",
     "solid-js": "^1.0.0",
     "tsdown": "^0.21.7"
   }

--- a/packages/solid/src/fromSolidStore.ts
+++ b/packages/solid/src/fromSolidStore.ts
@@ -1,0 +1,55 @@
+import type { Accessor } from 'solid-js'
+import type { FieldDef, InputValues, Umpire } from '@umpire/core'
+import {
+  reactiveUmp,
+  type ReactiveUmpOptions,
+  type ReactiveUmpire,
+} from '@umpire/signals'
+import { solidAdapter } from '@umpire/signals/solid'
+
+export type FromSolidStoreOptions<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+> = {
+  values: InputValues<F>
+  set(name: keyof F & string, value: unknown): void
+  conditions?: Partial<{ [K in keyof C & string]: Accessor<C[K]> }>
+}
+
+export type SolidStoreUmpire<F extends Record<string, FieldDef>> = ReactiveUmpire<F>
+
+export function fromSolidStore<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  ump: Umpire<F, C>,
+  options: FromSolidStoreOptions<F, C>,
+): SolidStoreUmpire<F> {
+  const fieldNames = ump.graph().nodes as Array<keyof F & string>
+
+  const signals = Object.fromEntries(
+    fieldNames.map((name) => [
+      name,
+      {
+        get: () => options.values[name],
+        set: (value: unknown) => options.set(name, value),
+      },
+    ]),
+  ) as NonNullable<ReactiveUmpOptions<F>['signals']>
+
+  let conditions: NonNullable<ReactiveUmpOptions<F>['conditions']> | undefined
+  if (options.conditions) {
+    conditions = {}
+    for (const [name, accessor] of Object.entries(options.conditions)) {
+      if (!accessor) {
+        continue
+      }
+      conditions[name] = { get: accessor as Accessor<unknown> }
+    }
+  }
+
+  return reactiveUmp(ump, solidAdapter, {
+    signals,
+    conditions,
+  })
+}

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,0 +1,1 @@
+export { useUmpire } from './useUmpire.js'

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,1 +1,6 @@
+export { fromSolidStore } from './fromSolidStore.js'
+export type {
+  FromSolidStoreOptions,
+  SolidStoreUmpire,
+} from './fromSolidStore.js'
 export { useUmpire } from './useUmpire.js'

--- a/packages/solid/src/snapshot.ts
+++ b/packages/solid/src/snapshot.ts
@@ -1,0 +1,52 @@
+function snapshotValue(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime())
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => snapshotValue(entry))
+  }
+
+  if (value instanceof Map) {
+    return new Map(
+      Array.from(value.entries(), ([key, entry]) => [snapshotValue(key), snapshotValue(entry)]),
+    )
+  }
+
+  if (value instanceof Set) {
+    return new Set(Array.from(value.values(), (entry) => snapshotValue(entry)))
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype === Object.prototype || prototype === null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, snapshotValue(entry)]),
+    )
+  }
+
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(value)
+    } catch {
+      return value
+    }
+  }
+
+  return value
+}
+
+export function snapshotRecord<T extends Record<string, unknown> | undefined>(
+  value: T,
+): T {
+  if (!value) {
+    return value
+  }
+
+  return Object.fromEntries(
+    Object.keys(value).map((key) => [key, snapshotValue(value[key])]),
+  ) as T
+}

--- a/packages/solid/src/useUmpire.ts
+++ b/packages/solid/src/useUmpire.ts
@@ -1,0 +1,50 @@
+import { batch, createComputed, createSignal, type Accessor } from 'solid-js'
+import type {
+  AvailabilityMap,
+  FieldDef,
+  Foul,
+  InputValues,
+  Snapshot,
+  Umpire,
+} from '@umpire/core'
+import { snapshotRecord } from './snapshot.js'
+
+export function useUmpire<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  ump: Umpire<F, C>,
+  values: Accessor<InputValues<F>>,
+  conditions?: Accessor<C>,
+): {
+  check: Accessor<AvailabilityMap<F>>
+  fouls: Accessor<Foul<F>[]>
+} {
+  const initialValues = snapshotRecord(values())
+  const initialConditions = snapshotRecord(conditions?.())
+  const [check, setCheck] = createSignal(
+    ump.check(initialValues, initialConditions),
+  )
+  const [fouls, setFouls] = createSignal<Foul<F>[]>([])
+  let previousSnapshot: Snapshot<F, C> | undefined
+
+  createComputed(() => {
+    const currentValues = snapshotRecord(values())
+    const currentConditions = snapshotRecord(conditions?.())
+    const nextCheck = ump.check(currentValues, currentConditions, previousSnapshot?.values)
+    const nextFouls = previousSnapshot
+      ? ump.play(previousSnapshot, { values: currentValues, conditions: currentConditions })
+      : []
+
+    batch(() => {
+      setCheck(() => nextCheck)
+      setFouls(() => nextFouls)
+      previousSnapshot = {
+        values: currentValues,
+        conditions: currentConditions,
+      }
+    })
+  })
+
+  return { check, fouls }
+}

--- a/packages/solid/src/useUmpire.ts
+++ b/packages/solid/src/useUmpire.ts
@@ -20,11 +20,7 @@ export function useUmpire<
   check: Accessor<AvailabilityMap<F>>
   fouls: Accessor<Foul<F>[]>
 } {
-  const initialValues = snapshotRecord(values())
-  const initialConditions = snapshotRecord(conditions?.())
-  const [check, setCheck] = createSignal(
-    ump.check(initialValues, initialConditions),
-  )
+  const [currentCheck, setCheck] = createSignal<AvailabilityMap<F>>()
   const [fouls, setFouls] = createSignal<Foul<F>[]>([])
   let previousSnapshot: Snapshot<F, C> | undefined
 
@@ -45,6 +41,8 @@ export function useUmpire<
       }
     })
   })
+
+  const check: Accessor<AvailabilityMap<F>> = () => currentCheck()!
 
   return { check, fouls }
 }

--- a/packages/solid/test-setup.ts
+++ b/packages/solid/test-setup.ts
@@ -1,0 +1,7 @@
+import { mock } from 'bun:test'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+mock.module('solid-js', () => require('solid-js/dist/solid.cjs'))
+mock.module('solid-js/store', () => require('solid-js/store/dist/store.cjs'))

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -8,5 +8,5 @@
     "jsxImportSource": "solid-js"
   },
   "include": ["src"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../signals" }]
 }

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/solid/tsdown.config.ts
+++ b/packages/solid/tsdown.config.ts
@@ -6,7 +6,10 @@ export default defineConfig([
     entry: { 'index.browser': 'src/index.ts' },
     format: ['esm'],
     platform: 'browser',
-    deps: { neverBundle: ['solid-js', '@umpire/core'] },
+    deps: {
+      neverBundle: ['solid-js', '@umpire/core'],
+      alwaysBundle: ['@umpire/signals', '@umpire/signals/solid'],
+    },
     outDir: 'dist',
     clean: false,
     dts: false,
@@ -19,7 +22,10 @@ export default defineConfig([
     format: ['iife'],
     globalName: 'UmpireSolid',
     platform: 'browser',
-    deps: { neverBundle: ['solid-js', '@umpire/core'] },
+    deps: {
+      neverBundle: ['solid-js', '@umpire/core'],
+      alwaysBundle: ['@umpire/signals', '@umpire/signals/solid'],
+    },
     outputOptions: {
       globals: { 'solid-js': 'Solid', '@umpire/core': 'Umpire' },
     },

--- a/packages/solid/tsdown.config.ts
+++ b/packages/solid/tsdown.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig([
+  // Externalized ESM — user provides Solid + core
+  {
+    entry: { 'index.browser': 'src/index.ts' },
+    format: ['esm'],
+    platform: 'browser',
+    deps: { neverBundle: ['solid-js', '@umpire/core'] },
+    outDir: 'dist',
+    clean: false,
+    dts: false,
+    minify: true,
+    sourcemap: true,
+  },
+  // Externalized IIFE — user provides Solid + core via script tags
+  {
+    entry: { 'index': 'src/index.ts' },
+    format: ['iife'],
+    globalName: 'UmpireSolid',
+    platform: 'browser',
+    deps: { neverBundle: ['solid-js', '@umpire/core'] },
+    outputOptions: {
+      globals: { 'solid-js': 'Solid', '@umpire/core': 'Umpire' },
+    },
+    outDir: 'dist',
+    clean: false,
+    dts: false,
+    minify: true,
+    sourcemap: true,
+  },
+])

--- a/packages/solid/tsdown.config.ts
+++ b/packages/solid/tsdown.config.ts
@@ -1,9 +1,12 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig([
-  // Externalized ESM — user provides Solid + core
+  // Bundled ESM — browser and import conditions resolve here
   {
-    entry: { 'index.browser': 'src/index.ts' },
+    entry: {
+      index: 'src/index.ts',
+      'index.browser': 'src/index.ts',
+    },
     format: ['esm'],
     platform: 'browser',
     deps: {
@@ -16,9 +19,9 @@ export default defineConfig([
     minify: true,
     sourcemap: true,
   },
-  // Externalized IIFE — user provides Solid + core via script tags
+  // Bundled IIFE — user provides Solid + core via script tags
   {
-    entry: { 'index': 'src/index.ts' },
+    entry: { index: 'src/index.ts' },
     format: ['iife'],
     globalName: 'UmpireSolid',
     platform: 'browser',

--- a/test/preload-workspace-aliases.ts
+++ b/test/preload-workspace-aliases.ts
@@ -10,6 +10,9 @@ if (process.env.BUN_DISABLE_WORKSPACE_MOCKS !== 'true') {
   mock.module('@umpire/react', () => require('../packages/react/src/index.js'))
   mock.module('@umpire/solid', () => require('../packages/solid/src/index.js'))
   mock.module('@umpire/signals', () => require('../packages/signals/src/index.js'))
+  mock.module('@umpire/signals/solid', () =>
+    require('../packages/signals/src/adapters/solid.js'),
+  )
   mock.module('@umpire/testing', () => require('../packages/testing/src/index.js'))
   mock.module('@umpire/zod', () => require('../packages/zod/src/index.js'))
   mock.module('@umpire/json', () => require('../packages/json/src/index.js'))

--- a/test/preload-workspace-aliases.ts
+++ b/test/preload-workspace-aliases.ts
@@ -8,6 +8,7 @@ if (process.env.BUN_DISABLE_WORKSPACE_MOCKS !== 'true') {
   mock.module('@umpire/store', () => require('../packages/store/src/index.js'))
   mock.module('@umpire/reads', () => require('../packages/reads/src/index.js'))
   mock.module('@umpire/react', () => require('../packages/react/src/index.js'))
+  mock.module('@umpire/solid', () => require('../packages/solid/src/index.js'))
   mock.module('@umpire/signals', () => require('../packages/signals/src/index.js'))
   mock.module('@umpire/testing', () => require('../packages/testing/src/index.js'))
   mock.module('@umpire/zod', () => require('../packages/zod/src/index.js'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1566,7 +1566,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@umpire/signals@workspace:packages/signals":
+"@umpire/signals@workspace:^, @umpire/signals@workspace:packages/signals":
   version: 0.0.0-use.local
   resolution: "@umpire/signals@workspace:packages/signals"
   dependencies:
@@ -1596,6 +1596,7 @@ __metadata:
   resolution: "@umpire/solid@workspace:packages/solid"
   dependencies:
     "@umpire/core": "workspace:^"
+    "@umpire/signals": "workspace:^"
     solid-js: "npm:^1.0.0"
     tsdown: "npm:^0.21.7"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,6 +1591,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@umpire/solid@workspace:packages/solid":
+  version: 0.0.0-use.local
+  resolution: "@umpire/solid@workspace:packages/solid"
+  dependencies:
+    "@umpire/core": "workspace:^"
+    solid-js: "npm:^1.0.0"
+    tsdown: "npm:^0.21.7"
+  peerDependencies:
+    solid-js: ^1.0.0
+  languageName: unknown
+  linkType: soft
+
 "@umpire/store@workspace:^, @umpire/store@workspace:packages/store":
   version: 0.0.0-use.local
   resolution: "@umpire/store@workspace:packages/store"
@@ -2249,7 +2261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.2.2, csstype@npm:^3.2.3":
+"csstype@npm:^3.1.0, csstype@npm:^3.2.2, csstype@npm:^3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
@@ -4609,6 +4621,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"seroval-plugins@npm:~1.5.0":
+  version: 1.5.2
+  resolution: "seroval-plugins@npm:1.5.2"
+  peerDependencies:
+    seroval: ^1.0
+  checksum: 10c0/feccb47f269c3d378979b835e5bada25a1f34fd811aae99e2c5f8ec65c6b06286627d6fdc5855a89f060aeba799d615da583b6b18e51a5d0f6e161dd8105cb95
+  languageName: node
+  linkType: hard
+
+"seroval@npm:~1.5.0":
+  version: 1.5.2
+  resolution: "seroval@npm:1.5.2"
+  checksum: 10c0/6efe24fc00aa667408214d890fe5ff316bf120ea2239278051bce86c9beaeac2c6692020316ccbc32f7daf74bbffa0f27f3a3e5190d82e089180009cab590bbf
+  languageName: node
+  linkType: hard
+
 "set-function-length@npm:^1.2.2":
   version: 1.2.2
   resolution: "set-function-length@npm:1.2.2"
@@ -4738,6 +4766,17 @@ __metadata:
     ip-address: "npm:^10.0.1"
     smart-buffer: "npm:^4.2.0"
   checksum: 10c0/2805a43a1c4bcf9ebf6e018268d87b32b32b06fbbc1f9282573583acc155860dc361500f89c73bfbb157caa1b4ac78059eac0ef15d1811eb0ca75e0bdadbc9d2
+  languageName: node
+  linkType: hard
+
+"solid-js@npm:^1.0.0":
+  version: 1.9.12
+  resolution: "solid-js@npm:1.9.12"
+  dependencies:
+    csstype: "npm:^3.1.0"
+    seroval: "npm:~1.5.0"
+    seroval-plugins: "npm:~1.5.0"
+  checksum: 10c0/bfab10ea42b4954e0de8e0e4710d45456836c9bf12fbe8d35a567e3877a26f3af2105bf92940cdfb64c169418035d8eb1d5f44a198cc3b76f274e79ad008fec4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add a new `@umpire/solid` package with `useUmpire()` for component-local state and `fromSolidStore()` for shared Solid store/context state
- add package docs, tests, build setup, and repo wiring for the new adapter
- update the docs nav and cross-links so Solid support is easier to discover alongside Signals and Store adapters

## Testing
- `yarn workspace @umpire/solid test`
- `yarn workspace @umpire/solid test --coverage`
- `yarn workspace @umpire/solid typecheck`
- `yarn workspace @umpire/solid build`
- `yarn --cwd docs build`
