### PR TITLE
✨ Derive oneOf rules from Zod discriminated unions

### DIFF
--- a/.changeset/zod-discriminated-union.md
+++ b/.changeset/zod-discriminated-union.md
@@ -1,0 +1,5 @@
+---
+'@umpire/zod': minor
+---
+
+Add `deriveOneOf` and `deriveDiscriminatedFields` to derive umpire `oneOf` rules from Zod `z.discriminatedUnion` schemas. Supports both Zod v3 and v4.

--- a/docs/src/content/docs/adapters/validation/zod.md
+++ b/docs/src/content/docs/adapters/validation/zod.md
@@ -136,8 +136,114 @@ If `confirmPassword` is disabled, `deriveSchema` excludes it and the refinement 
 
 `@umpire/zod` handles the common case. If you need finer control — async validators, nested schemas, custom coercion, or `superRefine` — the manual intersection approach in [Composing with Validation](/umpire/concepts/validation/) gives you full flexibility.
 
+## Discriminated Unions
+
+If you have an existing Zod discriminated union that models mutually-exclusive field groups, you can derive an umpire `oneOf` rule from it directly. This is a compatibility path — umpire's native [`oneOf`](/umpire/api/rules/one-of/) gives you the same structure without the schema coupling. But if your validation layer already defines the groups via `z.discriminatedUnion`, there is no reason to duplicate that definition.
+
+Take this payment method schema as the running example:
+
+```ts
+const paymentSchema = z.discriminatedUnion('method', [
+  z.object({
+    method: z.literal('card'),
+    cardNumber: z.string(),
+    cvv: z.string(),
+  }),
+  z.object({
+    method: z.literal('bank'),
+    routingNumber: z.string(),
+    accountNumber: z.string(),
+  }),
+])
+```
+
+### `deriveOneOf(schema, options)`
+
+Derives a `oneOf` Rule from a `z.discriminatedUnion`. You supply your own field definitions — this only produces the rule.
+
+```ts
+deriveOneOf(
+  schema: z.ZodDiscriminatedUnion,
+  options: DeriveOptions,
+): Rule
+```
+
+```ts
+import { deriveOneOf } from '@umpire/zod'
+import { umpire } from '@umpire/core'
+
+const ump = umpire({
+  fields: {
+    method:        { required: true },
+    cardNumber:    { required: true },
+    cvv:           { required: true },
+    routingNumber: { required: true },
+    accountNumber: { required: true },
+  },
+  rules: [
+    deriveOneOf(paymentSchema, { groupName: 'paymentMethod' }),
+  ],
+})
+```
+
+`activeBranch` is wired automatically: it reads the discriminator field from state and returns the active branch name. When the discriminator holds `'card'`, the `bank` branch fields are disabled; when it holds `'bank'`, the `card` branch fields are disabled.
+
+### `deriveDiscriminatedFields(schema, options)`
+
+Derives both the field definitions and the `oneOf` rule together. Use this when you do not already have field definitions and want the schema to be the source of truth.
+
+```ts
+deriveDiscriminatedFields(
+  schema: z.ZodDiscriminatedUnion,
+  options: DeriveOptions & { required?: boolean },
+): { fields: Record<string, FieldDef>, rule: Rule }
+```
+
+```ts
+import { deriveDiscriminatedFields } from '@umpire/zod'
+import { umpire } from '@umpire/core'
+
+const { fields, rule } = deriveDiscriminatedFields(paymentSchema, {
+  groupName: 'paymentMethod',
+})
+
+const ump = umpire({ fields, rules: [rule] })
+```
+
+`required` inference follows Zod's optionality: non-optional Zod fields become `required: true`, optional fields become `required: false`. Pass `required: true` to override this and mark all non-discriminator fields as required regardless of Zod optionality.
+
+The discriminator field (`method` in this example) is always `required: true` in the derived field definitions. It is not included in any branch array — branches contain only the variant-specific fields.
+
+### `DeriveOptions`
+
+```ts
+type DeriveOptions = {
+  groupName: string               // name for the oneOf group
+  exclude?: string[]              // fields to omit from branch arrays and field definitions
+  branchNames?: Record<string, string>  // remap Zod literal values to branch names
+}
+```
+
+`branchNames` is useful when your Zod literal values are not valid or readable umpire branch names. The state holds the raw literal value; `activeBranch` translates it to the mapped branch name at runtime.
+
+```ts
+deriveOneOf(paymentSchema, {
+  groupName: 'paymentMethod',
+  branchNames: { card: 'creditCard', bank: 'bankTransfer' },
+})
+```
+
+With this mapping, umpire branches are named `creditCard` and `bankTransfer`, but the discriminator field in state still holds `'card'` or `'bank'`.
+
+### Compatibility
+
+Both functions work with Zod v3 and v4. The literal value is read from `._def.value` (v3) or `.value` (v4) — whichever is present.
+
+`oneOf` throws at config time if any field appears in more than one branch. This mirrors the expectation from `z.discriminatedUnion` that variant shapes are non-overlapping (the discriminator field is excluded from this check).
+
 ## See also
 
