### PR TITLE
🧹 Docs Demo Type Cleanup

### DIFF
--- a/docs/src/components/FreightQuoteDemo.tsx
+++ b/docs/src/components/FreightQuoteDemo.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource preact */
 import { useRef } from 'preact/hooks'
 import { enabledWhen, oneOf, requires, umpire } from '@umpire/core'
 import { register } from '@umpire/devtools/slim'

--- a/docs/src/components/LearnDemos.tsx
+++ b/docs/src/components/LearnDemos.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource preact */
 import { useMemo, useRef, useState } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
 import {
@@ -11,7 +12,7 @@ import {
   umpire,
 } from '@umpire/core'
 import { snapshotValue } from '@umpire/core/snapshot'
-import type { FieldStatus, InputValues } from '@umpire/core'
+import type { FieldStatus } from '@umpire/core'
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const phonePattern = /^\d{10,}$/
@@ -606,7 +607,7 @@ const playUmp = umpire<typeof playFields, PlanConditions>({
 
 export function PlayDemo() {
   const [plan, setPlan] = useState<PlanConditions['plan']>('business')
-  const [values, setValues] = useState<InputValues>({
+  const [values, setValues] = useState({
     companyName: '',
     companySize: '',
   })

--- a/docs/src/components/PcBuilderDemo.tsx
+++ b/docs/src/components/PcBuilderDemo.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { requires, umpire, type Snapshot } from '@umpire/core'
 import { register } from '@umpire/devtools/slim'
 import { createReads, enabledWhenRead, fairWhenRead, ReadInputType } from '@umpire/reads'
-import { createCoach } from '../lib/createCoach.ts'
+import { createCoach } from '../lib/createCoach'
 import '../styles/pc-builder-demo.css'
 
 type Socket = 'LGA1700' | 'AM5'
@@ -211,7 +211,7 @@ const hintUmp = umpire<typeof hintFields, HintInput>({
 type PcValues = ReturnType<typeof pcUmp.init>
 type PcCheck = ReturnType<typeof pcUmp.check>
 type HintCheck = ReturnType<typeof hintUmp.check>
-type PcSnapshot = Snapshot<typeof pcFields, PcConditions>
+type PcSnapshot = Snapshot<PcConditions>
 
 type StepDefinition = {
   index: number

--- a/docs/src/components/SignalsFineGrainedDemo.tsx
+++ b/docs/src/components/SignalsFineGrainedDemo.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource preact */
 import { useRef } from 'preact/hooks'
 import { enabledWhen, requires, umpire } from '@umpire/core'
 import { reactiveUmp, type ReactiveUmpire, type SignalProtocol } from '@umpire/signals'

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
 }


### PR DESCRIPTION
I'd like to get these all looking clean in vim. Not a great look to have weird type artifacts that are just overlooked when trying to demonstrate how to do things in my cool new library!

Docs does not treat typecheck as a hard blocker, this is just for editor sanity.