### PR TITLE
♻️ Share snapshot cloning across adapters

### DIFF
--- a/.changeset/few-cups-snapshot.md
+++ b/.changeset/few-cups-snapshot.md
@@ -1,0 +1,13 @@
+---
+"@umpire/core": patch
+"@umpire/devtools": patch
+"@umpire/pinia": patch
+"@umpire/react": patch
+"@umpire/redux": patch
+"@umpire/signals": patch
+"@umpire/tanstack-store": patch
+"@umpire/vuex": patch
+---
+
+- Add a shared `snapshotValue()` helper to `@umpire/core` for cloning previous plain-data snapshots without changing custom-instance comparison semantics.
+- Use shared snapshotting across the React, devtools, signals, Pinia, Vuex, Redux, and TanStack Store integrations so in-place nested plain-object mutations do not rewrite the saved "before" snapshot.

--- a/.changeset/few-cups-snapshot.md
+++ b/.changeset/few-cups-snapshot.md
@@ -9,5 +9,5 @@
 "@umpire/vuex": patch
 ---
 
-- Add a shared `snapshotValue()` helper to `@umpire/core` for cloning previous plain-data snapshots without changing custom-instance comparison semantics.
+- Add a shared `snapshotValue()` helper at `@umpire/core/snapshot` for cloning previous plain-data snapshots without changing custom-instance comparison semantics.
 - Use shared snapshotting across the React, devtools, signals, Pinia, Vuex, Redux, and TanStack Store integrations so in-place nested plain-object mutations do not rewrite the saved "before" snapshot.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 
 - Use Yarn 4 with `nodeLinker: node-modules`. Never use `npm` in this repo.
 - Bun 1.2+ is required for repo test commands; `yarn test` shells out to `bun test`.
+- Workspace package tests preload `test/preload-workspace-aliases.ts` so sibling `@umpire/*` imports resolve to source without a prior build. When adding a new exported subpath that tests import from another workspace, add a matching `mock.module(...)` entry there too.
 - Root commands: `yarn build`, `yarn test`, `yarn typecheck`, `yarn docs`, `yarn docs:build`.
 - Most packages build with `tsc`; `@umpire/devtools` builds with `tsup`.
 - Prefer `yarn turbo run test --filter=@umpire/<package>` for a single package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 
 - Use Yarn 4 with `nodeLinker: node-modules`. Never use `npm` in this repo.
 - Bun 1.2+ is required for repo test commands; `yarn test` shells out to `bun test`.
-- Workspace package tests preload `test/preload-workspace-aliases.ts` so sibling `@umpire/*` imports resolve to source without a prior build. When adding a new exported subpath that tests import from another workspace, add a matching `mock.module(...)` entry there too.
+- Workspace package tests preload `test/preload-workspace-aliases.ts`; add matching `mock.module(...)` entries there for new exported `@umpire/*` subpaths used before build.
 - Root commands: `yarn build`, `yarn test`, `yarn typecheck`, `yarn docs`, `yarn docs:build`.
 - Most packages build with `tsc`; `@umpire/devtools` builds with `tsup`.
 - Prefer `yarn turbo run test --filter=@umpire/<package>` for a single package.

--- a/docs/src/components/LearnDemos.tsx
+++ b/docs/src/components/LearnDemos.tsx
@@ -8,6 +8,7 @@ import {
   enabledWhen,
   oneOf,
   requires,
+  snapshotValue,
   umpire,
 } from '@umpire/core'
 import type { FieldStatus, InputValues } from '@umpire/core'