+- [`oneOf`](/umpire/api/rules/one-of/) — the native rule for mutually-exclusive field groups
 - [Validator Integrations](/umpire/adapters/validation/) — the general contract and how it extends to other libraries
 - [Composing with Validation](/umpire/concepts/validation/) — conceptual boundary and manual patterns
 - [Signup Form + Zod](/umpire/examples/signup/) — full walkthrough with `deriveSchema`, the render loop, and foul handling

--- a/packages/zod/__tests__/discriminated.test.ts
+++ b/packages/zod/__tests__/discriminated.test.ts
@@ -167,7 +167,7 @@ describe('deriveDiscriminatedFields', () => {
       rules: [rule],
     })
 
-    const withCard = u.check({ method: 'creditCard' })
+    const withCard = u.check({ method: 'card' })
     expect(withCard.cardNumber.enabled).toBe(true)
     expect(withCard.cvv.enabled).toBe(true)
     expect(withCard.routingNumber.enabled).toBe(false)

--- a/packages/zod/__tests__/discriminated.test.ts
+++ b/packages/zod/__tests__/discriminated.test.ts
@@ -49,6 +49,27 @@ describe('deriveOneOf', () => {
     expect(withBank.cardNumber.enabled).toBe(false)
     expect(withBank.cvv.enabled).toBe(false)
   })
+
+  test('all branch fields enabled when discriminator is not set', () => {
+    const rule = deriveOneOf(paymentSchema, { groupName: 'payment' })
+
+    const u = umpire({
+      fields: {
+        method: { required: true },
+        cardNumber: { required: true },
+        cvv: { required: true },
+        routingNumber: { required: true },
+        accountNumber: { required: true },
+      },
+      rules: [rule],
+    })
+
+    const initial = u.check({})
+    expect(initial.cardNumber.enabled).toBe(true)
+    expect(initial.cvv.enabled).toBe(true)
+    expect(initial.routingNumber.enabled).toBe(true)
+    expect(initial.accountNumber.enabled).toBe(true)
+  })
 })
 
 describe('deriveDiscriminatedFields', () => {
@@ -151,6 +172,71 @@ describe('deriveDiscriminatedFields', () => {
     expect(withCard.cvv.enabled).toBe(true)
     expect(withCard.routingNumber.enabled).toBe(false)
     expect(withCard.accountNumber.enabled).toBe(false)
+  })
+
+  test('branchNames with exclude: fields correctly derived when both options used', () => {
+    const schema = z.discriminatedUnion('kind', [
+      z.object({
+        kind: z.literal('a'),
+        fieldA: z.string(),
+        commonField: z.string(),
+      }),
+      z.object({
+        kind: z.literal('b'),
+        fieldB: z.number(),
+        commonField: z.string(),
+      }),
+    ])
+
+    const { fields, rule } = deriveDiscriminatedFields(schema, {
+      groupName: 'combined',
+      branchNames: { a: 'typeA', b: 'typeB' },
+      exclude: ['commonField'],
+    })
+
+    // Verify commonField is excluded
+    expect(fields.commonField).toBeUndefined()
+    // Verify other fields are present
+    expect(fields.fieldA.required).toBe(true)
+    expect(fields.fieldB.required).toBe(true)
+    expect(fields.kind.required).toBe(true)
+
+    // Verify the rule works end-to-end with the remapped branch names
+    const u = umpire({
+      fields: {
+        kind: { required: true },
+        fieldA: { required: true },
+        fieldB: { required: true },
+      },
+      rules: [rule],
+    })
+
+    const withTypeA = u.check({ kind: 'typeA' })
+    expect(withTypeA.fieldA.enabled).toBe(true)
+    expect(withTypeA.fieldB.enabled).toBe(false)
+
+    const withTypeB = u.check({ kind: 'typeB' })
+    expect(withTypeB.fieldB.enabled).toBe(true)
+    expect(withTypeB.fieldA.enabled).toBe(false)
+  })
+
+  test('overlapping fields across variants throws at oneOf validation', () => {
+    const schema = z.discriminatedUnion('kind', [
+      z.object({
+        kind: z.literal('a'),
+        shared: z.string(),
+        onlyA: z.string(),
+      }),
+      z.object({
+        kind: z.literal('b'),
+        shared: z.string().optional(),
+        onlyB: z.number(),
+      }),
+    ])
+
+    expect(() =>
+      deriveDiscriminatedFields(schema, { groupName: 'overlap' }),
+    ).toThrow('field "shared" appears in multiple branches')
   })
 })
 

