### PR TITLE
🔌 Add @umpire/solid to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
       zod_changed: ${{ steps.versions.outputs.zod_changed }}
       testing_changed: ${{ steps.versions.outputs.testing_changed }}
       eslint_plugin_changed: ${{ steps.versions.outputs.eslint_plugin_changed }}
+      solid_changed: ${{ steps.versions.outputs.solid_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,7 +69,7 @@ jobs:
             }
           })();
           const isZeroSha = !before || /^0+$/.test(before);
-          const packages = ['core', 'json', 'reads', 'devtools', 'store', 'signals', 'react', 'redux', 'pinia', 'tanstack-store', 'vuex', 'zustand', 'zod', 'testing', 'eslint-plugin'];
+          const packages = ['core', 'json', 'reads', 'devtools', 'store', 'signals', 'react', 'redux', 'pinia', 'tanstack-store', 'vuex', 'zustand', 'zod', 'testing', 'eslint-plugin', 'solid'];
 
           const readCurrentVersion = (pkg) => {
             const packageJson = path.join('packages', pkg, 'package.json');
@@ -280,6 +281,16 @@ jobs:
       - name: Publish @umpire/eslint-plugin
         if: needs.detect-version-changes.outputs.eslint_plugin_changed == 'true'
         working-directory: packages/eslint-plugin
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="latest"
+          if echo "$VERSION" | grep -q "-"; then TAG="alpha"; fi
+          yarn pack -o package.tgz
+          npm publish package.tgz --provenance --access public --tag "$TAG"
+
+      - name: Publish @umpire/solid
+        if: needs.detect-version-changes.outputs.solid_changed == 'true'
+        working-directory: packages/solid
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG="latest"

--- a/scripts/set-latest.sh
+++ b/scripts/set-latest.sh
@@ -21,7 +21,7 @@ C_DIM="\033[38;5;243m"
 C_BOLD="\033[1m"
 C_RESET="\033[0m"
 
-ALL_PACKAGES=(core json signals react zustand store redux tanstack-store zod reads devtools testing pinia vuex eslint-plugin)
+ALL_PACKAGES=(core json signals react zustand store redux tanstack-store zod reads devtools testing pinia vuex eslint-plugin solid)
 DRY_RUN=false
 MODE=""
 VERSION=""


### PR DESCRIPTION
## Summary
- Adds \`@umpire/solid\` to the version-detection and publish steps in \`publish.yml\`
- Adds \`solid\` to \`scripts/set-latest.sh\` for the \`latest\` dist-tag promotion script
- Future version bumps will trigger automatic CI publish

## Notes
- First publish was done manually (required local npm auth — no \`--provenance\` flag, OIDC only works in CI)
- All subsequent publishes are fully automated through this pipeline