@@ -612,10 +613,16 @@ export function PlayDemo() {
 
   const conditions = { plan }
   const availability = useMemo(() => playUmp.check(values, conditions), [values, plan])
-  const prevRef = useRef({ values, conditions })
+  const prevRef = useRef({
+    values: snapshotValue(values),
+    conditions: snapshotValue(conditions),
+  })
   const fouls = useMemo(() => {
     const result = playUmp.play(prevRef.current, { values, conditions })
-    prevRef.current = { values, conditions }
+    prevRef.current = {
+      values: snapshotValue(values),
+      conditions: snapshotValue(conditions),
+    }
     return result
   }, [values, plan])
 

--- a/docs/src/components/LearnDemos.tsx
+++ b/docs/src/components/LearnDemos.tsx
@@ -8,9 +8,9 @@ import {
   enabledWhen,
   oneOf,
   requires,
-  snapshotValue,
   umpire,
 } from '@umpire/core'
+import { snapshotValue } from '@umpire/core/snapshot'
 import type { FieldStatus, InputValues } from '@umpire/core'
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/

--- a/docs/src/content/docs/adapters/pinia.mdx
+++ b/docs/src/content/docs/adapters/pinia.mdx
@@ -53,7 +53,7 @@ See [Selection](/umpire/concepts/selection/) for the full breakdown of patterns.
 
 Pinia's `$subscribe((mutation, state) => void)` passes the new state but not the previous one. Umpire uses the previous snapshot to detect transitions — which fields just became disabled, which values to recommend clearing. This adapter keeps a snapshot of `$state` before each update and supplies it as the previous state.
 
-The snapshot is a shallow copy. Pinia's `$state` is a Vue reactive proxy, so without copying, both `prev` and `next` would point at the same live object.
+The snapshot clones plain nested data like objects, arrays, maps, sets, and dates so in-place mutations do not rewrite the saved "before" state.
 
 ## Example
 

--- a/docs/src/content/docs/adapters/vuex.mdx
+++ b/docs/src/content/docs/adapters/vuex.mdx
@@ -51,7 +51,7 @@ See [Selection](/umpire/concepts/selection/) for the full breakdown of patterns.
 
 ## Why Vuex Needs a Shim
 
-Vuex's `subscribe((mutation, state) => void)` fires after every committed mutation and passes the new state, but not the previous one. Umpire uses the previous snapshot to detect transitions — which fields just became disabled, which values to recommend clearing. This adapter saves a reference to state before each mutation fires and supplies it as the previous state.
+Vuex's `subscribe((mutation, state) => void)` fires after every committed mutation and passes the new state, but not the previous one. Umpire uses the previous snapshot to detect transitions — which fields just became disabled, which values to recommend clearing. This adapter snapshots the previous state before each mutation fires and supplies it as the previous state.
 
 Note: `subscribe()` fires on mutations only. If your app dispatches actions that commit mutations, those mutations will still trigger the subscriber — but direct action dispatches without a corresponding mutation will not. In practice, all state changes in a well-structured Vuex app go through mutations, so this is rarely an issue.
 

--- a/packages/core/__tests__/snapshot.test.ts
+++ b/packages/core/__tests__/snapshot.test.ts
@@ -1,4 +1,4 @@
-import { snapshotValue } from '../src/index.js'
+import { snapshotValue } from '../src/snapshot.js'
 
 class CustomValue {
   constructor(readonly value: string) {}

--- a/packages/core/__tests__/snapshot.test.ts
+++ b/packages/core/__tests__/snapshot.test.ts
@@ -1,0 +1,63 @@
+import { snapshotValue } from '../src/index.js'
+
+class CustomValue {
+  constructor(readonly value: string) {}
+}
+
+describe('snapshotValue', () => {
+  test('deep-clones plain objects and arrays', () => {
+    const original = {
+      nested: {
+        tags: ['alpha', 'beta'],
+      },
+    }
+
+    const snapshot = snapshotValue(original)
+    snapshot.nested.tags.push('gamma')
+
+    expect(original.nested.tags).toEqual(['alpha', 'beta'])
+    expect(snapshot).toEqual({
+      nested: {
+        tags: ['alpha', 'beta', 'gamma'],
+      },
+    })
+  })
+
+  test('clones dates, maps, and sets', () => {
+    const date = new Date('2026-01-01T00:00:00.000Z')
+    const original = {
+      date,
+      map: new Map<string, { count: number }>([['items', { count: 1 }]]),
+      set: new Set([{ label: 'one' }]),
+    }
+
+    const snapshot = snapshotValue(original)
+    const mapped = snapshot.map.get('items')
+    const setEntry = Array.from(snapshot.set)[0] as { label: string }
+
+    mapped!.count = 2
+    setEntry.label = 'updated'
+
+    expect(snapshot.date).not.toBe(date)
+    expect(snapshot.date.toISOString()).toBe(date.toISOString())
+    expect(original.map.get('items')).toEqual({ count: 1 })
+    expect(Array.from(original.set)[0]).toEqual({ label: 'one' })
+  })
+
+  test('preserves custom instances by reference', () => {
+    const custom = new CustomValue('keep-prototype')
+    const snapshot = snapshotValue({ custom })
+
+    expect(snapshot.custom).toBe(custom)
+  })
+
+  test('supports cyclic plain-object graphs', () => {
+    const original = { label: 'root' } as { label: string; self?: unknown }
+    original.self = original
+
+    const snapshot = snapshotValue(original)
+
+    expect(snapshot).not.toBe(original)
+    expect(snapshot.self).toBe(snapshot)
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,11 @@
       "types": "./dist/index.d.ts",
       "browser": "./dist/index.browser.js",
       "import": "./dist/index.js"
+    },
+    "./snapshot": {
+      "types": "./dist/snapshot.d.ts",
+      "browser": "./dist/snapshot.js",
+      "import": "./dist/snapshot.js"
     }
   },
   "scripts": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,7 +47,6 @@ export { field } from './field.js'
 export { foulMap } from './foul-map.js'
 export { isSatisfied } from './satisfaction.js'
 export { isNamedCheck } from './validation.js'
-export { snapshotValue } from './snapshot.js'
 export {
   defineRule,
   enabledWhen,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export { field } from './field.js'
 export { foulMap } from './foul-map.js'
 export { isSatisfied } from './satisfaction.js'
 export { isNamedCheck } from './validation.js'
+export { snapshotValue } from './snapshot.js'
 export {
   defineRule,
   enabledWhen,

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -1,0 +1,68 @@
+function cloneSnapshotValue<T>(
+  value: T,
+  seen: WeakMap<object, unknown>,
+): T {
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T
+  }
+
+  const cached = seen.get(value)
+  if (cached) {
+    return cached as T
+  }
+
+  if (Array.isArray(value)) {
+    const clone: unknown[] = []
+    seen.set(value, clone)
+
+    for (const entry of value) {
+      clone.push(cloneSnapshotValue(entry, seen))
+    }
+
+    return clone as T
+  }
+
+  if (value instanceof Map) {
+    const clone = new Map<unknown, unknown>()
+    seen.set(value, clone)
+
+    for (const [key, entry] of value.entries()) {
+      clone.set(cloneSnapshotValue(key, seen), cloneSnapshotValue(entry, seen))
+    }
+
+    return clone as T
+  }
+
+  if (value instanceof Set) {
+    const clone = new Set<unknown>()
+    seen.set(value, clone)
+
+    for (const entry of value.values()) {
+      clone.add(cloneSnapshotValue(entry, seen))
+    }
+
+    return clone as T
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype === Object.prototype || prototype === null) {
+    const clone = Object.create(prototype) as Record<string, unknown>
+    seen.set(value, clone)
+
+    for (const [key, entry] of Object.entries(value)) {
+      clone[key] = cloneSnapshotValue(entry, seen)
+    }
+
+    return clone as T
+  }
+
+  return value
+}
+
+export function snapshotValue<T>(value: T): T {
+  return cloneSnapshotValue(value, new WeakMap<object, unknown>())
+}

--- a/packages/devtools/entrypoints/react.ts
+++ b/packages/devtools/entrypoints/react.ts
@@ -7,6 +7,7 @@ import type {
   Snapshot,
   Umpire,
 } from '@umpire/core'
+import { snapshotValue } from '@umpire/core'
 import type { RegisterOptions } from '../src/types.js'
 import { register, unregister } from '../src/registry.js'
 
@@ -58,7 +59,10 @@ export function useUmpireWithDevtools<
     return ump.play(prev, { values, conditions })
   }, [conditions, ump, values])
 
-  prevRef.current = { values, conditions }
+  prevRef.current = {
+    values: snapshotValue(values),
+    conditions: snapshotValue(conditions),
+  }
 
   useDebugValue({ check, fouls }, formatUmpireDebugValue)
 

--- a/packages/devtools/entrypoints/react.ts
+++ b/packages/devtools/entrypoints/react.ts
@@ -7,7 +7,7 @@ import type {
   Snapshot,
   Umpire,
 } from '@umpire/core'
-import { snapshotValue } from '@umpire/core'
+import { snapshotValue } from '@umpire/core/snapshot'
 import type { RegisterOptions } from '../src/types.js'
 import { register, unregister } from '../src/registry.js'
 

--- a/packages/pinia/__tests__/fromPiniaStore.test.ts
+++ b/packages/pinia/__tests__/fromPiniaStore.test.ts
@@ -130,4 +130,50 @@ describe('fromPiniaStore', () => {
 
     us.destroy()
   })
+
+  it('snapshots nested selected objects before in-place mutations', async () => {
+    const nestedFields = {
+      settings: {},
+      note: { default: '' },
+    } as const
+
+    type NestedState = {
+      settings: { allowNote: boolean }
+      note: string
+    }
+
+    const useNestedStore = defineStore('nested-form', {
+      state: (): NestedState => ({
+        settings: { allowNote: true },
+        note: 'keep me',
+      }),
+    })
+
+    setActivePinia(createPinia())
+    const store = useNestedStore()
+    const ump = umpire({
+      fields: nestedFields,
+      rules: [
+        enabledWhen('note', (values) => {
+          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+        }),
+      ],
+    })
+    const us = fromPiniaStore(ump, store, {
+      select: (state) => ({
+        settings: state.settings,
+        note: state.note,
+      }),
+    })
+
+    store.$patch((state) => {
+      state.settings.allowNote = false
+    })
+    await nextTick()
+
+    expect(us.field('note').enabled).toBe(false)
+    expect(us.fouls.some((foul) => foul.field === 'note')).toBe(true)
+
+    us.destroy()
+  })
 })

--- a/packages/pinia/src/index.ts
+++ b/packages/pinia/src/index.ts
@@ -1,4 +1,5 @@
-import { snapshotValue, type FieldDef, type Umpire } from '@umpire/core'
+import type { FieldDef, Umpire } from '@umpire/core'
+import { snapshotValue } from '@umpire/core/snapshot'
 import {
   fromStore,
   type FromStoreOptions,

--- a/packages/pinia/src/index.ts
+++ b/packages/pinia/src/index.ts
@@ -1,4 +1,4 @@
-import type { FieldDef, Umpire } from '@umpire/core'
+import { snapshotValue, type FieldDef, type Umpire } from '@umpire/core'
 import {
   fromStore,
   type FromStoreOptions,
@@ -11,7 +11,7 @@ export type PiniaStoreApi<S> = {
 }
 
 function snapshotState<S>(state: S): S {
-  return Object.assign({}, state) as S
+  return snapshotValue(state)
 }
 
 export function fromPiniaStore<

--- a/packages/react/__tests__/useUmpire.test.ts
+++ b/packages/react/__tests__/useUmpire.test.ts
@@ -125,6 +125,33 @@ describe('useUmpire', () => {
     expect(result.current.fouls).toEqual([])
   })
 
+  it('snapshots previous nested objects between renders', () => {
+    const nestedFields = {
+      settings: {},
+      note: { default: '' },
+    } satisfies Record<string, FieldDef>
+    const sharedSettings = { allowNote: true }
+    const ump = umpire({
+      fields: nestedFields,
+      rules: [
+        enabledWhen('note', (values) => {
+          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+        }),
+      ],
+    })
+
+    const { result, rerender } = renderHook(
+      ({ values }) => useUmpire(ump, values),
+      { initialProps: { values: { settings: sharedSettings, note: 'keep me' } } },
+    )
+
+    sharedSettings.allowNote = false
+    rerender({ values: { settings: sharedSettings, note: 'keep me' } })
+
+    expect(result.current.check.note.enabled).toBe(false)
+    expect(result.current.fouls.some((foul) => foul.field === 'note')).toBe(true)
+  })
+
   it('passes conditions to check', () => {
     type Ctx = { premium: boolean }
 

--- a/packages/react/src/useUmpire.ts
+++ b/packages/react/src/useUmpire.ts
@@ -7,7 +7,7 @@ import type {
   Snapshot,
   Umpire,
 } from '@umpire/core'
-import { snapshotValue } from '@umpire/core'
+import { snapshotValue } from '@umpire/core/snapshot'
 import { formatUmpireDebugValue } from './debugValue.js'
 
 export function useUmpire<

--- a/packages/react/src/useUmpire.ts
+++ b/packages/react/src/useUmpire.ts
@@ -7,6 +7,7 @@ import type {
   Snapshot,
   Umpire,
 } from '@umpire/core'
+import { snapshotValue } from '@umpire/core'
 import { formatUmpireDebugValue } from './debugValue.js'
 
 export function useUmpire<
@@ -36,7 +37,10 @@ export function useUmpire<
   }, [ump, values, conditions])
 
   // Update prev ref after computing check and fouls
-  prevRef.current = { values, conditions }
+  prevRef.current = {
+    values: snapshotValue(values),
+    conditions: snapshotValue(conditions),
+  }
 
   useDebugValue({ check, fouls }, formatUmpireDebugValue)
 

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -6,7 +6,10 @@ export default defineConfig([
     entry: { 'index.browser': 'src/index.ts' },
     format: ['esm'],
     platform: 'browser',
-    deps: { neverBundle: ['react', '@umpire/core'] },
+    deps: {
+      neverBundle: ['react', '@umpire/core'],
+      alwaysBundle: ['@umpire/core/snapshot'],
+    },
     outDir: 'dist',
     clean: false,
     dts: false,
@@ -19,7 +22,10 @@ export default defineConfig([
     format: ['iife'],
     globalName: 'UmpireReact',
     platform: 'browser',
-    deps: { neverBundle: ['react', '@umpire/core'] },
+    deps: {
+      neverBundle: ['react', '@umpire/core'],
+      alwaysBundle: ['@umpire/core/snapshot'],
+    },
     outputOptions: {
       globals: { react: 'React', '@umpire/core': 'Umpire' },
     },

--- a/packages/redux/__tests__/fromReduxStore.test.ts
+++ b/packages/redux/__tests__/fromReduxStore.test.ts
@@ -156,4 +156,62 @@ describe('fromReduxStore', () => {
     store.dispatch({ type: 'patch', payload: { password: '' } })
     expect(calls).toHaveLength(1)
   })
+
+  it('snapshots nested selected objects before in-place mutations', () => {
+    const nestedFields = {
+      settings: {},
+      note: { default: '' },
+    } as const
+
+    type NestedState = {
+      settings: { allowNote: boolean }
+      note: string
+    }
+
+    type NestedAction = {
+      type: 'disableNote'
+    }
+
+    function nestedReducer(
+      state: NestedState = {
+        settings: { allowNote: true },
+        note: 'keep me',
+      },
+      action: NestedAction,
+    ): NestedState {
+      if (action.type === 'disableNote') {
+        state.settings.allowNote = false
+
+        return {
+          ...state,
+          settings: state.settings,
+        }
+      }
+
+      return state
+    }
+
+    const store = legacy_createStore(nestedReducer)
+    const ump = umpire({
+      fields: nestedFields,
+      rules: [
+        enabledWhen('note', (values) => {
+          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+        }),
+      ],
+    })
+    const us = fromReduxStore(ump, store, {
+      select: (state) => ({
+        settings: state.settings,
+        note: state.note,
+      }),
+    })
+
+    store.dispatch({ type: 'disableNote' })
+
+    expect(us.field('note').enabled).toBe(false)
+    expect(us.fouls.some((foul) => foul.field === 'note')).toBe(true)
+
+    us.destroy()
+  })
 })

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -1,4 +1,5 @@
-import { snapshotValue, type FieldDef, type Umpire } from '@umpire/core'
+import type { FieldDef, Umpire } from '@umpire/core'
+import { snapshotValue } from '@umpire/core/snapshot'
 import {
   fromStore,
   type FromStoreOptions,

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -1,4 +1,4 @@
-import type { FieldDef, Umpire } from '@umpire/core'
+import { snapshotValue, type FieldDef, type Umpire } from '@umpire/core'
 import {
   fromStore,
   type FromStoreOptions,
@@ -19,7 +19,7 @@ export function fromReduxStore<
   store: ReduxStoreApi<S>,
   options: FromStoreOptions<S, F, C>,
 ): UmpireStore<F> {
-  let prevState = store.getState()
+  let prevState = snapshotValue(store.getState())
 
   return fromStore(ump, {
     getState: () => store.getState(),
@@ -28,7 +28,7 @@ export function fromReduxStore<
         const nextState = store.getState()
         const currentPrevState = prevState
 
-        prevState = nextState
+        prevState = snapshotValue(nextState)
         listener(nextState, currentPrevState)
       })
     },

--- a/packages/signals/__tests__/reactive.test.ts
+++ b/packages/signals/__tests__/reactive.test.ts
@@ -538,4 +538,34 @@ describe('reactiveUmp with disables rules', () => {
     // After clearing the value, the foul should disappear
     expect(reactive.fouls.length).toBe(0)
   })
+
+  test('fouls snapshots nested object values before in-place mutations', () => {
+    const adapter = createMockAdapter()
+    const sharedSettings = { allowNote: true }
+
+    const ump = umpire({
+      fields: {
+        settings: {},
+        note: { default: '' },
+      },
+      rules: [
+        enabledWhen('note', (values) => {
+          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+        }),
+      ],
+    })
+
+    const reactive = reactiveUmp(ump, adapter)
+
+    reactive.set('settings', sharedSettings)
+    reactive.set('note', 'keep me')
+    adapter._flush()
+
+    sharedSettings.allowNote = false
+    reactive.set('settings', sharedSettings)
+    adapter._flush()
+
+    expect(reactive.field('note').enabled).toBe(false)
+    expect(reactive.fouls.some((foul) => foul.field === 'note')).toBe(true)
+  })
 })

--- a/packages/signals/src/reactive.ts
+++ b/packages/signals/src/reactive.ts
@@ -6,7 +6,7 @@ import type {
   Foul,
   Umpire,
 } from '@umpire/core'
-import { snapshotValue } from '@umpire/core'
+import { snapshotValue } from '@umpire/core/snapshot'
 import type { SignalProtocol } from './protocol.js'
 
 // ---------------------------------------------------------------------------

--- a/packages/signals/src/reactive.ts
+++ b/packages/signals/src/reactive.ts
@@ -6,6 +6,7 @@ import type {
   Foul,
   Umpire,
 } from '@umpire/core'
+import { snapshotValue } from '@umpire/core'
 import type { SignalProtocol } from './protocol.js'
 
 // ---------------------------------------------------------------------------
@@ -173,32 +174,34 @@ export function reactiveUmp<
     // signal dependencies), so it recomputes whenever field/condition signals
     // change — no version counter needed.
 
-    let beforeValues: InputValues<F> = Object.fromEntries(
-      fieldNames.map((n) => [n, fieldSignals.get(n)!.get()]),
-    ) as InputValues<F>
-    let beforeConditions: C = Object.fromEntries(
-      Object.keys(conditionSignals).map((k) => [k, conditionSignals[k].get()]),
-    ) as C
-    let lastValues: InputValues<F> = { ...beforeValues }
-    let lastConditions: C = { ...beforeConditions } as C
+    function readSnapshotValues() {
+      return snapshotValue(Object.fromEntries(
+        fieldNames.map((name) => [name, fieldSignals.get(name)!.get()]),
+      ) as InputValues<F>)
+    }
+
+    function readSnapshotConditions() {
+      return snapshotValue(Object.fromEntries(
+        Object.keys(conditionSignals).map((name) => [name, conditionSignals[name].get()]),
+      ) as C)
+    }
+
+    let beforeValues: InputValues<F> = readSnapshotValues()
+    let beforeConditions: C = readSnapshotConditions()
+    let lastValues: InputValues<F> = snapshotValue(beforeValues)
+    let lastConditions: C = snapshotValue(beforeConditions)
 
     let isFirstRun = true
 
     const dispose = adapter.effect(() => {
       // Read all field signals to register as dependencies
-      const currentVals = {} as InputValues<F>
-      for (const name of fieldNames) {
-        currentVals[name] = fieldSignals.get(name)!.get() as InputValues<F>[typeof name]
-      }
-      const currentCond = {} as Record<string, unknown>
-      for (const k of Object.keys(conditionSignals)) {
-        currentCond[k] = conditionSignals[k].get()
-      }
+      const currentVals = readSnapshotValues()
+      const currentCond = readSnapshotConditions()
 
       if (isFirstRun) {
         isFirstRun = false
         lastValues = currentVals
-        lastConditions = currentCond as C
+        lastConditions = currentCond
         return
       }
 
@@ -208,7 +211,7 @@ export function reactiveUmp<
 
       // Store new current
       lastValues = currentVals
-      lastConditions = currentCond as C
+      lastConditions = currentCond
     })
 
     disposeFns.push(dispose)

--- a/packages/tanstack-store/__tests__/fromTanStackStore.test.ts
+++ b/packages/tanstack-store/__tests__/fromTanStackStore.test.ts
@@ -153,4 +153,59 @@ describe('fromTanStackStore', () => {
 
     expect(unsubscribeCalls).toBe(1)
   })
+
+  it('snapshots nested selected objects before in-place mutations', () => {
+    type NestedState = {
+      settings: { allowNote: boolean }
+      note: string
+    }
+
+    const nestedFields = {
+      settings: {},
+      note: { default: '' },
+    } as const
+
+    const listeners = new Set<() => void>()
+    const store = {
+      state: {
+        settings: { allowNote: true },
+        note: 'keep me',
+      } satisfies NestedState,
+      subscribe(listener: () => void) {
+        listeners.add(listener)
+        return () => {
+          listeners.delete(listener)
+        }
+      },
+    }
+    const ump = umpire({
+      fields: nestedFields,
+      rules: [
+        enabledWhen('note', (values) => {
+          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+        }),
+      ],
+    })
+    const us = fromTanStackStore(ump, store, {
+      select: (state) => ({
+        settings: state.settings,
+        note: state.note,
+      }),
+    })
+
+    store.state.settings.allowNote = false
+    store.state = {
+      ...store.state,
+      settings: store.state.settings,
+    }
+
+    for (const listener of listeners) {
+      listener()
+    }
+
+    expect(us.field('note').enabled).toBe(false)
+    expect(us.fouls.some((foul) => foul.field === 'note')).toBe(true)
+
+    us.destroy()
+  })
 })

--- a/packages/tanstack-store/src/index.ts
+++ b/packages/tanstack-store/src/index.ts
@@ -1,4 +1,5 @@
-import { snapshotValue, type FieldDef, type Umpire } from '@umpire/core'
+import type { FieldDef, Umpire } from '@umpire/core'
+import { snapshotValue } from '@umpire/core/snapshot'
 import {
   fromStore,
   type FromStoreOptions,

--- a/packages/tanstack-store/src/index.ts
+++ b/packages/tanstack-store/src/index.ts
@@ -1,4 +1,4 @@
-import type { FieldDef, Umpire } from '@umpire/core'
+import { snapshotValue, type FieldDef, type Umpire } from '@umpire/core'
 import {
   fromStore,
   type FromStoreOptions,
@@ -33,7 +33,7 @@ export function fromTanStackStore<
   store: TanStackStoreApi<S>,
   options: FromStoreOptions<S, F, C>,
 ): UmpireStore<F> {
-  let prevState = store.state
+  let prevState = snapshotValue(store.state)
 
   return fromStore(ump, {
     getState: () => store.state,
@@ -42,7 +42,7 @@ export function fromTanStackStore<
         const nextState = store.state
         const currentPrevState = prevState
 
-        prevState = nextState
+        prevState = snapshotValue(nextState)
         listener(nextState, currentPrevState)
       }))
     },

--- a/packages/vuex/__tests__/fromVuexStore.test.ts
+++ b/packages/vuex/__tests__/fromVuexStore.test.ts
@@ -128,4 +128,49 @@ describe('fromVuexStore', () => {
 
     us.destroy()
   })
+
+  it('snapshots nested selected objects before in-place mutations', () => {
+    const nestedFields = {
+      settings: {},
+      note: { default: '' },
+    } as const
+
+    type NestedState = {
+      settings: { allowNote: boolean }
+      note: string
+    }
+
+    const store = createStore<NestedState>({
+      state: {
+        settings: { allowNote: true },
+        note: 'keep me',
+      },
+      mutations: {
+        disableNote(state) {
+          state.settings.allowNote = false
+        },
+      },
+    })
+    const ump = umpire({
+      fields: nestedFields,
+      rules: [
+        enabledWhen('note', (values) => {
+          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+        }),
+      ],
+    })
+    const us = fromVuexStore(ump, store, {
+      select: (state) => ({
+        settings: state.settings,
+        note: state.note,
+      }),
+    })
+
+    store.commit('disableNote')
+
+    expect(us.field('note').enabled).toBe(false)
+    expect(us.fouls.some((foul) => foul.field === 'note')).toBe(true)
+
+    us.destroy()
+  })
 })

