### PR TITLE
Prepare JSON conformance fixtures for external ports

### DIFF
--- a/.changeset/json-conformance-fixtures.md
+++ b/.changeset/json-conformance-fixtures.md
@@ -1,0 +1,5 @@
+---
+"@umpire/json": patch
+---
+
+Ship the `conformance/` directory with the published package so external ports (Kotlin, Python, Dart, etc.) can consume the cross-runtime fixtures without cloning the repo. Adds `conformance/index.json` as a discovery manifest and a language-neutral pseudocode runner guide to `conformance/README.md`.

--- a/packages/json/conformance/README.md
+++ b/packages/json/conformance/README.md
@@ -102,3 +102,53 @@ yarn turbo run test --filter=@umpire/json -- --runTestsByPath __tests__/conforma
 The TypeScript runner in `__tests__/conformance.test.ts` is the reference
 implementation today. Other runtimes should aim to match the fixture outputs,
 not necessarily the exact structure of the Jest test.
+
+## Writing A Port Runner
+
+No Node.js or TypeScript tooling required. The fixtures are plain JSON and the
+evaluation loop is simple. In pseudocode:
+
+```
+load index.json
+for each entry in index.fixtures:
+    fixture = parse_json(entry.path)         # ConformanceFixture shape
+    validate that fixture.fixtureVersion == 1
+
+    for each case in fixture.cases:
+        result = your_umpire_impl.check(
+            schema   = fixture.schema,
+            values   = case.values,
+            conds    = case.conditions ?? {},
+            prev     = case.prev ?? {},
+        )
+        assert result == case.expectedAvailability, case.id
+
+for each entry in index.failures:
+    fixture = parse_json(entry.path)         # FailureFixture shape
+    for each failure in fixture.failures:
+        if failure.phase == "validate":
+            assert your_validate_schema(failure.schema) raises error
+                   containing failure.errorIncludes
+        else:  # "evaluate"
+            assert your_umpire_impl.check(failure.schema, ...) raises error
+                   containing failure.errorIncludes
+```
+
+The `expectedAvailability` map has one entry per field declared in `schema.fields`.
+Each entry is:
+
+```
+{
+  "enabled":  bool,
+  "fair":     bool,
+  "required": bool,
+  "reason":   string | null,   // first blocking reason, null when enabled
+  "reasons":  string[],        // all blocking reasons, [] when enabled
+  "valid":    bool,            // only present when a validator is attached
+  "error":    string           // only present when a validator fires
+}
+```
+
+`valid` and `error` only appear on fields that have a named validator and are
+both enabled and satisfied. Omit them entirely (do not emit `null`) for fields
+that have no validator or are currently disabled/unsatisfied.

--- a/packages/json/conformance/README.md
+++ b/packages/json/conformance/README.md
@@ -144,11 +144,13 @@ Each entry is:
   "required": bool,
   "reason":   string | null,   // first blocking reason, null when enabled
   "reasons":  string[],        // all blocking reasons, [] when enabled
-  "valid":    bool,            // only present when a validator is attached
-  "error":    string           // only present when a validator fires
+  "valid":    bool,            // only present when a validator is attached to this field
+  "error":    string           // only present when validation fails (valid is false)
 }
 ```
 
-`valid` and `error` only appear on fields that have a named validator and are
-both enabled and satisfied. Omit them entirely (do not emit `null`) for fields
-that have no validator or are currently disabled/unsatisfied.
+`valid` appears on any field that has a named validator and is currently enabled
+and satisfied. `error` appears only when `valid` is `false` — do not emit
+`"error": null` for a field that passes validation. Omit both `valid` and
+`error` entirely for fields that have no validator or are currently
+disabled/unsatisfied.

--- a/packages/json/conformance/README.md
+++ b/packages/json/conformance/README.md
@@ -108,10 +108,16 @@ not necessarily the exact structure of the Jest test.
 No Node.js or TypeScript tooling required. The fixtures are plain JSON and the
 evaluation loop is simple. In pseudocode:
 
+All paths in `index.json` are relative to `index.json` itself (i.e., relative
+to the `conformance/` directory). Resolve them against the directory that
+contains `index.json`, not the repo root or the working directory of your test
+runner.
+
 ```
-load index.json
+load index.json                              # located at conformance/index.json
+base_dir = directory containing index.json  # i.e. conformance/
 for each entry in index.fixtures:
-    fixture = parse_json(entry.path)         # ConformanceFixture shape
+    fixture = parse_json(base_dir / entry.path)   # ConformanceFixture shape
     validate that fixture.fixtureVersion == 1
 
     for each case in fixture.cases:
