### PR TITLE
📦 Lower Node engine requirement to 22 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         run: yarn test:coverage:istanbul
 
       - name: Upload coverage to Coveralls
+        if: matrix.node-version == '24'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -18,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: yarn
 
       - name: Install dependencies
@@ -31,6 +34,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: typecheck
+    strategy:
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: yarn
 
       - uses: oven-sh/setup-bun@v2
@@ -62,6 +68,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: test
+    strategy:
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -70,7 +79,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: yarn
 
       - uses: oven-sh/setup-bun@v2

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "packageManager": "yarn@4.13.0",
   "engines": {
-    "node": ">=24",
+    "node": ">=22",
     "bun": ">=1.2"
   },
   "workspaces": [


### PR DESCRIPTION
Update engines.node from >=24 to >=22, as Node 22 LTS is in active
support through April 2027. Add Node 22 and 24 to CI matrix to prevent
regressions against the new minimum version.

Fixes #36