### PR TITLE
🩹 Scope demo color tokens to root for shared docs UI

### DIFF
--- a/docs/src/styles/settings/_settings.site-tokens.css
+++ b/docs/src/styles/settings/_settings.site-tokens.css
@@ -29,5 +29,10 @@
   --umpire-font-mono: 'JetBrains Mono', monospace;
   --umpire-font-heading: 'Space Grotesk', sans-serif;
   --umpire-font-body: 'Work Sans', sans-serif;
+  --umpire-demo-white-2: rgba(255, 255, 255, 0.02);
+  --umpire-demo-white-3: rgba(255, 255, 255, 0.03);
+  --umpire-demo-green-8: rgba(107, 254, 156, 0.08);
+  --umpire-demo-green-16: rgba(107, 254, 156, 0.16);
+  --umpire-demo-red-12: rgba(255, 113, 108, 0.12);
   color-scheme: dark;
 }


### PR DESCRIPTION
## Summary
- Add the missing `--umpire-demo-*` color/surface tokens to `:root` in `docs/src/styles/settings/_settings.site-tokens.css`.
- Keep existing `.c-umpire-demo` token definitions intact while making shared docs surfaces (homepage scoreboard, nav, hero) resolve these variables correctly.