### PR TITLE
🔧 Remove duplicated requires rule evaluation logic

### DIFF
--- a/.changeset/remove-duplicated-requires-evaluation.md
+++ b/.changeset/remove-duplicated-requires-evaluation.md
@@ -1,0 +1,5 @@
+---
+"@umpire/core": patch
+---
+
+Remove duplicated requires rule evaluation logic from evaluator.ts

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -2,7 +2,6 @@ import {
   combineCompositeResults,
   getCompositeFailureReasons,
 } from './composite.js'
-import { isSatisfied } from './satisfaction.js'
 import { getInternalRuleMetadata, isFairRule, isGateRule, resolveReason } from './rules.js'
 import type { AvailabilityMap, FieldDef, FieldValues, Rule, RuleEvaluation } from './types.js'
 
@@ -103,38 +102,6 @@ export function evaluateRuleForField<
     )
 
     return combineCompositeResults(metadata.constraint, 'or', branchResults)
-  }
-
-  if (metadata?.kind === 'requires') {
-    const reasons = metadata.dependencies.flatMap((dependency) => {
-      if (typeof dependency !== 'string') {
-        if (dependency(values, conditions)) {
-          return []
-        }
-
-        return [
-          resolveReason(metadata.options?.reason, values, conditions, 'required condition not met'),
-        ]
-      }
-
-      const dependencySatisfied = isSatisfied(values[dependency], fields[dependency])
-      const dependencyEnabled = availability[dependency]?.enabled ?? true
-      const dependencyFair = availability[dependency]?.fair ?? true
-
-      if (dependencySatisfied && dependencyEnabled && dependencyFair) {
-        return []
-      }
-
-      return [
-        resolveReason(metadata.options?.reason, values, conditions, `requires ${dependency}`),
-      ]
-    })
-
-    return {
-      enabled: reasons.length === 0,
-      reason: reasons[0] ?? null,
-      reasons: reasons.length === 0 ? undefined : reasons,
-    }
   }
 
   let evaluation = baseRuleCache.get(rule)


### PR DESCRIPTION
## Summary

- Removes the `metadata?.kind === 'requires'` special case from `evaluateRuleForField` in `evaluator.ts`
- The `requires` rule's own `evaluate()` method in `rules.ts` already produces identical results, making the evaluator's inline reimplementation redundant
- Also removes the now-unused `isSatisfied` import from `evaluator.ts`
- Requires rules now flow through the normal `baseRuleCache` path like all other rules (benign caching improvement)

Closes #47