### PR TITLE
📦 Set updateInternalDependencies to minor for adapter sync

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,6 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch",
+  "updateInternalDependencies": "minor",
   "ignore": []
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,13 @@
 - `play()` suggests resets only for fields that became disabled and still hold stale values.
 - `challenge()` and `scorecard()` are debugging surfaces, not app-state inputs.
 
+## Releases and Versioning
+
+Changesets workflow with `.changeset/config.json`:
+- `updateInternalDependencies: "minor"` ensures adapter packages get a patch bump when `core` bumps minor or major, triggering a new publish with updated dep ranges.
+- All packages are kept in sync: when a referenced package bumps, dependents are re-published automatically.
+- This maintains consistency without requiring a full major cascade on every internal change.
+
 ## Contributor Notes
 
 - ESM-only, `verbatimModuleSyntax`, `import type` and `export type`, and `.js` extensions in TypeScript import paths.


### PR DESCRIPTION
When core bumps minor/major, adapters get a patch bump and
are re-published with updated dependency ranges. This keeps
the ecosystem in sync without requiring full major cascades.