### PR TITLE
🔧 Pin CI to Node 22 LTS, restore Coveralls upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -21,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: yarn
 
       - name: Install dependencies
@@ -34,9 +31,6 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: typecheck
-    strategy:
-      matrix:
-        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -45,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: yarn
 
       - uses: oven-sh/setup-bun@v2
@@ -59,7 +53,6 @@ jobs:
         run: yarn test:coverage:istanbul
 
       - name: Upload coverage to Coveralls
-        if: matrix.node-version == '24'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,9 +62,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: test
-    strategy:
-      matrix:
-        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -80,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: yarn
 
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

- Removes the Node 22/24 matrix from all three jobs — everything pins to Node 22 LTS
- Removes the `if: matrix.node-version == '24'` guard (was a string/integer type mismatch that silently suppressed Coveralls on every run)
- Coveralls now uploads unconditionally on every test run

Fixes the duplicate CI runs and broken Coveralls reporting introduced in #42.