--- a/packages/zod/__tests__/discriminated.test.ts
+++ b/packages/zod/__tests__/discriminated.test.ts
@@ -1,0 +1,238 @@
+import { describe, test, expect } from 'bun:test'
+import { z } from 'zod'
+import { umpire } from '@umpire/core'
+import { deriveOneOf, deriveDiscriminatedFields } from '../src/discriminated.js'
+
+const paymentSchema = z.discriminatedUnion('method', [
+  z.object({
+    method: z.literal('card'),
+    cardNumber: z.string(),
+    cvv: z.string(),
+  }),
+  z.object({
+    method: z.literal('bank'),
+    routingNumber: z.string(),
+    accountNumber: z.string(),
+  }),
+])
+
+describe('deriveOneOf', () => {
+  test('returns a rule function from a two-variant discriminated union', () => {
+    const rule = deriveOneOf(paymentSchema, { groupName: 'payment' })
+    expect(typeof rule).toBe('object')
+    expect(rule.type).toBe('oneOf')
+  })
+
+  test('end-to-end: setting discriminator hides other branch fields', () => {
+    const rule = deriveOneOf(paymentSchema, { groupName: 'payment' })
+
+    const u = umpire({
+      fields: {
+        method: { required: true },
+        cardNumber: { required: true },
+        cvv: { required: true },
+        routingNumber: { required: true },
+        accountNumber: { required: true },
+      },
+      rules: [rule],
+    })
+
+    const withCard = u.check({ method: 'card' })
+    expect(withCard.cardNumber.enabled).toBe(true)
+    expect(withCard.cvv.enabled).toBe(true)
+    expect(withCard.routingNumber.enabled).toBe(false)
+    expect(withCard.accountNumber.enabled).toBe(false)
+
+    const withBank = u.check({ method: 'bank' })
+    expect(withBank.routingNumber.enabled).toBe(true)
+    expect(withBank.accountNumber.enabled).toBe(true)
+    expect(withBank.cardNumber.enabled).toBe(false)
+    expect(withBank.cvv.enabled).toBe(false)
+  })
+})
+
+describe('deriveDiscriminatedFields', () => {
+  test('fields contain all variant keys plus discriminator', () => {
+    const { fields } = deriveDiscriminatedFields(paymentSchema, {
+      groupName: 'payment',
+    })
+
+    expect(Object.keys(fields).sort()).toEqual(
+      ['accountNumber', 'cardNumber', 'cvv', 'method', 'routingNumber'].sort(),
+    )
+    expect(fields.method.required).toBe(true)
+  })
+
+  test('required inference: optional Zod fields produce required false', () => {
+    const schema = z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('a'),
+        requiredField: z.string(),
+        optionalField: z.string().optional(),
+      }),
+      z.object({
+        type: z.literal('b'),
+        anotherField: z.number(),
+      }),
+    ])
+
+    const { fields } = deriveDiscriminatedFields(schema, {
+      groupName: 'test',
+    })
+
+    expect(fields.requiredField.required).toBe(true)
+    expect(fields.optionalField.required).toBe(false)
+    expect(fields.anotherField.required).toBe(true)
+  })
+
+  test('required override: all non-discriminator fields become required', () => {
+    const schema = z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('a'),
+        optField: z.string().optional(),
+      }),
+      z.object({
+        type: z.literal('b'),
+        otherField: z.number(),
+      }),
+    ])
+
+    const { fields } = deriveDiscriminatedFields(schema, {
+      groupName: 'test',
+      required: true,
+    })
+
+    expect(fields.optField.required).toBe(true)
+    expect(fields.otherField.required).toBe(true)
+    expect(fields.type.required).toBe(true)
+  })
+
+  test('exclude removes keys from fields and branch arrays', () => {
+    const { fields, rule } = deriveDiscriminatedFields(paymentSchema, {
+      groupName: 'payment',
+      exclude: ['cvv'],
+    })
+
+    expect(fields.cvv).toBeUndefined()
+
+    const u = umpire({
+      fields: {
+        method: { required: true },
+        cardNumber: { required: true },
+        routingNumber: { required: true },
+        accountNumber: { required: true },
+      },
+      rules: [rule],
+    })
+
+    const withCard = u.check({ method: 'card' })
+    expect(withCard.cardNumber.enabled).toBe(true)
+  })
+
+  test('branchNames remaps discriminator literal values', () => {
+    const { rule } = deriveDiscriminatedFields(paymentSchema, {
+      groupName: 'payment',
+      branchNames: { card: 'creditCard', bank: 'bankTransfer' },
+    })
+
+    const u = umpire({
+      fields: {
+        method: { required: true },
+        cardNumber: { required: true },
+        cvv: { required: true },
+        routingNumber: { required: true },
+        accountNumber: { required: true },
+      },
+      rules: [rule],
+    })
+
+    const withCard = u.check({ method: 'creditCard' })
+    expect(withCard.cardNumber.enabled).toBe(true)
+    expect(withCard.cvv.enabled).toBe(true)
+    expect(withCard.routingNumber.enabled).toBe(false)
+    expect(withCard.accountNumber.enabled).toBe(false)
+  })
+})
+
+describe('zod v4 compatibility', () => {
+  test('extractBranches reads discriminator from _zod.def when .discriminator is absent', () => {
+    // Simulate a v4-shaped schema: no .discriminator getter, discriminator in _zod.def,
+    // and ZodLiteral exposes .value getter (not ._def.value)
+    const v4LikeSchema = {
+      _zod: {
+        def: { discriminator: 'method' },
+      },
+      options: [
+        {
+          shape: {
+            method: { _def: { values: ['card'] }, value: 'card', isOptional: () => false },
+            cardNumber: { isOptional: () => false },
+          },
+        },
+        {
+          shape: {
+            method: { _def: { values: ['bank'] }, value: 'bank', isOptional: () => false },
+            routingNumber: { isOptional: () => false },
+          },
+        },
+      ],
+    }
+
+    // deriveDiscriminatedFields exercises extractBranches internally
+    const { fields, rule } = deriveDiscriminatedFields(v4LikeSchema as any, {
+      groupName: 'v4test',
+    })
+
+    expect(fields.method).toEqual({ required: true })
+    expect(fields.cardNumber).toEqual({ required: true })
+    expect(fields.routingNumber).toEqual({ required: true })
+    expect(Object.keys(fields).sort()).toEqual(['cardNumber', 'method', 'routingNumber'])
+
+    // Verify the rule works end-to-end with umpire
+    const u = umpire({
+      fields: {
+        method: { required: true },
+        cardNumber: { required: true },
+        routingNumber: { required: true },
+      },
+      rules: [rule],
+    })
+
+    const withCard = u.check({ method: 'card' })
+    expect(withCard.cardNumber.enabled).toBe(true)
+    expect(withCard.routingNumber.enabled).toBe(false)
+
+    const withBank = u.check({ method: 'bank' })
+    expect(withBank.routingNumber.enabled).toBe(true)
+    expect(withBank.cardNumber.enabled).toBe(false)
+  })
+
+  test('extractBranches still uses .discriminator when present (v3 path)', () => {
+    // Simulate a v3-shaped schema: .discriminator getter present
+    const v3LikeSchema = {
+      discriminator: 'type',
+      options: [
+        {
+          shape: {
+            type: { _def: { value: 'x' }, isOptional: () => false },
+            xField: { isOptional: () => false },
+          },
+        },
+        {
+          shape: {
+            type: { _def: { value: 'y' }, isOptional: () => false },
+            yField: { isOptional: () => true },
+          },
+        },
+      ],
+    }
+
+    const { fields } = deriveDiscriminatedFields(v3LikeSchema as any, {
+      groupName: 'v3test',
+    })
+
+    expect(fields.type).toEqual({ required: true })
+    expect(fields.xField).toEqual({ required: true })
+    expect(fields.yField).toEqual({ required: false })
+  })
+})