@@ -124,7 +130,7 @@ for each entry in index.fixtures:
         assert result == case.expectedAvailability, case.id
 
 for each entry in index.failures:
-    fixture = parse_json(entry.path)         # FailureFixture shape
+    fixture = parse_json(base_dir / entry.path)   # FailureFixture shape
     for each failure in fixture.failures:
         if failure.phase == "validate":
             assert your_validate_schema(failure.schema) raises error

--- a/packages/json/conformance/index.json
+++ b/packages/json/conformance/index.json
@@ -1,0 +1,67 @@
+{
+  "fixtureVersion": 1,
+  "fixtures": [
+    {
+      "id": "auth-either-of",
+      "path": "fixtures/auth-either-of.json",
+      "description": "eitherOf() with named auth paths: submit is enabled when any branch's ANDed rules all pass. Covers single-branch pass, multi-branch pass, all-branches-fail, and a three-branch scenario."
+    },
+    {
+      "id": "box-score-checks",
+      "path": "fixtures/box-score-checks.json",
+      "description": "Named portable checks should behave the same way everywhere and use the same default reasons when no rule-level override is supplied."
+    },
+    {
+      "id": "bullpen-structural",
+      "path": "fixtures/bullpen-structural.json",
+      "description": "Structural availability, conditions, oneOf prev resolution, anyOf, fairWhen, and excluded carry-forward."
+    },
+    {
+      "id": "dsl-matrix",
+      "path": "fixtures/dsl-matrix.json",
+      "description": "Expression DSL coverage across comparisons, presence checks, membership, conditions, combinators, and predicate-form rules."
+    },
+    {
+      "id": "dugout-emptiness",
+      "path": "fixtures/dugout-emptiness.json",
+      "description": "Portable isEmpty strategies should agree on what counts as present before a dependency can unlock a target field."
+    },
+    {
+      "id": "plan-either-of-fair",
+      "path": "fixtures/plan-either-of-fair.json",
+      "description": "eitherOf() should also support fairWhen branches, keeping a field fair when any named branch's ANDed fairness checks pass."
+    },
+    {
+      "id": "rain-delay-chain",
+      "path": "fixtures/rain-delay-chain.json",
+      "description": "A disabled field can knock out a whole downstream requires chain, even when stale values are still present."
+    },
+    {
+      "id": "rotation-cascade",
+      "path": "fixtures/rotation-cascade.json",
+      "description": "A foul field can stay enabled itself while still cascading availability failures through downstream requires links."
+    },
+    {
+      "id": "scoreboard-source-checks",
+      "path": "fixtures/scoreboard-source-checks.json",
+      "description": "Portable named checks can act as field-bound sources inside other rules, not just as top-level same-field checks."
+    },
+    {
+      "id": "stale-signal-disables",
+      "path": "fixtures/stale-signal-disables.json",
+      "description": "A disabled source field can still disable its own targets when it holds a satisfied stale value."
+    },
+    {
+      "id": "validator-surface",
+      "path": "fixtures/validator-surface.json",
+      "description": "Portable validators should only surface valid/error for enabled, satisfied fields and should not change structural availability."
+    }
+  ],
+  "failures": [
+    {
+      "id": "bad-call-sheet-failures",
+      "path": "failures/bad-call-sheet-failures.json",
+      "description": "Invalid references, invalid check patterns, wrong condition types, and missing runtime conditions should fail descriptively."
+    }
+  ]
+}

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "dist",
+    "conformance",
     "AGENTS.md",
     ".claude"
   ],


### PR DESCRIPTION
## Summary

- Add `conformance/` to `files` in `packages/json/package.json` so fixtures ship in the npm tarball — external Kotlin/Python/Dart ports can download them via `npm pack @umpire/json` without cloning the repo
- Add `conformance/index.json` as a flat manifest listing every fixture and failure file with its `id`, `path`, and `description` for programmatic discovery
- Add a "Writing A Port Runner" section to `conformance/README.md` with language-neutral pseudocode and an explicit description of the `expectedAvailability` field shape, so ports don't need Node.js or any JS tooling to get started

## Test plan

- [ ] Confirm `bun test __tests__/conformance.test.ts` still passes (23 tests)
- [ ] Confirm `conformance/` appears in the output of `npm pack --dry-run` for `@umpire/json`
- [ ] Eyeball `conformance/index.json` entries match the files actually present in `conformance/fixtures/` and `conformance/failures/`

https://claude.ai/code/session_01HvbXHxEttNtg9hgL84HTqG