### PR TITLE
🧹 Consolidate duplicated getFieldNameOrThrow helper

### DIFF
--- a/.changeset/consolidate-getFieldNameOrThrow.md
+++ b/.changeset/consolidate-getFieldNameOrThrow.md
@@ -1,0 +1,5 @@
+---
+"@umpire/core": patch
+---
+
+Consolidate duplicated `getFieldNameOrThrow` into a single export from `field.ts`

--- a/packages/core/src/field.ts
+++ b/packages/core/src/field.ts
@@ -199,7 +199,7 @@ export function getFieldBuilderName(value: unknown): string | undefined {
   return typeof name === 'string' ? name : undefined
 }
 
-function getFieldNameOrThrow<
+export function getFieldNameOrThrow<
   F extends Record<string, FieldDef>,
   V,
 >(

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -3,7 +3,7 @@ import {
   getCompositeTargetEvaluation,
 } from './composite.js'
 import { shouldWarnInDev } from './dev.js'
-import { getFieldBuilderName } from './field.js'
+import { getFieldBuilderName, getFieldNameOrThrow } from './field.js'
 import { isSatisfied } from './satisfaction.js'
 import { isNamedCheck as isNamedCheckValidator, runFieldValidator } from './validation.js'
 import type {
@@ -350,24 +350,6 @@ function getFairCheckField<
   predicate: FairPredicate<V, F, C>,
 ): (keyof F & string) | undefined {
   return predicate._checkField
-}
-
-function getFieldNameOrThrow<
-  F extends Record<string, FieldDef>,
-  V,
->(
-  field: FieldSelector<F, V>,
-): keyof F & string {
-  if (typeof field === 'string') {
-    return field
-  }
-
-  const name = getFieldBuilderName(field)
-  if (!name) {
-    throw new Error('[@umpire/core] Named field builder required when passing a field() value to a rule')
-  }
-
-  return name as keyof F & string
 }
 
 export function getSourceField<


### PR DESCRIPTION
## Summary

- Exports `getFieldNameOrThrow` from `field.ts` (was already defined there but unexported)
- Removes the identical duplicate definition from `rules.ts`
- `rules.ts` now imports `getFieldNameOrThrow` from `./field.js` alongside the existing `getFieldBuilderName` import

Closes #46