### PR TITLE
📦 Remove .claude from published npm files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "repository": {
     "type": "git",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -28,8 +28,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -17,8 +17,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "peerDependencies": {
     "eslint": ">=9.0.0"

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -20,8 +20,7 @@
   "files": [
     "dist",
     "conformance",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^"

--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^"

--- a/packages/reads/package.json
+++ b/packages/reads/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^"

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -41,8 +41,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^"

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -21,8 +21,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^"

--- a/packages/tanstack-store/package.json
+++ b/packages/tanstack-store/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -17,8 +17,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "peerDependencies": {
     "@umpire/core": "^0.1.0-alpha.10"

--- a/packages/vuex/package.json
+++ b/packages/vuex/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -22,8 +22,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/core": "workspace:^"

--- a/packages/zustand/package.json
+++ b/packages/zustand/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "AGENTS.md",
-    ".claude"
+    "AGENTS.md"
   ],
   "dependencies": {
     "@umpire/store": "workspace:^"


### PR DESCRIPTION
The .claude/rules/ directory contains symlinks (e.g. umpire-core.md -> ../../AGENTS.md) which npm rejects at publish time with E415 Unsupported Media Type.

.claude is only useful locally for Claude Code context — it has no value in the npm tarball. AGENTS.md stays since it is a real file.

Fixes the publish failure seen in alpha.10.