### PR TITLE
✨ Add Config-Driven UI example with live JSON editor demo

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -149,6 +149,7 @@ export default defineConfig({
             { label: 'Freight Quote', slug: 'examples/freight-quote' },
             { label: 'Login + Captcha', slug: 'examples/captcha' },
             { label: 'Signup Form + Zod', slug: 'examples/signup' },
+            { label: 'Config-Driven UI', slug: 'examples/config-driven-ui' },
           ],
         },
       ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "@preact/signals-core": "^1.0.0",
     "@umpire/core": "portal:../packages/core",
     "@umpire/devtools": "portal:../packages/devtools",
+    "@umpire/json": "portal:../packages/json",
     "@umpire/react": "portal:../packages/react",
     "@umpire/reads": "portal:../packages/reads",
     "@umpire/signals": "portal:../packages/signals",
@@ -35,6 +36,7 @@
     "@umpire/core": "portal:../packages/core",
     "@umpire/reads": "portal:../packages/reads",
     "@umpire/devtools": "portal:../packages/devtools",
+    "@umpire/json": "portal:../packages/json",
     "@umpire/store": "portal:../packages/store",
     "vite": "^6.4.1"
   },

--- a/docs/src/components/ConfigDrivenDemo.tsx
+++ b/docs/src/components/ConfigDrivenDemo.tsx
@@ -1,0 +1,539 @@
+import { useMemo, useState } from 'react'
+import { umpire } from '@umpire/core'
+import type { FieldDef, InputValues, Umpire } from '@umpire/core'
+import { fromJson } from '@umpire/json'
+import type { JsonRule, UmpireJsonSchema } from '@umpire/json'
+import { useUmpire } from '@umpire/react'
+import '../styles/components/_components.config-driven-demo.css'
+
+// The "seeded" JSON the demo opens with. Small, branchy, shows three rule
+// types. Lifted verbatim from the plan so the narrative and the demo match.
+const seedSchema: UmpireJsonSchema = {
+  version: 1,
+  fields: {
+    accountType: { required: true, isEmpty: 'string' },
+    email:       { required: true, isEmpty: 'string' },
+    companyName: { required: true, isEmpty: 'string' },
+    taxId:       { required: true, isEmpty: 'string' },
+    country:     { required: true, isEmpty: 'string' },
+    state:       { required: true, isEmpty: 'string' },
+  },
+  rules: [
+    {
+      type: 'enabledWhen',
+      field: 'companyName',
+      when: { op: 'eq', field: 'accountType', value: 'business' },
+      reason: 'Business accounts only',
+    },
+    {
+      type: 'enabledWhen',
+      field: 'taxId',
+      when: { op: 'eq', field: 'accountType', value: 'business' },
+      reason: 'Business accounts only',
+    },
+    {
+      type: 'enabledWhen',
+      field: 'state',
+      when: { op: 'eq', field: 'country', value: 'US' },
+      reason: 'US addresses only',
+    },
+  ],
+  validators: {
+    email: { op: 'email', error: 'Enter a valid email address' },
+  },
+}
+
+const seedJson = JSON.stringify(seedSchema, null, 2)
+
+type FieldMeta = {
+  label: string
+  placeholder?: string
+  inputType?: 'text' | 'email' | 'select'
+  options?: Array<{ value: string; label: string }>
+}
+
+// Renderer-side metadata. The point of the page: **the renderer owns this
+// map, the umpire owns behavior.** Adding a new field to the JSON falls back
+// to the "text" default without touching this file — see `metaFor()`.
+const fieldMeta: Record<string, FieldMeta> = {
+  accountType: {
+    label: 'Account type',
+    inputType: 'select',
+    options: [
+      { value: 'individual', label: 'Individual' },
+      { value: 'business',   label: 'Business' },
+    ],
+  },
+  email:       { label: 'Email',        placeholder: 'alex@example.com', inputType: 'email' },
+  companyName: { label: 'Company name', placeholder: 'Acme Corporation' },
+  taxId:       { label: 'Tax ID',       placeholder: 'e.g. 12-3456789' },
+  country: {
+    label: 'Country',
+    inputType: 'select',
+    options: [
+      { value: 'US',    label: 'United States' },
+      { value: 'CA',    label: 'Canada' },
+      { value: 'Other', label: 'Elsewhere' },
+    ],
+  },
+  state:         { label: 'State',            placeholder: 'CA' },
+  billingEmail:  { label: 'Billing contact',  placeholder: 'billing@acme.com', inputType: 'email' },
+}
+
+function metaFor(field: string): FieldMeta {
+  return fieldMeta[field] ?? { label: field, placeholder: `Enter ${field}` }
+}
+
+// ── Mutations: the three "try this" single-click edits ──────────────────────
+
+type Mutation = {
+  id: string
+  label: string
+  blurb: string
+  tone: 'add' | 'swap' | 'break'
+  apply: (schema: UmpireJsonSchema) => UmpireJsonSchema
+  isApplied: (schema: UmpireJsonSchema) => boolean
+}
+
+const addBillingContactRule: JsonRule = {
+  type: 'enabledWhen',
+  field: 'billingEmail',
+  when: { op: 'eq', field: 'accountType', value: 'business' },
+  reason: 'Business accounts only',
+}
+
+const mutations: Mutation[] = [
+  {
+    id: 'add-rule',
+    label: '+ Add a rule',
+    tone: 'add',
+    blurb: 'Wire a billing contact to the business branch.',
+    apply(schema) {
+      if (schema.fields.billingEmail) return schema
+      return {
+        ...schema,
+        fields: {
+          ...schema.fields,
+          billingEmail: { required: true, isEmpty: 'string' },
+        },
+        rules: [...schema.rules, addBillingContactRule],
+      }
+    },
+    isApplied(schema) {
+      return Boolean(schema.fields.billingEmail)
+    },
+  },
+  {
+    id: 'swap-validator',
+    label: '↻ Swap a validator',
+    tone: 'swap',
+    blurb: 'Restrict email to the @umpire.co domain.',
+    apply(schema) {
+      return {
+        ...schema,
+        validators: {
+          ...schema.validators,
+          email: {
+            op: 'matches',
+            pattern: '@umpire\\.co$',
+            error: 'Must be an @umpire.co address',
+          },
+        },
+      }
+    },
+    isApplied(schema) {
+      return schema.validators?.email?.op === 'matches'
+    },
+  },
+  {
+    id: 'break-it',
+    label: '⚠ Break it',
+    tone: 'break',
+    blurb: 'Introduce an op the schema can\u2019t serialize.',
+    apply(schema) {
+      return {
+        ...schema,
+        rules: schema.rules.map((rule) => {
+          if (rule.type === 'enabledWhen' && rule.field === 'state') {
+            return {
+              ...rule,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              when: { op: 'eqIgnoreCase', field: 'country', value: 'US' } as any,
+            }
+          }
+          return rule
+        }),
+      }
+    },
+    isApplied(schema) {
+      return schema.rules.some((rule) =>
+        rule.type === 'enabledWhen' &&
+        rule.field === 'state' &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (rule.when as any)?.op === 'eqIgnoreCase',
+      )
+    },
+  },
+]
+
+// ── Parse attempt ───────────────────────────────────────────────────────────
+
+type ParseAttempt =
+  | { status: 'ok'; schema: UmpireJsonSchema; ump: Umpire<Record<string, FieldDef>, Record<string, unknown>>; fieldOrder: string[] }
+  | { status: 'error'; error: string }
+
+function parseAttempt(text: string): ParseAttempt {
+  let raw: unknown
+  try {
+    raw = JSON.parse(text)
+  } catch (error) {
+    return { status: 'error', error: `JSON parse error: ${(error as Error).message}` }
+  }
+
+  try {
+    // `fromJson()` calls validateSchema() internally and throws on failure.
+    const schema = raw as UmpireJsonSchema
+    const { fields, rules, validators } = fromJson(schema)
+    const ump = umpire({ fields, rules, validators })
+    const fieldOrder = Object.keys(schema.fields)
+    return { status: 'ok', schema, ump, fieldOrder }
+  } catch (error) {
+    return { status: 'error', error: (error as Error).message }
+  }
+}
+
+function cls(...parts: Array<string | false | null | undefined>): string {
+  return parts.filter(Boolean).join(' ')
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export default function ConfigDrivenDemo() {
+  const [jsonText, setJsonText] = useState(seedJson)
+  const parse = useMemo(() => parseAttempt(jsonText), [jsonText])
+
+  function replaceSchema(next: UmpireJsonSchema) {
+    setJsonText(JSON.stringify(next, null, 2))
+  }
+
+  function resetSeed() {
+    setJsonText(seedJson)
+  }
+
+  const appliedMutations = parse.status === 'ok'
+    ? mutations.filter((m) => m.isApplied(parse.schema))
+    : []
+
+  return (
+    <div className="c-umpire-demo c-config-demo">
+      <div className="c-config-demo__prompts">
+        <div className="c-config-demo__prompts-header">
+          <span className="c-umpire-demo__eyebrow">Try this</span>
+          <button
+            type="button"
+            className="c-config-demo__reset"
+            onClick={resetSeed}
+            disabled={jsonText === seedJson}
+          >
+            Reset JSON
+          </button>
+        </div>
+        <div className="c-config-demo__prompts-list">
+          {mutations.map((mutation) => {
+            const applied = parse.status === 'ok' && mutation.isApplied(parse.schema)
+            return (
+              <button
+                key={mutation.id}
+                type="button"
+                className={cls(
+                  'c-config-demo__prompt',
+                  `c-config-demo__prompt--${mutation.tone}`,
+                  applied && 'is-applied',
+                )}
+                onClick={() => {
+                  if (parse.status !== 'ok') return
+                  replaceSchema(mutation.apply(parse.schema))
+                }}
+                disabled={parse.status !== 'ok' || applied}
+              >
+                <span className="c-config-demo__prompt-label">{mutation.label}</span>
+                <span className="c-config-demo__prompt-blurb">{mutation.blurb}</span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="c-umpire-demo__layout c-config-demo__layout">
+        <section className="c-umpire-demo__panel c-config-demo__panel--json">
+          <div className="c-umpire-demo__panel-header">
+            <div>
+              <div className="c-umpire-demo__eyebrow">Portable schema</div>
+              <h2 className="c-umpire-demo__title">schema.json</h2>
+            </div>
+            <span className="c-umpire-demo__panel-accent">
+              {parse.status === 'ok' ? `v${parse.schema.version} · editable` : 'rejected'}
+            </span>
+          </div>
+          <div className="c-umpire-demo__panel-body c-config-demo__panel-body--json">
+            <textarea
+              className="c-config-demo__editor"
+              value={jsonText}
+              spellCheck={false}
+              onChange={(event) => setJsonText(event.currentTarget.value)}
+              aria-label="Umpire schema JSON"
+            />
+            {appliedMutations.length > 0 && (
+              <div className="c-config-demo__applied">
+                {appliedMutations.map((mutation) => (
+                  <span
+                    key={mutation.id}
+                    className={cls('c-config-demo__applied-pill', `c-config-demo__applied-pill--${mutation.tone}`)}
+                  >
+                    {mutation.label.replace(/^[+↻⚠]\s*/, '')}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="c-umpire-demo__panel c-config-demo__panel--form">
+          {parse.status === 'ok' ? (
+            <LiveForm parse={parse} />
+          ) : (
+            <SchemaRejected error={parse.error} onReset={resetSeed} />
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+// ── Form (only mounts when the schema parses) ───────────────────────────────
+
+type LiveFormProps = {
+  parse: Extract<ParseAttempt, { status: 'ok' }>
+}
+
+function initValuesFrom(fieldOrder: string[]): InputValues {
+  const values: Record<string, unknown> = {}
+  for (const field of fieldOrder) {
+    values[field] = ''
+  }
+  return values
+}
+
+function LiveForm({ parse }: LiveFormProps) {
+  const { ump, fieldOrder } = parse
+  // Key the values to the fieldOrder signature so adding a field resets state
+  // *only when field identity changes* — validator swaps carry values through.
+  const signature = fieldOrder.join('|')
+  return <LiveFormInner key={signature} ump={ump} fieldOrder={fieldOrder} />
+}
+
+type LiveFormInnerProps = {
+  ump: Umpire<Record<string, FieldDef>, Record<string, unknown>>
+  fieldOrder: string[]
+}
+
+function LiveFormInner({ ump, fieldOrder }: LiveFormInnerProps) {
+  const [values, setValues] = useState<InputValues>(() => initValuesFrom(fieldOrder))
+  const { check, fouls } = useUmpire(ump, values)
+
+  function setField(field: string, next: string) {
+    setValues((current) => ({ ...current, [field]: next }))
+  }
+
+  function applyResets() {
+    setValues((current) => {
+      const next = { ...current }
+      for (const foul of fouls) {
+        next[foul.field as string] = foul.suggestedValue as string
+      }
+      return next
+    })
+  }
+
+  const allRequired = fieldOrder.filter((field) => check[field]?.required)
+  const availableRequired = allRequired.filter((field) => check[field]?.enabled)
+  const satisfiedCount = availableRequired.filter((field) => {
+    const v = values[field]
+    return typeof v === 'string' && v.length > 0
+  }).length
+
+  return (
+    <>
+      <div className="c-umpire-demo__panel-header">
+        <div>
+          <div className="c-umpire-demo__eyebrow">Rendered form</div>
+          <h2 className="c-umpire-demo__title">generic.tsx</h2>
+        </div>
+        <span className="c-umpire-demo__panel-accent">
+          {satisfiedCount}/{availableRequired.length} required
+        </span>
+      </div>
+      <div className="c-umpire-demo__panel-body c-config-demo__panel-body--form">
+        {fouls.length > 0 && (
+          <div className="c-umpire-demo__fouls c-config-demo__fouls">
+            <div className="c-umpire-demo__fouls-copy">
+              <div className="c-umpire-demo__fouls-kicker">Flag fouls</div>
+              <div className="c-umpire-demo__fouls-list">
+                {fouls.map((foul) => (
+                  <div key={String(foul.field)} className="c-umpire-demo__foul">
+                    <span className="c-umpire-demo__foul-field">{metaFor(String(foul.field)).label}</span>
+                    <span className="c-umpire-demo__foul-reason">{foul.reason}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <button type="button" className="c-umpire-demo__reset-button" onClick={applyResets}>
+              Apply resets
+            </button>
+          </div>
+        )}
+
+        <div className="c-umpire-demo__fields">
+          {fieldOrder.map((field) => {
+            const meta = metaFor(field)
+            const av = check[field]
+            if (!av) return null
+            const value = typeof values[field] === 'string' ? (values[field] as string) : ''
+            const showValidator = av.enabled && av.valid === false && value.length > 0
+
+            return (
+              <div
+                key={field}
+                className={cls(
+                  'c-umpire-demo__field',
+                  !av.enabled && 'is-disabled',
+                )}
+              >
+                <div className="c-umpire-demo__field-header">
+                  <span className="c-umpire-demo__field-label">
+                    {meta.label}
+                    {av.required && <span className="c-config-demo__required">*</span>}
+                  </span>
+                  <FieldBadge enabled={av.enabled} required={av.required} />
+                </div>
+                {meta.inputType === 'select' ? (
+                  <select
+                    className="c-umpire-demo__input"
+                    value={value}
+                    disabled={!av.enabled}
+                    onChange={(event) => setField(field, event.currentTarget.value)}
+                  >
+                    <option value="">Select…</option>
+                    {meta.options?.map((option) => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    className="c-umpire-demo__input"
+                    type={meta.inputType ?? 'text'}
+                    placeholder={meta.placeholder}
+                    value={value}
+                    disabled={!av.enabled}
+                    onChange={(event) => setField(field, event.currentTarget.value)}
+                  />
+                )}
+                {!av.enabled && av.reason && (
+                  <div className="c-config-demo__field-note c-config-demo__field-note--disabled">
+                    {av.reason}
+                  </div>
+                )}
+                {showValidator && (
+                  <div className="c-config-demo__field-note c-config-demo__field-note--invalid">
+                    {av.error ?? av.reason ?? 'Invalid value'}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        <UmpireCall check={check} fieldOrder={fieldOrder} />
+      </div>
+    </>
+  )
+}
+
+// ── Umpire's Call — the "which rules fired?" strip ──────────────────────────
+
+type UmpireCallProps = {
+  check: ReturnType<Umpire<Record<string, FieldDef>, Record<string, unknown>>['check']>
+  fieldOrder: string[]
+}
+
+function UmpireCall({ check, fieldOrder }: UmpireCallProps) {
+  const rows = fieldOrder.map((field) => {
+    const av = check[field]
+    if (!av) return null
+    let verdict: 'in-play' | 'out' | 'invalid' = 'in-play'
+    let copy = av.required ? 'in play · required' : 'in play'
+    if (!av.enabled) {
+      verdict = 'out'
+      copy = av.reason ?? 'out of play'
+    } else if (av.valid === false) {
+      verdict = 'invalid'
+      copy = av.error ?? av.reason ?? 'fails validator'
+    }
+    return { field, verdict, copy }
+  }).filter((row): row is { field: string; verdict: 'in-play' | 'out' | 'invalid'; copy: string } => row !== null)
+
+  return (
+    <div className="c-config-demo__call">
+      <div className="c-config-demo__call-header">
+        <span className="c-umpire-demo__eyebrow">Umpire&rsquo;s call</span>
+        <span className="c-config-demo__call-hint">live derivation of the current schema</span>
+      </div>
+      <ul className="c-config-demo__call-list">
+        {rows.map((row) => (
+          <li key={row.field} className={cls('c-config-demo__call-row', `c-config-demo__call-row--${row.verdict}`)}>
+            <span className="c-config-demo__call-field">{row.field}</span>
+            <span className="c-config-demo__call-verdict">{row.verdict.replace('-', ' ')}</span>
+            <span className="c-config-demo__call-copy">{row.copy}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+// ── Field badge ─────────────────────────────────────────────────────────────
+
+function FieldBadge({ enabled, required }: { enabled: boolean; required: boolean }) {
+  if (!enabled) {
+    return <span className="c-umpire-demo__status is-disabled"><span className="c-umpire-demo__status-dot" />out</span>
+  }
+  if (required) {
+    return <span className="c-umpire-demo__status is-enabled"><span className="c-umpire-demo__status-dot" />required</span>
+  }
+  return <span className="c-umpire-demo__status is-enabled"><span className="c-umpire-demo__status-dot" />in play</span>
+}
+
+// ── Schema rejected ─────────────────────────────────────────────────────────
+
+function SchemaRejected({ error, onReset }: { error: string; onReset: () => void }) {
+  return (
+    <>
+      <div className="c-umpire-demo__panel-header">
+        <div>
+          <div className="c-umpire-demo__eyebrow">Schema rejected</div>
+          <h2 className="c-umpire-demo__title">validateSchema()</h2>
+        </div>
+        <span className="c-umpire-demo__panel-accent">safe by default</span>
+      </div>
+      <div className="c-umpire-demo__panel-body c-config-demo__panel-body--error">
+        <p className="c-config-demo__error-lead">
+          The edit you made isn&rsquo;t expressible in the portable contract. No partial umpire was built.
+        </p>
+        <pre className="c-config-demo__error-pre">{error}</pre>
+        <button type="button" className="c-umpire-demo__reset-button" onClick={onReset}>
+          Restore seed JSON
+        </button>
+      </div>
+    </>
+  )
+}

--- a/docs/src/components/ConfigDrivenDemo.tsx
+++ b/docs/src/components/ConfigDrivenDemo.tsx
@@ -346,6 +346,10 @@ type LiveFormInnerProps = {
 function LiveFormInner({ ump, fieldOrder }: LiveFormInnerProps) {
   const [values, setValues] = useState<InputValues>(() => initValuesFrom(fieldOrder))
   const { check, fouls } = useUmpire(ump, values)
+  // Scorecard gives us Umpire's own `satisfied` per field — whatever `isEmpty`
+  // strategy the schema declares. Hand-rolling string-length checks would drift
+  // the moment a reader edits the JSON to use a different strategy.
+  const scorecard = useMemo(() => ump.scorecard({ values }), [ump, values])
 
   function setField(field: string, next: string) {
     setValues((current) => ({ ...current, [field]: next }))
@@ -363,10 +367,9 @@ function LiveFormInner({ ump, fieldOrder }: LiveFormInnerProps) {
 
   const allRequired = fieldOrder.filter((field) => check[field]?.required)
   const availableRequired = allRequired.filter((field) => check[field]?.enabled)
-  const satisfiedCount = availableRequired.filter((field) => {
-    const v = values[field]
-    return typeof v === 'string' && v.length > 0
-  }).length
+  const satisfiedCount = availableRequired.filter(
+    (field) => scorecard.fields[field]?.satisfied,
+  ).length
 
   return (
     <>
@@ -476,17 +479,23 @@ function UmpireCall({ check, fieldOrder }: UmpireCallProps) {
   const rows = fieldOrder.map((field) => {
     const av = check[field]
     if (!av) return null
-    let verdict: 'in-play' | 'out' | 'invalid' = 'in-play'
+    // Verdicts mirror Umpire's own `check()` fields in priority order: a
+    // disabled field is out of play entirely, a foul ball (fairWhen failure)
+    // ranks next, and only then do we look at validator results.
+    let verdict: 'in-play' | 'out' | 'foul' | 'invalid' = 'in-play'
     let copy = av.required ? 'in play · required' : 'in play'
     if (!av.enabled) {
       verdict = 'out'
       copy = av.reason ?? 'out of play'
+    } else if (!av.fair) {
+      verdict = 'foul'
+      copy = av.reason ?? 'foul — value fails a fairness rule'
     } else if (av.valid === false) {
       verdict = 'invalid'
       copy = av.error ?? av.reason ?? 'fails validator'
     }
     return { field, verdict, copy }
-  }).filter((row): row is { field: string; verdict: 'in-play' | 'out' | 'invalid'; copy: string } => row !== null)
+  }).filter((row): row is { field: string; verdict: 'in-play' | 'out' | 'foul' | 'invalid'; copy: string } => row !== null)
 
   return (
     <div className="c-config-demo__call">

--- a/docs/src/components/ConfigDrivenDemo.tsx
+++ b/docs/src/components/ConfigDrivenDemo.tsx
@@ -6,8 +6,9 @@ import type { JsonRule, UmpireJsonSchema } from '@umpire/json'
 import { useUmpire } from '@umpire/react'
 import '../styles/components/_components.config-driven-demo.css'
 
-// The "seeded" JSON the demo opens with. Small, branchy, shows three rule
-// types. Lifted verbatim from the plan so the narrative and the demo match.
+// The schema the demo loads with. Two `enabledWhen` branches (accountType →
+// company fields, country → state) plus a portable `email` validator —
+// enough to exercise the rule, validator, and schema-rejection paths.
 const seedSchema: UmpireJsonSchema = {
   version: 1,
   fields: {
@@ -52,9 +53,10 @@ type FieldMeta = {
   options?: Array<{ value: string; label: string }>
 }
 
-// Renderer-side metadata. The point of the page: **the renderer owns this
-// map, the umpire owns behavior.** Adding a new field to the JSON falls back
-// to the "text" default without touching this file — see `metaFor()`.
+// Labels, placeholders, and input types live on the renderer side. Umpire
+// owns behavior (enabled / required / valid) and this map owns presentation.
+// Fields that aren't listed here fall through `metaFor()` to a plain text
+// input, so adding a field to the schema doesn't require editing this file.
 const fieldMeta: Record<string, FieldMeta> = {
   accountType: {
     label: 'Account type',
@@ -84,7 +86,11 @@ function metaFor(field: string): FieldMeta {
   return fieldMeta[field] ?? { label: field, placeholder: `Enter ${field}` }
 }
 
-// ── Mutations: the three "try this" single-click edits ──────────────────────
+// ── Mutations: one-click schema edits wired to the prompt buttons ──────────
+//
+// Each mutation is idempotent: `apply()` produces the mutated schema and
+// `isApplied()` reports whether the current schema already reflects it, so
+// the same button can be disabled once its effect is visible.
 
 type Mutation = {
   id: string
@@ -459,7 +465,7 @@ function LiveFormInner({ ump, fieldOrder }: LiveFormInnerProps) {
   )
 }
 
-// ── Umpire's Call — the "which rules fired?" strip ──────────────────────────
+// ── Umpire's Call: per-field trace derived from the current check() result ─
 
 type UmpireCallProps = {
   check: ReturnType<Umpire<Record<string, FieldDef>, Record<string, unknown>>['check']>

--- a/docs/src/content/docs/adapters/json/index.md
+++ b/docs/src/content/docs/adapters/json/index.md
@@ -192,3 +192,4 @@ See [DSL & Portable Builders](/umpire/adapters/json/dsl/) for the full authoring
 - [DSL & Portable Builders](/umpire/adapters/json/dsl/) — `expr.*`, portable builders, round-trip guarantees, and conformance
 - [Composing with Validation](/umpire/concepts/validation/) — where `check()` fits conceptually
 - [check() helper](/umpire/api/rules/check/) — validator shapes in core
+- [Config-Driven UI, With Behavior](/umpire/examples/config-driven-ui/) — live-edit a JSON schema and watch a generic renderer respond

--- a/docs/src/content/docs/examples/config-driven-ui.mdx
+++ b/docs/src/content/docs/examples/config-driven-ui.mdx
@@ -1,0 +1,150 @@
+---
+title: Config-Driven UI, With Behavior
+description: Config-driven UI gets you most of the way there. Umpire is the behavior layer that keeps the config portable when the rules get real.
+---
+
+import ConfigDrivenDemo from '../../../components/ConfigDrivenDemo.tsx'
+
+Config-driven UI keeps coming back because it solves a real problem. *"Here&rsquo;s a generic component; drive it with a config object."* You have five forms that are 90% the same and you want them to stay 90% the same forever. A config object is how you keep the component from drifting into five separate code paths, and it genuinely works for that.
+
+The ceiling shows up when behavior varies across forms &mdash; conditional required fields, cross-field constraints, cascading resets. At that point, the config needs a way to express those rules, and the options in most libraries mean reaching for something the JSON can no longer carry on its own. Umpire&rsquo;s answer is to keep that layer declarative too: **behavior as data.**
+
+## The pattern you&rsquo;ve seen
+
+The shape is nearly identical across every take. A `fields` array. A generic renderer that maps each entry to an input. Maybe a `visibleWhen` or `dependencies` block for simple conditionality. Representative prior art:
+
+- Ketan Khairnar &mdash; [Configuration-Driven React Components](https://www.ketankhairnar.com/blog/configuration-driven-react-components/) &mdash; the post that prompted this page. A clear walk through the pattern and an honest read on where it reaches its limits.
+- [react-jsonschema-form](https://rjsf-team.github.io/react-jsonschema-form/) &mdash; the canonical config-driven form library. `dependencies` and `ui:widget` carry you far; this is the library most teams have met first.
+- [Formily](https://formilyjs.org/) &mdash; schema-driven forms with explicit reactions. Worth studying for how it models the reactive layer that behavior eventually demands.
+- Kent C. Dodds &mdash; [Inversion of Control](https://kentcdodds.com/blog/inversion-of-control) &mdash; foundational piece on component design and where the config boundary should sit.
+
+## Where it breaks
+
+Three situations tend to be where the declarative vibe cracks:
+
+- **Conditional requireds.** `state` only matters when `country === 'US'`. The config needs a way to express that without the renderer growing a special case per form.
+- **Cross-field validation.** `endDate` must come after `startDate`. The predicate isn&rsquo;t local to either field.
+- **Cascading resets.** Platform flips from Intel to AMD. Motherboard stale. RAM stale. Case stale. One field changed; three had to fall.
+
+Each one needs a rule that references other field values. The usual path is to reach for a function in the config &mdash; a `visibleWhen: (state) => …` or a `validate: (value, form) => …`. That works at runtime, but it means the config is no longer portable: it can&rsquo;t round-trip through JSON, it can&rsquo;t be authored outside engineering, and it can&rsquo;t cross a runtime boundary.
+
+## The missing layer
+
+Umpire declares behavior as data. Rules are a graph. The component asks Umpire *"is this field in play? required? foul?"* and doesn&rsquo;t need to know why.
+
+1. **Rules are data.** `requires`, `enabledWhen`, `fairWhen`, `disables`, `oneOf`, `eitherOf`, `anyOf` &mdash; all declarative. Predicates over field values and conditions, expressed without closures over component state.
+2. **The renderer stays generic.** One `fields.map()` loop reads `enabled`, `required`, `fair`, and `reason` off the availability map. No per-field branches. No `if (field === 'state')`.
+3. **`@umpire/json` round-trips.** Rules, fields, conditions, and portable validators all serialize. What can&rsquo;t serialize lands in `excluded` instead of disappearing silently.
+4. **Framework-agnostic.** Same schema. React, Solid, signals, Vue through stores &mdash; the behavior layer doesn&rsquo;t care.
+
+Config-driven UI&rsquo;s original promise was *one generic renderer, many forms.* Umpire&rsquo;s job is to keep that promise intact when the forms start having opinions about each other.
+
+## Same config, with behavior
+
+A typical config-driven config captures labels and placeholders:
+
+```json
+{
+  "fields": [
+    { "key": "email",       "label": "Email",         "type": "email" },
+    { "key": "companyName", "label": "Company",       "type": "text" },
+    { "key": "state",       "label": "State",         "type": "text" }
+  ]
+}
+```
+
+When behavior shows up, most libraries grow a function slot &mdash; `visibleWhen: (state) => …` &mdash; and the config is no longer portable. The Umpire-augmented version adds `rules` and `validators` that stay serializable:
+
+```json
+{
+  "version": 1,
+  "fields": {
+    "accountType": { "required": true, "isEmpty": "string" },
+    "email":       { "required": true, "isEmpty": "string" },
+    "companyName": { "required": true, "isEmpty": "string" },
+    "state":       { "required": true, "isEmpty": "string" }
+  },
+  "rules": [
+    { "type": "enabledWhen", "field": "companyName",
+      "when": { "op": "eq", "field": "accountType", "value": "business" },
+      "reason": "Business accounts only" },
+    { "type": "enabledWhen", "field": "state",
+      "when": { "op": "eq", "field": "country", "value": "US" },
+      "reason": "US addresses only" }
+  ],
+  "validators": {
+    "email": { "op": "email", "error": "Enter a valid email address" }
+  }
+}
+```
+
+No closures. No escape hatches. The right-hand side stays data all the way down.
+
+## Edit the config
+
+Below: a textarea on the left, the live form on the right, and Umpire&rsquo;s call on the bottom. The component code is the same component code regardless of what you type. Start with the seed, then press the *try this* buttons &mdash; each one mutates the JSON and the form responds.
+
+<ConfigDrivenDemo client:load />
+
+The three prompts each demonstrate one claim:
+
+- **Add a rule** &mdash; a new `billingEmail` field and an `enabledWhen` rule tying it to `accountType === 'business'`. The renderer picks up the field without any component edits or new case statements.
+- **Swap a validator** &mdash; the portable `email` validator becomes a `matches` regex. Email rejects anything outside `@umpire.co`. The field&rsquo;s value carries through; only the verdict changes.
+- **Break it** &mdash; an unknown expression op (`eqIgnoreCase`) goes in. `validateSchema()` rejects the schema before any umpire is built. The form panel switches to the error state, and the textarea shows you exactly what it found.
+
+## Three lines to hydrate
+
+```ts
+import { umpire } from '@umpire/core'
+import { fromJson } from '@umpire/json'
+
+const { fields, rules, validators } = fromJson(schema)
+const ump = umpire({ fields, rules, validators })
+```
+
+`fromJson()` calls `validateSchema()` first; if the schema is malformed or references unknown ops, it throws before any rules compile. The resulting `ump` is the same shape you&rsquo;d get from hand-written TypeScript &mdash; a generic renderer doesn&rsquo;t need to know the rules were authored in JSON.
+
+## The renderer stays thin
+
+```tsx
+{fieldOrder.map((field) => {
+  const meta = metaFor(field)          // label, placeholder — renderer concern
+  const av   = availability[field]     // enabled, required, valid, reason, error
+
+  return (
+    <Field key={field} label={meta.label} required={av.required} disabled={!av.enabled}>
+      <Input
+        {...meta}
+        disabled={!av.enabled}
+        onChange={(value) => setField(field, value)}
+      />
+      {!av.enabled && <Reason>{av.reason}</Reason>}
+      {av.valid === false && <Error>{av.error}</Error>}
+    </Field>
+  )
+})}
+```
+
+Labels, placeholders, and types stay on the renderer side. The rest &mdash; *"should this be in play? required? valid?"* &mdash; comes from Umpire. Rules can change without the component being aware.
+
+## What you still write in code
+
+- **Umpire doesn&rsquo;t render.** You still own the field &rarr; input map, the layout, the theming, and the copy.
+- **Arbitrary predicates don&rsquo;t serialize.** Stay inside `namedValidators.*` and the portable op set when the config is authored outside engineering. Custom functions still work at runtime &mdash; they land in `excluded` on the way to JSON.
+- **`play()` recommends; you decide.** Stale values after a condition change get flagged as fouls with suggested resets, but the form state is still yours to update.
+
+## When this is overkill
+
+- A single form with two fields and a checkbox. Ship a hand-rolled component.
+- A one-off admin page you&rsquo;ll delete in a quarter.
+- A single renderer with no interdependent fields anywhere. `visibleWhen: true` would do the job.
+
+Config-driven plus Umpire pays off when you have **three or more similar surfaces**, **non-engineers authoring configs**, or **behavior that needs to survive a runtime boundary** (CMS-authored forms, server-rendered previews, a native port). That&rsquo;s where *rules as data* starts earning its keep.
+
+## See also
+
+- [Quick Start](/umpire/learn/) &mdash; ten-minute walk through the rule primitives.
+- [`@umpire/json`](/umpire/adapters/json/) &mdash; the portable schema in full, including `excluded` and `conditions`.
+- [DSL & Portable Builders](/umpire/adapters/json/dsl/) &mdash; the `expr.*` vocabulary and round-trip guarantees.
+- [Availability vs Validation](/umpire/concepts/availability/) &mdash; the mental model behind `enabled`, `required`, `fair`.
+- [PC Builder](/umpire/examples/pc-builder/) &mdash; a cascade-heavy example in the same declarative spirit.

--- a/docs/src/content/docs/examples/pc-builder.mdx
+++ b/docs/src/content/docs/examples/pc-builder.mdx
@@ -189,3 +189,7 @@ That filtering logic is still not what Umpire is responsible for. The component 
 - It does not compute filtered option lists. That is ordinary UI logic.
 - It does not calculate the PSU recommendation. That label is derived directly from CPU tier plus GPU tier in render.
 - It does not clear fields automatically. The demo keeps stale values in state until `play()` recommends a reset and the user applies it.
+
+## See Also
+
+- [Config-Driven UI, With Behavior](/umpire/examples/config-driven-ui/) — the same cascade story, but authored entirely in portable JSON and hydrated at runtime.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -246,4 +246,5 @@ Use `@umpire/core` when you just need pure availability logic. Add `@umpire/reac
 - Read [Field Satisfaction Semantics](./concepts/satisfaction/) before writing rules with `isEmpty`.
 - Use [umpire()](./api/umpire/) and [Rules](./api/rules/) as the reference for the core API.
 - See [Signup Form Walkthrough](./examples/signup/) for the same example broken down step by step.
+- Read [Config-Driven UI, With Behavior](./examples/config-driven-ui/) to see rules-as-data applied to the classic schema-form pattern.
 </div>

--- a/docs/src/styles/components/_components.config-driven-demo.css
+++ b/docs/src/styles/components/_components.config-driven-demo.css
@@ -343,6 +343,11 @@
   color: rgba(255, 204, 200, 0.78);
 }
 
+.c-config-demo__call-row--foul {
+  background: rgba(255, 170, 90, 0.06);
+  color: rgba(255, 225, 195, 0.84);
+}
+
 .c-config-demo__call-row--invalid {
   background: rgba(254, 208, 35, 0.06);
   color: rgba(255, 240, 184, 0.84);

--- a/docs/src/styles/components/_components.config-driven-demo.css
+++ b/docs/src/styles/components/_components.config-driven-demo.css
@@ -1,0 +1,413 @@
+/* Config-driven UI demo — JSON editor + live renderer + Umpire's call strip. */
+
+.c-config-demo {
+  --umpire-demo-border: var(--umpire-demo-green-14);
+  --umpire-demo-layout-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  --umpire-demo-fields-gap: 0.75rem;
+  --umpire-demo-field-gap: 0.32rem;
+  --umpire-demo-field-padding: 0.72rem 0.78rem 0.78rem;
+  --umpire-demo-field-radius: 0.75rem;
+  --umpire-demo-field-disabled-opacity: 0.6;
+  --umpire-demo-input-radius: 0.62rem;
+  --umpire-demo-input-padding: 0.6rem 0.72rem;
+  --umpire-demo-input-bg: rgba(255, 255, 255, 0.045);
+  --umpire-demo-label-color: var(--umpire-demo-text-muted, #9da09b);
+  --umpire-demo-status-gap: 0.32rem;
+  --umpire-demo-status-padding: 0.22rem 0.5rem;
+  --umpire-demo-status-font-size: 0.6rem;
+  --umpire-demo-status-dot-size: 0.4rem;
+  --umpire-demo-status-dot-glow: 0 0 6px currentColor;
+  --umpire-demo-fouls-padding: 0.75rem 0.9rem;
+  --umpire-demo-fouls-border-color: var(--umpire-demo-yellow-18);
+  --umpire-demo-fouls-radius: 0.85rem;
+  --umpire-demo-fouls-bg:
+    linear-gradient(90deg, rgba(254, 208, 35, 0.1), rgba(254, 208, 35, 0.04)),
+    rgba(18, 18, 18, 0.92);
+  --umpire-demo-fouls-copy-display: flex;
+  --umpire-demo-fouls-copy-direction: column;
+  --umpire-demo-fouls-copy-gap: 0.2rem;
+  --umpire-demo-fouls-kicker-font-size: 0.62rem;
+  --umpire-demo-fouls-kicker-letter-spacing: var(--umpire-demo-tracking-wider);
+  --umpire-demo-fouls-kicker-color: rgba(254, 208, 35, 0.85);
+  --umpire-demo-fouls-list-direction: column;
+  --umpire-demo-fouls-list-wrap: nowrap;
+  --umpire-demo-fouls-list-gap: 0.2rem;
+  --umpire-demo-fouls-list-margin-top: 0.25rem;
+  --umpire-demo-foul-wrap: wrap;
+  --umpire-demo-foul-gap: 0.35rem;
+  --umpire-demo-foul-font-size: 0.78rem;
+  --umpire-demo-foul-field-font-size: 0.7rem;
+  --umpire-demo-foul-field-font-weight: 700;
+  --umpire-demo-foul-field-color: #fff3b8;
+  --umpire-demo-foul-reason-font-size: 0.78rem;
+  --umpire-demo-foul-reason-color: rgba(255, 243, 184, 0.82);
+  --umpire-demo-reset-button-padding: 0.44rem 0.78rem;
+  --umpire-demo-reset-button-border-color: rgba(254, 208, 35, 0.34);
+  --umpire-demo-reset-button-bg: var(--umpire-demo-yellow-16);
+  --umpire-demo-reset-button-color: #fff1a8;
+  --umpire-demo-reset-button-font-size: 0.66rem;
+  --umpire-demo-reset-button-font-weight: 700;
+  --umpire-demo-reset-button-letter-spacing: var(--umpire-demo-tracking);
+  --umpire-demo-reset-button-hover-bg: var(--umpire-demo-yellow-24);
+  --umpire-demo-reset-button-hover-transform: translateY(-1px);
+  --umpire-demo-reset-button-hover-shadow: none;
+}
+
+/* ── Prompts (three try-this buttons + reset) ───────────────────────────── */
+
+.c-config-demo__prompts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid rgba(107, 254, 156, 0.18);
+  border-radius: var(--umpire-demo-radius-lg);
+  background:
+    linear-gradient(180deg, rgba(107, 254, 156, 0.06), transparent 70%),
+    rgba(16, 16, 16, 0.85);
+}
+
+.c-config-demo__prompts-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.c-config-demo__reset {
+  flex-shrink: 0;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--umpire-demo-radius-pill);
+  padding: 0.35rem 0.75rem;
+  background: transparent;
+  color: var(--umpire-demo-text-dim, rgba(245, 247, 244, 0.6));
+  font-family: var(--umpire-demo-font-mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: var(--umpire-demo-tracking);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.18s ease, border-color 0.18s ease;
+}
+
+.c-config-demo__reset:hover:not(:disabled) {
+  color: var(--umpire-demo-text);
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.c-config-demo__reset:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
+.c-config-demo__prompts-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.c-config-demo__prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.6rem 0.75rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.7rem;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--umpire-demo-text);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.c-config-demo__prompt:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateY(-1px);
+}
+
+.c-config-demo__prompt:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.c-config-demo__prompt.is-applied {
+  opacity: 0.8;
+}
+
+.c-config-demo__prompt--add {
+  border-color: rgba(107, 254, 156, 0.22);
+  background:
+    linear-gradient(135deg, rgba(107, 254, 156, 0.08), transparent 60%),
+    rgba(255, 255, 255, 0.03);
+}
+
+.c-config-demo__prompt--add:hover:not(:disabled) {
+  border-color: rgba(107, 254, 156, 0.45);
+}
+
+.c-config-demo__prompt--swap {
+  border-color: rgba(107, 165, 254, 0.22);
+  background:
+    linear-gradient(135deg, rgba(107, 165, 254, 0.08), transparent 60%),
+    rgba(255, 255, 255, 0.03);
+}
+
+.c-config-demo__prompt--swap:hover:not(:disabled) {
+  border-color: rgba(107, 165, 254, 0.45);
+}
+
+.c-config-demo__prompt--break {
+  border-color: rgba(255, 113, 108, 0.22);
+  background:
+    linear-gradient(135deg, rgba(255, 113, 108, 0.08), transparent 60%),
+    rgba(255, 255, 255, 0.03);
+}
+
+.c-config-demo__prompt--break:hover:not(:disabled) {
+  border-color: rgba(255, 113, 108, 0.45);
+}
+
+.c-config-demo__prompt-label {
+  font-family: var(--umpire-demo-font-heading);
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.c-config-demo__prompt-blurb {
+  font-family: var(--umpire-demo-font-mono);
+  font-size: 0.68rem;
+  line-height: 1.4;
+  color: var(--umpire-demo-text-muted, rgba(245, 247, 244, 0.55));
+}
+
+/* ── Layout panes ───────────────────────────────────────────────────────── */
+
+.c-config-demo__layout {
+  align-items: stretch;
+}
+
+.c-config-demo__panel--json,
+.c-config-demo__panel--form {
+  display: flex;
+  flex-direction: column;
+}
+
+.c-config-demo__panel-body--json {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.c-config-demo__editor {
+  flex: 1;
+  min-height: 22rem;
+  width: 100%;
+  padding: 0.9rem 0.95rem;
+  border: 0;
+  border-radius: 0;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 18%),
+    rgba(10, 10, 10, 0.85);
+  color: var(--umpire-demo-text);
+  font-family: var(--umpire-demo-font-mono);
+  font-size: 0.78rem;
+  line-height: 1.6;
+  resize: vertical;
+  outline: none;
+  white-space: pre;
+  tab-size: 2;
+}
+
+.c-config-demo__editor:focus {
+  box-shadow: inset 0 0 0 1px rgba(107, 254, 156, 0.28);
+}
+
+.c-config-demo__applied {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.55rem 0.8rem 0.7rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(10, 10, 10, 0.6);
+}
+
+.c-config-demo__applied-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid currentColor;
+  border-radius: var(--umpire-demo-radius-pill);
+  font-family: var(--umpire-demo-font-mono);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: var(--umpire-demo-tracking);
+  text-transform: uppercase;
+  opacity: 0.82;
+}
+
+.c-config-demo__applied-pill--add   { color: var(--umpire-demo-green); }
+.c-config-demo__applied-pill--swap  { color: #8fb8ff; }
+.c-config-demo__applied-pill--break { color: var(--umpire-demo-red); }
+
+/* ── Form pane ──────────────────────────────────────────────────────────── */
+
+.c-config-demo__panel-body--form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.c-config-demo__required {
+  margin-left: 0.25rem;
+  color: rgba(107, 254, 156, 0.72);
+}
+
+.c-config-demo__field-note {
+  font-family: var(--umpire-demo-font-mono);
+  font-size: 0.68rem;
+  line-height: 1.35;
+}
+
+.c-config-demo__field-note--disabled {
+  color: rgba(245, 247, 244, 0.5);
+}
+
+.c-config-demo__field-note--invalid {
+  color: rgba(255, 113, 108, 0.9);
+}
+
+/* ── Umpire's call (rule trace strip) ───────────────────────────────────── */
+
+.c-config-demo__call {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding: 0.75rem 0.85rem 0.85rem;
+  border: 1px dashed rgba(107, 254, 156, 0.18);
+  border-radius: var(--umpire-demo-radius-md);
+  background:
+    linear-gradient(180deg, rgba(107, 254, 156, 0.03), transparent 60%),
+    rgba(10, 10, 10, 0.55);
+}
+
+.c-config-demo__call-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.c-config-demo__call-hint {
+  font-family: var(--umpire-demo-font-mono);
+  font-size: 0.6rem;
+  color: rgba(245, 247, 244, 0.4);
+  letter-spacing: 0.04em;
+}
+
+.c-config-demo__call-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
+}
+
+.c-config-demo__call-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    'field   verdict'
+    'copy    copy';
+  align-items: baseline;
+  gap: 0.2rem 0.6rem;
+  padding: 0.42rem 0.55rem;
+  border-radius: 0.4rem;
+  font-family: var(--umpire-demo-font-mono);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.c-config-demo__call-row--in-play {
+  background: rgba(107, 254, 156, 0.05);
+  color: rgba(245, 247, 244, 0.78);
+}
+
+.c-config-demo__call-row--out {
+  background: rgba(255, 113, 108, 0.05);
+  color: rgba(255, 204, 200, 0.78);
+}
+
+.c-config-demo__call-row--invalid {
+  background: rgba(254, 208, 35, 0.06);
+  color: rgba(255, 240, 184, 0.84);
+}
+
+.c-config-demo__call-field {
+  grid-area: field;
+  font-weight: 700;
+  color: var(--umpire-demo-text);
+}
+
+.c-config-demo__call-verdict {
+  grid-area: verdict;
+  font-size: 0.58rem;
+  letter-spacing: var(--umpire-demo-tracking);
+  text-transform: uppercase;
+  opacity: 0.72;
+  white-space: nowrap;
+}
+
+.c-config-demo__call-copy {
+  grid-area: copy;
+  min-width: 0;
+  color: inherit;
+  opacity: 0.82;
+  overflow-wrap: break-word;
+}
+
+/* ── Schema-rejected pane ───────────────────────────────────────────────── */
+
+.c-config-demo__panel-body--error {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.c-config-demo__error-lead {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: rgba(245, 247, 244, 0.82);
+}
+
+.c-config-demo__error-pre {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid rgba(255, 113, 108, 0.25);
+  border-radius: var(--umpire-demo-radius-sm);
+  background: rgba(255, 113, 108, 0.08);
+  color: rgba(255, 204, 200, 0.95);
+  font-family: var(--umpire-demo-font-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
+@media (max-width: 50rem) {
+  .c-config-demo__prompts-list {
+    grid-template-columns: 1fr;
+  }
+
+  .c-config-demo__editor {
+    min-height: 16rem;
+  }
+}

--- a/docs/src/styles/main.css
+++ b/docs/src/styles/main.css
@@ -35,6 +35,7 @@
 @import './components/_components.calendar-demo.css';
 @import './components/_components.minesweeper-demo.css';
 @import './components/_components.pc-builder-demo.css';
+@import './components/_components.config-driven-demo.css';
 @import './components/_components.minefield-callout.css';
 @import './components/_components.divider.css';
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1867,6 +1867,14 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@umpire/json@portal:../packages/json::locator=umpire-docs%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@umpire/json@portal:../packages/json::locator=umpire-docs%40workspace%3A."
+  dependencies:
+    "@umpire/core": "workspace:^"
+  languageName: node
+  linkType: soft
+
 "@umpire/react@portal:../packages/react::locator=umpire-docs%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@umpire/react@portal:../packages/react::locator=umpire-docs%40workspace%3A."
@@ -5804,6 +5812,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     "@umpire/core": "portal:../packages/core"
     "@umpire/devtools": "portal:../packages/devtools"
+    "@umpire/json": "portal:../packages/json"
     "@umpire/react": "portal:../packages/react"
     "@umpire/reads": "portal:../packages/reads"
     "@umpire/signals": "portal:../packages/signals"


### PR DESCRIPTION
## Summary

- New `/examples/config-driven-ui/` page positioning Umpire as the behavior layer that completes the config-driven UI pattern.
- `<ConfigDrivenDemo />` client component: textarea on the left, live form on the right, Umpire's per-field call strip along the bottom. Three idempotent *try this* mutations (add a rule, swap a validator, break the schema) demonstrate the round-trip story end-to-end without asking the reader to write TypeScript.
- Tone-passed to lead with what config-driven UI already gets right, then introduce Umpire as the piece that keeps the config portable when behavior shows up. Prior art (Khairnar, rjsf, Formily, Kent C. Dodds) is framed as load-bearing teaching material rather than cautionary tales.
- Sidebar entry under **Examples**, reciprocal cross-links from the index page, `@umpire/json` overview, and `pc-builder.mdx`.

## Test plan

- [x] `cd docs && yarn build` &mdash; 54 pages, `/examples/config-driven-ui/index.html` emitted cleanly.
- [x] Load the page in dev; confirm seed schema hydrates and the form renders six fields.
- [x] Press **Add a rule** &mdash; verify `billingEmail` appears and tracks `accountType === 'business'`.
- [x] Press **Swap a validator** &mdash; verify the email field rejects non-`@umpire.co` values while keeping its current value.
- [x] Press **Break it** &mdash; verify the schema-rejected pane shows, not a half-rendered form.
- [x] Resize narrow and confirm the Umpire's Call rows wrap `field + verdict` on one row and copy on the next (no letter-by-letter breaks).