--- a/packages/vuex/src/index.ts
+++ b/packages/vuex/src/index.ts
@@ -1,4 +1,5 @@
-import { snapshotValue, type FieldDef, type Umpire } from '@umpire/core'
+import type { FieldDef, Umpire } from '@umpire/core'
+import { snapshotValue } from '@umpire/core/snapshot'
 import {
   fromStore,
   type FromStoreOptions,

--- a/packages/vuex/src/index.ts
+++ b/packages/vuex/src/index.ts
@@ -1,4 +1,4 @@
-import type { FieldDef, Umpire } from '@umpire/core'
+import { snapshotValue, type FieldDef, type Umpire } from '@umpire/core'
 import {
   fromStore,
   type FromStoreOptions,
@@ -11,7 +11,7 @@ export type VuexStoreApi<S> = {
 }
 
 function snapshotState<S>(state: S): S {
-  return Object.assign({}, state) as S
+  return snapshotValue(state)
 }
 
 export function fromVuexStore<

--- a/test/preload-workspace-aliases.ts
+++ b/test/preload-workspace-aliases.ts
@@ -5,6 +5,7 @@ const require = createRequire(import.meta.url)
 
 if (process.env.BUN_DISABLE_WORKSPACE_MOCKS !== 'true') {
   mock.module('@umpire/core', () => require('../packages/core/src/index.js'))
+  mock.module('@umpire/core/snapshot', () => require('../packages/core/src/snapshot.js'))
   mock.module('@umpire/store', () => require('../packages/store/src/index.js'))
   mock.module('@umpire/reads', () => require('../packages/reads/src/index.js'))
   mock.module('@umpire/react', () => require('../packages/react/src/index.js'))

--- a/test/preload-workspace-aliases.ts
+++ b/test/preload-workspace-aliases.ts
@@ -4,6 +4,8 @@ import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
 
 if (process.env.BUN_DISABLE_WORKSPACE_MOCKS !== 'true') {
+  // Keep exported subpaths in sync with this file. Package tests and coverage runs
+  // preload these source aliases before sibling workspaces are built.
   mock.module('@umpire/core', () => require('../packages/core/src/index.js'))
   mock.module('@umpire/core/snapshot', () => require('../packages/core/src/snapshot.js'))
   mock.module('@umpire/store', () => require('../packages/store/src/index.js'))


### PR DESCRIPTION
## Summary
- add a shared `snapshotValue()` utility to `@umpire/core` for previous-state snapshotting
- update adapters and hooks that track prior snapshots to use the shared helper
- add regression tests for nested in-place mutations so fouls and transition checks keep working when plain objects are reused
- update docs copy for the snapshot behavior and add a changeset

## Why
PR #26 exposed that previous-snapshot handling had drifted across packages. Some paths deep-cloned, some shallow-copied, and some kept raw references.

This follow-up consolidates the snapshotting behavior without changing value-comparison semantics. It fixes the practical bug around nested plain-data mutations while keeping the equality/setoid discussion as a separate concern.

## Scope
- `@umpire/core`
- `@umpire/react`
- `@umpire/signals`
- `@umpire/pinia`
- `@umpire/vuex`
- `@umpire/redux`
- `@umpire/tanstack-store`
- `@umpire/devtools`
- docs

## Notes
- custom class instances are still preserved by reference
- this PR does not introduce structural equality or `fantasy-land/equals`
- `packages/solid` is intentionally not touched here since that work is landing separately in PR #26

## Testing
- `yarn turbo run test typecheck --filter=@umpire/core --filter=@umpire/react --filter=@umpire/signals --filter=@umpire/pinia --filter=@umpire/vuex --filter=@umpire/redux --filter=@umpire/tanstack-store --filter=@umpire/devtools`
- `yarn --cwd docs build`