--- a/packages/zod/src/discriminated.ts
+++ b/packages/zod/src/discriminated.ts
@@ -39,6 +39,12 @@ function extractBranches(
     const shape = variant.shape
     const literalField = shape[discriminator] as any
     const rawValue: string = literalField._def?.value ?? literalField.value
+    if (rawValue == null) {
+      throw new Error(
+        `[@umpire/zod] Could not extract literal value from discriminator field "${discriminator}". ` +
+          `Expected a ZodLiteral with ._def.value (v3) or .value (v4).`,
+      )
+    }
     const branchName = options.branchNames?.[rawValue] ?? rawValue
     const branchFields: string[] = []
 

--- a/packages/zod/src/discriminated.ts
+++ b/packages/zod/src/discriminated.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod'
+import { oneOf, type Rule, type FieldDef } from '@umpire/core'
+
+type DiscriminatedUnionOption = z.ZodObject<z.ZodRawShape>
+
+type ExtractedBranches = {
+  discriminator: string
+  branches: Record<string, string[]>
+  fieldDefs: Record<string, { required: boolean }>
+}
+
+export type DeriveOptions = {
+  groupName: string
+  exclude?: string[]
+  branchNames?: Record<string, string>
+}
+
+function extractBranches(
+  schema: z.ZodDiscriminatedUnion<string, DiscriminatedUnionOption[]>,
+  options: {
+    exclude?: string[]
+    branchNames?: Record<string, string>
+    forceRequired?: boolean
+  } = {},
+): ExtractedBranches {
+  const discriminator: string =
+    'discriminator' in schema
+      ? (schema as any).discriminator
+      : (schema as any)._zod.def.discriminator
+  const excludeSet = new Set([discriminator, ...(options.exclude ?? [])])
+
+  const branches: Record<string, string[]> = {}
+  const fieldDefs: Record<string, { required: boolean }> = {}
+
+  // Discriminator field
+  fieldDefs[discriminator] = { required: true }
+
+  for (const variant of schema.options) {
+    const shape = variant.shape
+    const literalField = shape[discriminator] as any
+    const rawValue: string = literalField._def?.value ?? literalField.value
+    const branchName = options.branchNames?.[rawValue] ?? rawValue
+    const branchFields: string[] = []
+
+    for (const [key, zodType] of Object.entries(shape)) {
+      if (excludeSet.has(key)) continue
+
+      branchFields.push(key)
+
+      if (!(key in fieldDefs)) {
+        fieldDefs[key] = {
+          required: options.forceRequired ?? !zodType.isOptional(),
+        }
+      }
+    }
+
+    branches[branchName] = branchFields
+  }
+
+  return { discriminator, branches, fieldDefs }
+}
+
+/**
+ * Derive a oneOf rule from a Zod discriminated union.
+ */
+export function deriveOneOf<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  schema: z.ZodDiscriminatedUnion<string, DiscriminatedUnionOption[]>,
+  options: DeriveOptions,
+): Rule<F, C> {
+  const { discriminator, branches } = extractBranches(schema, options)
+  const branchNames = options.branchNames
+  return oneOf<F, C>(options.groupName, branches, {
+    activeBranch: (values) => {
+      const raw = values[discriminator as keyof F] as string | null | undefined
+      if (raw == null) return null
+      return branchNames?.[raw] ?? raw
+    },
+  })
+}
+
+/**
+ * Derive fields AND oneOf rule together.
+ */
+export function deriveDiscriminatedFields<
+  T extends z.ZodDiscriminatedUnion<string, DiscriminatedUnionOption[]>,
+>(
+  schema: T,
+  options: DeriveOptions & { required?: boolean },
+): {
+  fields: Record<string, FieldDef>
+  rule: Rule<Record<string, FieldDef>, Record<string, unknown>>
+} {
+  const { discriminator, branches, fieldDefs } = extractBranches(schema, {
+    ...options,
+    forceRequired: options.required,
+  })
+  const branchNames = options.branchNames
+
+  return {
+    fields: fieldDefs,
+    rule: oneOf(options.groupName, branches, {
+      activeBranch: (values) => {
+        const raw = values[discriminator as keyof typeof values] as string | null | undefined
+        if (raw == null) return null
+        return branchNames?.[raw] ?? raw
+      },
+    }),
+  }
+}

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -8,3 +8,4 @@ export type {
   ZodAdapter,
   ZodAdapterRunResult,
 } from './adapter.js'
+export { deriveOneOf, deriveDiscriminatedFields, type DeriveOptions } from './discriminated.js'


### PR DESCRIPTION
## Summary

- Add `deriveOneOf` and `deriveDiscriminatedFields` to `@umpire/zod` — derives umpire `oneOf` rules directly from Zod `z.discriminatedUnion` schemas
- Wires `activeBranch` so the discriminator field value drives branch selection
- Supports both Zod v3 and v4 runtime shapes (feature-detected)

## Test plan

- [x] 9 test cases covering: basic derivation, end-to-end branch toggling, required inference, `required` override, `exclude`, `branchNames` remapping, and v4 compatibility with mock schemas
- [x] Typecheck passes
- [x] Build passes
- [x] CI green
