### PR TITLE
🤙 Type Loosening for Improved Public Usage

### DIFF
--- a/.changeset/loosen-input-values.md
+++ b/.changeset/loosen-input-values.md
@@ -1,0 +1,11 @@
+---
+'@umpire/core': minor
+'@umpire/react': patch
+'@umpire/solid': patch
+'@umpire/signals': patch
+'@umpire/store': patch
+'@umpire/devtools': patch
+'@umpire/zod': patch
+---
+
+Loosen `InputValues` from a generic `FieldValues<F>` alias to `Record<string, unknown>`. Consumer call sites (`check()`, `play()`, `useUmpire()`, adapters) no longer require casts when passing form state or dynamic records. Predicate callbacks keep `FieldValues<F>` for typed field access. Remove phantom `F` parameter from `Snapshot` — only `C` (conditions) is structurally used.

--- a/docs/src/components/LineupCard.tsx
+++ b/docs/src/components/LineupCard.tsx
@@ -63,7 +63,7 @@ const lineupSlots: LineupSlot[] = [
 // affect availability but aren't form fields the user fills in. Conditions go
 // in the second argument to check() and play().
 
-const fields: Record<string, FieldDef> = Object.fromEntries(
+const fields = Object.fromEntries(
   playerIds.map(id => [id, {}]),
 )
 

--- a/packages/core/src/field.ts
+++ b/packages/core/src/field.ts
@@ -1,4 +1,4 @@
-import type { FieldDef, InputValues, RuleTraceAttachment } from './types.js'
+import type { FieldDef, FieldValues, RuleTraceAttachment } from './types.js'
 
 const FIELD_BUILDER = Symbol('umpire.fieldBuilder')
 const FIELD_STATE = Symbol('umpire.fieldState')
@@ -6,26 +6,26 @@ const FIELD_STATE = Symbol('umpire.fieldState')
 type ReasonOption<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-> = string | ((values: InputValues<F>, conditions: C) => string)
+> = string | ((values: FieldValues<F>, conditions: C) => string)
 
 type RuleOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 > = {
   reason?: ReasonOption<F, C>
-  trace?: RuleTraceAttachment<InputValues<F>, C> | RuleTraceAttachment<InputValues<F>, C>[]
+  trace?: RuleTraceAttachment<FieldValues<F>, C> | RuleTraceAttachment<FieldValues<F>, C>[]
 }
 
 type Predicate<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-> = (values: InputValues<F>, conditions: C) => boolean
+> = (values: FieldValues<F>, conditions: C) => boolean
 
 type FairPredicate<
   V,
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-> = (value: NonNullable<V>, values: InputValues<F>, conditions: C) => boolean
+> = (value: NonNullable<V>, values: FieldValues<F>, conditions: C) => boolean
 
 type FieldSelector<
   F extends Record<string, FieldDef>,

--- a/packages/core/src/scorecard.ts
+++ b/packages/core/src/scorecard.ts
@@ -11,7 +11,7 @@ export function scorecard<
   C extends Record<string, unknown>,
 >(
   ump: Umpire<F, C>,
-  snapshot: Snapshot<F, C>,
+  snapshot: Snapshot<C>,
   options?: ScorecardOptions<F, C>,
 ): ScorecardResult<F, C> {
   return ump.scorecard(snapshot, options)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,7 +79,9 @@ export type FieldValues<F extends Record<string, FieldDef>> = {
   [K in keyof F]?: FieldValue<F[K]>
 }
 
-export type InputValues<
+export type InputValues = Record<string, unknown>
+
+export type InputValuesWithDefaults<
   F extends Record<string, FieldDef> = Record<string, FieldDef>,
 > = FieldValues<F>
 
@@ -87,7 +89,7 @@ export type Snapshot<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 > = {
-  values: InputValues<F>
+  values: InputValues
   conditions?: C
 }
 
@@ -250,18 +252,18 @@ export interface Umpire<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
 > {
-  check(values: InputValues<F>, conditions?: C, prev?: InputValues<F>): AvailabilityMap<F>
+  check(values: InputValues, conditions?: C, prev?: InputValues): AvailabilityMap<F>
   play(before: Snapshot<F, C>, after: Snapshot<F, C>): Foul<F>[]
-  init(overrides?: InputValues<F>): FieldValues<F>
+  init(overrides?: InputValues): FieldValues<F>
   scorecard(
     snapshot: Snapshot<F, C>,
     options?: ScorecardOptions<F, C>,
   ): ScorecardResult<F, C>
   challenge(
     field: keyof F & string,
-    values: InputValues<F>,
+    values: InputValues,
     conditions?: C,
-    prev?: InputValues<F>,
+    prev?: InputValues,
   ): ChallengeTrace
   graph(): UmpireGraph
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -82,10 +82,7 @@ export type FieldValues<F extends Record<string, FieldDef>> = {
 export type InputValues = Record<string, unknown>
 
 
-export type Snapshot<
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown>,
-> = {
+export type Snapshot<C extends Record<string, unknown>> = {
   values: InputValues
   conditions?: C
 }
@@ -195,7 +192,7 @@ export type ScorecardTransition<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 > = {
-  before: Snapshot<F, C> | null
+  before: Snapshot<C> | null
   changedFields: Array<keyof F & string>
   fouls: Foul<F>[]
   foulsByField: Partial<Record<keyof F & string, Foul<F>>>
@@ -208,7 +205,7 @@ export type ScorecardOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 > = {
-  before?: Snapshot<F, C>
+  before?: Snapshot<C>
   includeChallenge?: boolean
 }
 
@@ -250,10 +247,10 @@ export interface Umpire<
   C extends Record<string, unknown> = Record<string, unknown>,
 > {
   check(values: InputValues, conditions?: C, prev?: InputValues): AvailabilityMap<F>
-  play(before: Snapshot<F, C>, after: Snapshot<F, C>): Foul<F>[]
+  play(before: Snapshot<C>, after: Snapshot<C>): Foul<F>[]
   init(overrides?: InputValues): FieldValues<F>
   scorecard(
-    snapshot: Snapshot<F, C>,
+    snapshot: Snapshot<C>,
     options?: ScorecardOptions<F, C>,
   ): ScorecardResult<F, C>
   challenge(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -81,9 +81,6 @@ export type FieldValues<F extends Record<string, FieldDef>> = {
 
 export type InputValues = Record<string, unknown>
 
-export type InputValuesWithDefaults<
-  F extends Record<string, FieldDef> = Record<string, FieldDef>,
-> = FieldValues<F>
 
 export type Snapshot<
   F extends Record<string, FieldDef>,

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -992,7 +992,7 @@ export function umpire<
     return recommendations
   }
 
-  function initValues(overrides?: InputValues<NormalizeFields<FInput>>) {
+  function initValues(overrides?: InputValues) {
     const values = {} as FieldValues<NormalizeFields<FInput>>
 
     for (const field of fieldNames) {
@@ -1014,9 +1014,9 @@ export function umpire<
 
   function buildChallenge(
     field: keyof NormalizeFields<FInput> & string,
-    values: InputValues<NormalizeFields<FInput>>,
+    values: InputValues,
     conditions?: C,
-    prev?: InputValues<NormalizeFields<FInput>>,
+    prev?: InputValues,
   ) {
     if (!(field in fields)) {
       throw new Error(`[@umpire/core] Unknown field "${field}"`)
@@ -1083,7 +1083,7 @@ export function umpire<
 
   function buildScorecard(
     snapshot: {
-      values: InputValues<NormalizeFields<FInput>>
+      values: InputValues
       conditions?: C
     },
     options: ScorecardOptions<NormalizeFields<FInput>, C> = {},
@@ -1175,7 +1175,11 @@ export function umpire<
   }
 
   return {
-    check(values, conditions, prev) {
+    check(
+      values: InputValues,
+      conditions?: C,
+      prev?: InputValues,
+    ) {
       const typedValues = values as FieldValues<NormalizeFields<FInput>>
 
       return attachValidationMetadata(
@@ -1209,7 +1213,12 @@ export function umpire<
       return buildScorecard(snapshot, options)
     },
 
-    challenge(field, values, conditions, prev) {
+    challenge(
+      field: keyof NormalizeFields<FInput> & string,
+      values: InputValues,
+      conditions?: C,
+      prev?: InputValues,
+    ) {
       return buildChallenge(field, values, conditions, prev)
     },
 

--- a/packages/devtools/entrypoints/react.ts
+++ b/packages/devtools/entrypoints/react.ts
@@ -42,7 +42,7 @@ export function useUmpireWithDevtools<
   conditions?: C,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
 ) {
-  const prevRef = useRef<Snapshot<F, C> | undefined>(undefined)
+  const prevRef = useRef<Snapshot<C> | undefined>(undefined)
 
   const check = useMemo(
     () => ump.check(values, conditions, prevRef.current?.values),

--- a/packages/devtools/entrypoints/react.ts
+++ b/packages/devtools/entrypoints/react.ts
@@ -33,12 +33,12 @@ function formatUmpireDebugValue<
 export function useUmpireWithDevtools<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-  ReadInput extends Record<string, unknown> = InputValues<F>,
+  ReadInput extends Record<string, unknown> = InputValues,
   Reads extends Record<string, unknown> = Record<string, unknown>,
 >(
   id: string,
   ump: Umpire<F, C>,
-  values: InputValues<F>,
+  values: InputValues,
   conditions?: C,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
 ) {
@@ -88,11 +88,11 @@ let nextId = 0
 export function useUmpire<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-  ReadInput extends Record<string, unknown> = InputValues<F>,
+  ReadInput extends Record<string, unknown> = InputValues,
   Reads extends Record<string, unknown> = Record<string, unknown>,
 >(
   ump: Umpire<F, C>,
-  values: InputValues<F>,
+  values: InputValues,
   conditions?: C,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
 ) {

--- a/packages/devtools/src/registry.ts
+++ b/packages/devtools/src/registry.ts
@@ -149,7 +149,7 @@ function resolveExtensions<
   ump: Umpire<F, C>,
   values: InputValues,
   conditions: C | undefined,
-  previous: Snapshot<F, C> | null,
+  previous: Snapshot<C> | null,
   scorecard: ScorecardResult<F, C>,
   readsInspection: AnyReadInspection | null,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
@@ -228,8 +228,8 @@ export const register: RegisterFn = <
   }
 
   const existing = registry.get(id)
-  const previous = (existing?.snapshot as Snapshot<F, C> | null) ?? null
-  const currentSnapshot: Snapshot<F, C> = {
+  const previous = (existing?.snapshot as Snapshot<C> | null) ?? null
+  const currentSnapshot: Snapshot<C> = {
     values,
     conditions,
   }

--- a/packages/devtools/src/registry.ts
+++ b/packages/devtools/src/registry.ts
@@ -66,7 +66,7 @@ function resolveReadsInspection<
   ReadInput extends Record<string, unknown>,
   Reads extends Record<string, unknown>,
 >(
-  values: InputValues<F>,
+  values: InputValues,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
 ): AnyReadInspection | null {
   const reads = options?.reads
@@ -147,7 +147,7 @@ function resolveExtensions<
   Reads extends Record<string, unknown>,
 >(
   ump: Umpire<F, C>,
-  values: InputValues<F>,
+  values: InputValues,
   conditions: C | undefined,
   previous: Snapshot<F, C> | null,
   scorecard: ScorecardResult<F, C>,
@@ -214,12 +214,12 @@ function buildFoulLog(
 export const register: RegisterFn = <
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-  ReadInput extends Record<string, unknown> = InputValues<F>,
+  ReadInput extends Record<string, unknown> = InputValues,
   Reads extends Record<string, unknown> = Record<string, unknown>,
 >(
   id: string,
   ump: Umpire<F, C>,
-  values: InputValues<F>,
+  values: InputValues,
   conditions?: C,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
 ) => {

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -74,7 +74,7 @@ export type DevtoolsExtensionInspectContext<
   previous: Snapshot<F, C> | null
   scorecard: ScorecardResult<F, C>
   ump: Umpire<F, C>
-  values: InputValues<F>
+  values: InputValues
 }
 
 export type DevtoolsExtension<
@@ -136,12 +136,12 @@ export type RegistryEntry = {
 export type RegisterFn = <
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-  ReadInput extends Record<string, unknown> = InputValues<F>,
+  ReadInput extends Record<string, unknown> = InputValues,
   Reads extends Record<string, unknown> = Record<string, unknown>,
 >(
   id: string,
   ump: Umpire<F, C>,
-  values: InputValues<F>,
+  values: InputValues,
   conditions?: C,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
 ) => void

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -71,7 +71,7 @@ export type DevtoolsExtensionInspectContext<
   C extends Record<string, unknown>,
 > = {
   conditions?: C
-  previous: Snapshot<F, C> | null
+  previous: Snapshot<C> | null
   scorecard: ScorecardResult<F, C>
   ump: Umpire<F, C>
   values: InputValues
@@ -108,7 +108,7 @@ export type DevtoolsFoulEvent = {
   timestamp: number
 }
 
-export type AnySnapshot = Snapshot<Record<string, FieldDef>, Record<string, unknown>>
+export type AnySnapshot = Snapshot<Record<string, unknown>>
 export type AnyScorecard = ScorecardResult<Record<string, FieldDef>, Record<string, unknown>>
 export type AnyUmpire = Umpire<Record<string, FieldDef>, Record<string, unknown>>
 export type AnyReadInspection = ReadTableInspection<Record<string, unknown>, Record<string, unknown>>

--- a/packages/react/src/useUmpire.ts
+++ b/packages/react/src/useUmpire.ts
@@ -15,7 +15,7 @@ export function useUmpire<
   C extends Record<string, unknown>,
 >(
   ump: Umpire<F, C>,
-  values: InputValues<F>,
+  values: InputValues,
   conditions?: C,
 ): {
   check: AvailabilityMap<F>

--- a/packages/react/src/useUmpire.ts
+++ b/packages/react/src/useUmpire.ts
@@ -21,7 +21,7 @@ export function useUmpire<
   check: AvailabilityMap<F>
   fouls: Foul<F>[]
 } {
-  const prevRef = useRef<Snapshot<F, C> | undefined>(undefined)
+  const prevRef = useRef<Snapshot<C> | undefined>(undefined)
 
   const check = useMemo(
     () => ump.check(values, conditions, prevRef.current?.values),

--- a/packages/signals/src/reactive.ts
+++ b/packages/signals/src/reactive.ts
@@ -69,8 +69,8 @@ export function reactiveUmp<
   const conditionSignals = options?.conditions ?? {}
 
   // --- 3. Lazy proxy for fine-grained predicate tracking ---
-  function createValuesProxy(): InputValues<F> {
-    return new Proxy({} as InputValues<F>, {
+  function createValuesProxy(): InputValues {
+    return new Proxy({} as InputValues, {
       get(_target, prop) {
         if (typeof prop !== 'string') return undefined
         const sig = fieldSignals.get(prop)
@@ -177,7 +177,7 @@ export function reactiveUmp<
     function readSnapshotValues() {
       return snapshotValue(Object.fromEntries(
         fieldNames.map((name) => [name, fieldSignals.get(name)!.get()]),
-      ) as InputValues<F>)
+      ) as InputValues)
     }
 
     function readSnapshotConditions() {
@@ -186,9 +186,9 @@ export function reactiveUmp<
       ) as C)
     }
 
-    let beforeValues: InputValues<F> = readSnapshotValues()
+    let beforeValues: InputValues = readSnapshotValues()
     let beforeConditions: C = readSnapshotConditions()
-    let lastValues: InputValues<F> = snapshotValue(beforeValues)
+    let lastValues: InputValues = snapshotValue(beforeValues)
     let lastConditions: C = snapshotValue(beforeConditions)
 
     let isFirstRun = true

--- a/packages/solid/src/fromSolidStore.ts
+++ b/packages/solid/src/fromSolidStore.ts
@@ -11,7 +11,7 @@ export type FromSolidStoreOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 > = {
-  values: InputValues<F>
+  values: InputValues
   set(name: keyof F & string, value: unknown): void
   conditions?: Partial<{ [K in keyof C & string]: Accessor<C[K]> }>
 }

--- a/packages/solid/src/useUmpire.ts
+++ b/packages/solid/src/useUmpire.ts
@@ -14,7 +14,7 @@ export function useUmpire<
   C extends Record<string, unknown>,
 >(
   ump: Umpire<F, C>,
-  values: Accessor<InputValues<F>>,
+  values: Accessor<InputValues>,
   conditions?: Accessor<C>,
 ): {
   check: Accessor<AvailabilityMap<F>>

--- a/packages/solid/src/useUmpire.ts
+++ b/packages/solid/src/useUmpire.ts
@@ -22,7 +22,7 @@ export function useUmpire<
 } {
   const [currentCheck, setCheck] = createSignal<AvailabilityMap<F>>()
   const [fouls, setFouls] = createSignal<Foul<F>[]>([])
-  let previousSnapshot: Snapshot<F, C> | undefined
+  let previousSnapshot: Snapshot<C> | undefined
 
   createComputed(() => {
     const currentValues = snapshotRecord(values())

--- a/packages/store/src/fromStore.ts
+++ b/packages/store/src/fromStore.ts
@@ -17,7 +17,7 @@ export type FromStoreOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 > = {
-  select: (state: S) => InputValues<F>
+  select: (state: S) => InputValues
   conditions?: (state: S) => C
 }
 

--- a/packages/zod/src/adapter.ts
+++ b/packages/zod/src/adapter.ts
@@ -45,7 +45,7 @@ export type ZodAdapterRunResult<F extends Record<string, FieldDef>> = {
 export type ZodAdapter<F extends Record<string, FieldDef>> = {
   run(
     availability: AvailabilityMap<F>,
-    values: InputValues<F>,
+    values: InputValues,
   ): ZodAdapterRunResult<F>
   validators: ValidationMap<F>
 }

--- a/packages/zod/src/devtools.ts
+++ b/packages/zod/src/devtools.ts
@@ -70,7 +70,7 @@ type ValidationExtensionInspectContext<
   previous: Snapshot<F, C> | null
   scorecard: ScorecardResult<F, C>
   ump: Umpire<F, C>
-  values: InputValues<F>
+  values: InputValues
 }
 
 type ValidationExtension<F extends Record<string, FieldDef>, C extends Record<string, unknown>> = {

--- a/packages/zod/src/devtools.ts
+++ b/packages/zod/src/devtools.ts
@@ -67,7 +67,7 @@ type ValidationExtensionInspectContext<
   C extends Record<string, unknown>,
 > = {
   conditions?: C
-  previous: Snapshot<F, C> | null
+  previous: Snapshot<C> | null
   scorecard: ScorecardResult<F, C>
   ump: Umpire<F, C>
   values: InputValues


### PR DESCRIPTION
The `FieldValues<F>` mapped type forces consumers to construct and cast values objects before passing them to `check()`, `flag()`, `useUmpire()`, etc. At runtime, umpire only reads values via bracket access and checks truthiness via `isSatisfied()` — it never validates the object shape. The types are more restrictive than the runtime requires, creating ceremony (casts, `Object.fromEntries` transforms) at every call site.

The lineup demo is the proof: `as FieldValues<typeof fields>` is required on a simple `Object.fromEntries()` call. Tests don't need casts because they pass inline object literals, but real components with dynamic state do.

Hopefully this helps. Proof will be in the pudding.

Hoping to see if i can further simplify the runtime from there.