### PR TITLE
✨ Promote satisfied onto FieldStatus

### DIFF
--- a/.changeset/curly-wombats-bow.md
+++ b/.changeset/curly-wombats-bow.md
@@ -1,0 +1,5 @@
+---
+"@umpire/core": patch
+---
+
+Expose field satisfaction on `check()` field status so consumers can read `satisfied` alongside enabled/fair/required metadata.

--- a/.changeset/neat-emus-raise.md
+++ b/.changeset/neat-emus-raise.md
@@ -1,0 +1,6 @@
+---
+'@umpire/json': patch
+'@umpire/signals': patch
+---
+
+Update the JSON conformance snapshots and signals reactive tests to cover the new `satisfied` field status so branch behavior and fixtures stay in sync.

--- a/docs/src/content/docs/api/check.md
+++ b/docs/src/content/docs/api/check.md
@@ -26,6 +26,7 @@ ump.check(
 ```ts
 type FieldStatus = {
   enabled: boolean
+  satisfied: boolean
   fair: boolean
   required: boolean
   reason: string | null
@@ -42,6 +43,7 @@ type AvailabilityMap<F extends Record<string, FieldDef>> = {
 ## Semantics
 
 - `enabled` is the combined result of every availability rule (`enabledWhen`, `requires`, `disables`, `oneOf`) targeting the field.
+- `satisfied` is whether the current value is non-empty under that field's `isEmpty` strategy.
 - `fair` is `false` when a `fairWhen` predicate returns `false` on a non-empty value. Always `true` when the field has no value. `fairWhen` only runs when the field is enabled.
 - `required` is suppressed to `false` when the field is disabled, even if the field definition says `required: true`.
 - `reason` is the first failure in declaration order — from either an availability rule or a `fairWhen` rule.

--- a/docs/src/content/docs/api/scorecard.md
+++ b/docs/src/content/docs/api/scorecard.md
@@ -30,6 +30,8 @@ type ScorecardResult<F, C> = {
 
 `check` and `graph` are the same values you would get from `ump.check()` and `ump.graph()` directly. The addition is `fields` — a per-field view that cross-references all of them — and `transition`, which describes what changed.
 
+Since `FieldStatus` now includes `satisfied`, use `check()` for render-time availability/completion state. Reach for `scorecard()` when you also need `value`, `present`, transition, foul, or graph context.
+
 ## Per-Field State
 
 Each entry in `fields` is a `ScorecardField`:
@@ -73,7 +75,7 @@ type ScorecardField<F> = {
 These are two distinct concepts.
 
 - `present` is raw JS presence: `value !== null && value !== undefined`.
-- `satisfied` additionally respects the field's `isEmpty` definition. An empty array or empty string can be `present` but not `satisfied` if the field definition treats them as empty.
+- `satisfied` additionally respects the field's `isEmpty` definition. An empty array or empty string can be `present` but not `satisfied` if the field definition treats them as empty. In scorecard output, this mirrors `check[field].satisfied`.
 
 `fair` only applies to fields that are `satisfied`. An unsatisfied field is never `fair` or `unfair` — it simply has no value to judge.
 

--- a/packages/core/__tests__/check.test.ts
+++ b/packages/core/__tests__/check.test.ts
@@ -41,6 +41,7 @@ describe('evaluate', () => {
 
     expect(evaluate(fields, rules, topoOrder, { alpha: 'on' }, {} as TestConditions).beta).toEqual({
       enabled: true,
+      satisfied: false,
       fair: true,
       required: false,
       reason: null,
@@ -50,6 +51,7 @@ describe('evaluate', () => {
       evaluate(fields, rules, topoOrder, { alpha: 'off' }, {} as TestConditions).beta,
     ).toEqual({
       enabled: false,
+      satisfied: false,
       fair: true,
       required: false,
       reason: 'alpha must be on',
@@ -78,6 +80,7 @@ describe('evaluate', () => {
 
     expect(result.gamma).toEqual({
       enabled: false,
+      satisfied: false,
       fair: true,
       required: false,
       reason: 'feature gate closed',
@@ -157,6 +160,7 @@ describe('evaluate', () => {
       evaluate(fields, rules, topoOrder, {}, { allow: true }).gamma,
     ).toEqual({
       enabled: true,
+      satisfied: false,
       fair: true,
       required: false,
       reason: null,
@@ -166,6 +170,7 @@ describe('evaluate', () => {
       evaluate(fields, rules, topoOrder, {}, { allow: false }).gamma,
     ).toEqual({
       enabled: false,
+      satisfied: false,
       fair: true,
       required: false,
       reason: 'allow must be true',
@@ -203,6 +208,7 @@ describe('evaluate', () => {
 
     expect(evaluate(fields, rules, topoOrder, { alpha: 'am5', beta: 'am5' }, {} as TestConditions).beta).toEqual({
       enabled: true,
+      satisfied: true,
       fair: true,
       required: false,
       reason: null,
@@ -212,6 +218,7 @@ describe('evaluate', () => {
       evaluate(fields, rules, topoOrder, { alpha: 'am5', beta: 'lga1700' }, {} as TestConditions).beta,
     ).toEqual({
       enabled: true,
+      satisfied: true,
       fair: false,
       required: false,
       reason: 'socket mismatch',
@@ -242,6 +249,7 @@ describe('evaluate', () => {
 
     expect(evaluate(fields, rules, topoOrder, {}, {} as TestConditions).beta).toEqual({
       enabled: false,
+      satisfied: false,
       fair: true,
       required: false,
       reason: null,
@@ -411,10 +419,10 @@ describe('evaluate', () => {
     const result = evaluate(fields, rules, topoOrder, {}, {} as TestConditions)
 
     expect(result).toEqual({
-      alpha: { enabled: true, fair: true, required: true, reason: null, reasons: [] },
-      beta: { enabled: true, fair: true, required: false, reason: null, reasons: [] },
-      gamma: { enabled: true, fair: true, required: false, reason: null, reasons: [] },
-      delta: { enabled: true, fair: true, required: true, reason: null, reasons: [] },
+      alpha: { enabled: true, satisfied: false, fair: true, required: true, reason: null, reasons: [] },
+      beta: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
+      gamma: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
+      delta: { enabled: true, satisfied: false, fair: true, required: true, reason: null, reasons: [] },
     })
   })
 })

--- a/packages/core/__tests__/edge-cases.test.ts
+++ b/packages/core/__tests__/edge-cases.test.ts
@@ -22,10 +22,10 @@ describe('edge cases', () => {
     })
 
     expect(ump.check({})).toEqual({
-      alpha: { enabled: true, fair: true, required: true, reason: null, reasons: [] },
-      beta: { enabled: true, fair: true, required: false, reason: null, reasons: [] },
-      gamma: { enabled: true, fair: true, required: false, reason: null, reasons: [] },
-      delta: { enabled: true, fair: true, required: false, reason: null, reasons: [] },
+      alpha: { enabled: true, satisfied: false, fair: true, required: true, reason: null, reasons: [] },
+      beta: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
+      gamma: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
+      delta: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
     })
   })
 
@@ -70,6 +70,7 @@ describe('edge cases', () => {
 
     expect(ump.check({}).delta).toEqual({
       enabled: false,
+      satisfied: false,
       fair: true,
       required: false,
       reason: 'first failure',
@@ -90,6 +91,7 @@ describe('edge cases', () => {
 
     expect(ump.check({}).delta).toEqual({
       enabled: true,
+      satisfied: false,
       fair: true,
       required: false,
       reason: null,

--- a/packages/core/__tests__/fair-when.test.ts
+++ b/packages/core/__tests__/fair-when.test.ts
@@ -31,6 +31,7 @@ describe('fairWhen', () => {
 
     expect(result.motherboard).toEqual({
       enabled: true,
+      satisfied: true,
       fair: false,
       required: true,
       reason: 'Motherboard no longer matches the selected CPU',
@@ -38,6 +39,7 @@ describe('fairWhen', () => {
     })
     expect(result.ram).toEqual({
       enabled: false,
+      satisfied: true,
       fair: true,
       required: false,
       reason: 'Pick a valid motherboard first',
@@ -66,6 +68,7 @@ describe('fairWhen', () => {
 
     expect(ump.check({ motherboard: '' }).motherboard).toEqual({
       enabled: true,
+      satisfied: false,
       fair: true,
       required: false,
       reason: null,
@@ -163,6 +166,7 @@ describe('fairWhen', () => {
 
     expect(ump.check({ selection: 'omega' }).selection).toEqual({
       enabled: true,
+      satisfied: true,
       fair: true,
       required: false,
       reason: null,
@@ -171,6 +175,7 @@ describe('fairWhen', () => {
 
     expect(ump.check({ selection: 'beta' }).selection).toEqual({
       enabled: true,
+      satisfied: true,
       fair: false,
       required: false,
       reason: 'Must be alpha',
@@ -215,6 +220,7 @@ describe('field()', () => {
     })
     expect(ump.check({ toggle: false, details: 'manual' }).details).toEqual({
       enabled: false,
+      satisfied: true,
       fair: true,
       required: false,
       reason: 'Turn the toggle on first',
@@ -246,6 +252,7 @@ describe('field()', () => {
       }).motherboard,
     ).toEqual({
       enabled: true,
+      satisfied: true,
       fair: false,
       required: true,
       reason: 'Motherboard no longer matches the selected CPU',
@@ -272,6 +279,7 @@ describe('field()', () => {
 
     expect(ump.check({}).motherboard).toEqual({
       enabled: false,
+      satisfied: false,
       fair: true,
       required: false,
       reason: 'Pick a CPU first',

--- a/packages/core/__tests__/field-status-satisfied.test.ts
+++ b/packages/core/__tests__/field-status-satisfied.test.ts
@@ -1,0 +1,49 @@
+import { isEmptyArray, isEmptyObject, isEmptyPresent, isEmptyString } from '../src/emptiness.js'
+import { umpire } from '../src/umpire.js'
+
+describe('check() field status satisfied', () => {
+  test('reflects configured isEmpty strategies', () => {
+    const ump = umpire({
+      fields: {
+        presentField: { isEmpty: isEmptyPresent },
+        stringField: { isEmpty: isEmptyString },
+        arrayField: { isEmpty: isEmptyArray },
+        objectField: { isEmpty: isEmptyObject },
+        numberField: { isEmpty: (value) => typeof value !== 'number' || Number.isNaN(value) },
+        booleanField: { isEmpty: (value) => typeof value !== 'boolean' },
+      },
+      rules: [],
+    })
+
+    const unsatisfied = ump.check({
+      presentField: undefined,
+      stringField: '',
+      arrayField: [],
+      objectField: {},
+      numberField: NaN,
+      booleanField: undefined,
+    })
+    const satisfied = ump.check({
+      presentField: 0,
+      stringField: 'x',
+      arrayField: ['x'],
+      objectField: { id: 1 },
+      numberField: 42,
+      booleanField: false,
+    })
+
+    expect(unsatisfied.presentField.satisfied).toBe(false)
+    expect(unsatisfied.stringField.satisfied).toBe(false)
+    expect(unsatisfied.arrayField.satisfied).toBe(false)
+    expect(unsatisfied.objectField.satisfied).toBe(false)
+    expect(unsatisfied.numberField.satisfied).toBe(false)
+    expect(unsatisfied.booleanField.satisfied).toBe(false)
+
+    expect(satisfied.presentField.satisfied).toBe(true)
+    expect(satisfied.stringField.satisfied).toBe(true)
+    expect(satisfied.arrayField.satisfied).toBe(true)
+    expect(satisfied.objectField.satisfied).toBe(true)
+    expect(satisfied.numberField.satisfied).toBe(true)
+    expect(satisfied.booleanField.satisfied).toBe(true)
+  })
+})

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -3,6 +3,7 @@ import {
   getCompositeFailureReasons,
 } from './composite.js'
 import { getInternalRuleMetadata, isFairRule, isGateRule, resolveReason } from './rules.js'
+import { isSatisfied } from './satisfaction.js'
 import type { AvailabilityMap, FieldDef, FieldValues, Rule, RuleEvaluation } from './types.js'
 
 function partitionRulesByPhase<
@@ -202,6 +203,7 @@ export function evaluate<
 
     availability[field] = {
       enabled,
+      satisfied: isSatisfied(values[field], fields[field]),
       fair,
       required: enabled ? fields[field].required ?? false : false,
       reason,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,7 @@ export type ValidationMap<F extends Record<string, FieldDef>> = Partial<{
 
 export type FieldStatus = {
   enabled: boolean
+  satisfied: boolean
   fair: boolean
   required: boolean
   reason: string | null

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -923,7 +923,7 @@ export function umpire<
 
       // Validation metadata only applies once a field is structurally active
       // and has a satisfied value to validate.
-      if (!validator || !status.enabled || !isSatisfied(values[field], fields[field])) {
+      if (!validator || !status.enabled || !status.satisfied) {
         validated[field] = status
         continue
       }
@@ -974,7 +974,7 @@ export function umpire<
       const currentValue = after.values[field]
       const suggestedValue = fields[field].default
 
-      if (!isSatisfied(currentValue, fields[field])) {
+      if (!afterAvailability[field].satisfied) {
         continue
       }
 
@@ -1122,12 +1122,11 @@ export function umpire<
         const availability = check[field]
         const value = typedValues[field]
         const present = isPresent(value)
-        const satisfied = isSatisfied(value, fields[field])
         const scorecardField: ScorecardResult<NormalizeFields<FInput>, C>['fields'][typeof field] = {
           field,
           value,
           present,
-          satisfied,
+          satisfied: availability.satisfied,
           enabled: availability.enabled,
           fair: availability.fair,
           required: availability.required,

--- a/packages/json/__tests__/conformance.test.ts
+++ b/packages/json/__tests__/conformance.test.ts
@@ -17,6 +17,7 @@ type JsonFixtureValue =
 
 type ExpectedFieldStatus = {
   enabled: boolean
+  satisfied: boolean
   fair: boolean
   required: boolean
   reason: string | null

--- a/packages/json/conformance/fixtures/auth-either-of.json
+++ b/packages/json/conformance/fixtures/auth-either-of.json
@@ -35,13 +35,19 @@
             {
               "type": "enabledWhen",
               "field": "submit",
-              "when": { "op": "present", "field": "email" },
+              "when": {
+                "op": "present",
+                "field": "email"
+              },
               "reason": "Enter your email"
             },
             {
               "type": "enabledWhen",
               "field": "submit",
-              "when": { "op": "present", "field": "password" },
+              "when": {
+                "op": "present",
+                "field": "password"
+              },
               "reason": "Enter your password"
             }
           ],
@@ -49,13 +55,19 @@
             {
               "type": "enabledWhen",
               "field": "submit",
-              "when": { "op": "cond", "condition": "ssoAvailable" },
+              "when": {
+                "op": "cond",
+                "condition": "ssoAvailable"
+              },
               "reason": "SSO is not available for this account"
             },
             {
               "type": "enabledWhen",
               "field": "submit",
-              "when": { "op": "present", "field": "email" },
+              "when": {
+                "op": "present",
+                "field": "email"
+              },
               "reason": "Enter your email"
             }
           ],
@@ -63,13 +75,19 @@
             {
               "type": "enabledWhen",
               "field": "submit",
-              "when": { "op": "cond", "condition": "magicLinkEnabled" },
+              "when": {
+                "op": "cond",
+                "condition": "magicLinkEnabled"
+              },
               "reason": "Magic link is not enabled for this tenant"
             },
             {
               "type": "enabledWhen",
               "field": "submit",
-              "when": { "op": "present", "field": "email" },
+              "when": {
+                "op": "present",
+                "field": "email"
+              },
               "reason": "Enter your email"
             }
           ]
@@ -89,10 +107,38 @@
         "magicLinkEnabled": false
       },
       "expectedAvailability": {
-        "email": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "ssoToken": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "ssoToken": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "submit": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     },
     {
@@ -106,10 +152,38 @@
         "magicLinkEnabled": false
       },
       "expectedAvailability": {
-        "email": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "ssoToken": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "ssoToken": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "submit": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     },
     {
@@ -122,10 +196,38 @@
         "magicLinkEnabled": true
       },
       "expectedAvailability": {
-        "email": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "ssoToken": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "ssoToken": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "submit": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     },
     {
@@ -140,10 +242,38 @@
         "magicLinkEnabled": true
       },
       "expectedAvailability": {
-        "email": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "ssoToken": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "ssoToken": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "submit": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     },
     {
@@ -154,10 +284,45 @@
         "magicLinkEnabled": false
       },
       "expectedAvailability": {
-        "email": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "ssoToken": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": false, "fair": true, "required": false, "reason": "Enter your email", "reasons": ["Enter your email", "Enter your password", "SSO is not available for this account", "Enter your email", "Magic link is not enabled for this tenant", "Enter your email"] }
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "ssoToken": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "submit": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Enter your email",
+          "reasons": [
+            "Enter your email",
+            "Enter your password",
+            "SSO is not available for this account",
+            "Enter your email",
+            "Magic link is not enabled for this tenant",
+            "Enter your email"
+          ],
+          "satisfied": false
+        }
       }
     },
     {
@@ -170,10 +335,42 @@
         "magicLinkEnabled": false
       },
       "expectedAvailability": {
-        "email": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "ssoToken": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": false, "fair": true, "required": false, "reason": "Enter your password", "reasons": ["Enter your password", "SSO is not available for this account", "Magic link is not enabled for this tenant"] }
+        "email": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "ssoToken": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "submit": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Enter your password",
+          "reasons": [
+            "Enter your password",
+            "SSO is not available for this account",
+            "Magic link is not enabled for this tenant"
+          ],
+          "satisfied": false
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/box-score-checks.json
+++ b/packages/json/conformance/fixtures/box-score-checks.json
@@ -77,23 +77,92 @@
         "scorerEmail": "pressbox@ballpark.example",
         "highlightUrl": "https://mlb.example/highlights/9th-inning",
         "jerseyNumber": "27",
-        "benchBats": ["Soto"],
-        "walkupClips": ["intro", "chorus", "outro"],
+        "benchBats": [
+          "Soto"
+        ],
+        "walkupClips": [
+          "intro",
+          "chorus",
+          "outro"
+        ],
         "pitchCount": 1,
         "bullpenArms": 8,
         "lineupSlot": 4,
         "inning": 9
       },
       "expectedAvailability": {
-        "scorerEmail": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "highlightUrl": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "jerseyNumber": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "benchBats": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "walkupClips": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pitchCount": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "bullpenArms": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "lineupSlot": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "inning": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "scorerEmail": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "highlightUrl": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "jerseyNumber": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "benchBats": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "walkupClips": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "pitchCount": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "bullpenArms": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "lineupSlot": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "inning": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     },
     {
@@ -103,22 +172,108 @@
         "highlightUrl": "/highlights/9th",
         "jerseyNumber": "100",
         "benchBats": [],
-        "walkupClips": ["a", "b", "c", "d"],
+        "walkupClips": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ],
         "pitchCount": 0,
         "bullpenArms": 9,
         "lineupSlot": 10,
         "inning": 9.5
       },
       "expectedAvailability": {
-        "scorerEmail": { "enabled": true, "fair": false, "required": false, "reason": "Must be a valid email address", "reasons": ["Must be a valid email address"] },
-        "highlightUrl": { "enabled": true, "fair": false, "required": false, "reason": "Must be a valid URL", "reasons": ["Must be a valid URL"] },
-        "jerseyNumber": { "enabled": true, "fair": false, "required": false, "reason": "Must match the required format", "reasons": ["Must match the required format"] },
-        "benchBats": { "enabled": true, "fair": false, "required": false, "reason": "Must be at least 1 characters", "reasons": ["Must be at least 1 characters"] },
-        "walkupClips": { "enabled": true, "fair": false, "required": false, "reason": "Must be 3 characters or fewer", "reasons": ["Must be 3 characters or fewer"] },
-        "pitchCount": { "enabled": true, "fair": false, "required": false, "reason": "Must be at least 1", "reasons": ["Must be at least 1"] },
-        "bullpenArms": { "enabled": true, "fair": false, "required": false, "reason": "Must be 8 or less", "reasons": ["Must be 8 or less"] },
-        "lineupSlot": { "enabled": true, "fair": false, "required": false, "reason": "Must be between 1 and 9", "reasons": ["Must be between 1 and 9"] },
-        "inning": { "enabled": true, "fair": false, "required": false, "reason": "Must be a whole number", "reasons": ["Must be a whole number"] }
+        "scorerEmail": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must be a valid email address",
+          "reasons": [
+            "Must be a valid email address"
+          ],
+          "satisfied": true
+        },
+        "highlightUrl": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must be a valid URL",
+          "reasons": [
+            "Must be a valid URL"
+          ],
+          "satisfied": true
+        },
+        "jerseyNumber": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must match the required format",
+          "reasons": [
+            "Must match the required format"
+          ],
+          "satisfied": true
+        },
+        "benchBats": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must be at least 1 characters",
+          "reasons": [
+            "Must be at least 1 characters"
+          ],
+          "satisfied": true
+        },
+        "walkupClips": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must be 3 characters or fewer",
+          "reasons": [
+            "Must be 3 characters or fewer"
+          ],
+          "satisfied": true
+        },
+        "pitchCount": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must be at least 1",
+          "reasons": [
+            "Must be at least 1"
+          ],
+          "satisfied": true
+        },
+        "bullpenArms": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must be 8 or less",
+          "reasons": [
+            "Must be 8 or less"
+          ],
+          "satisfied": true
+        },
+        "lineupSlot": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must be between 1 and 9",
+          "reasons": [
+            "Must be between 1 and 9"
+          ],
+          "satisfied": true
+        },
+        "inning": {
+          "enabled": true,
+          "fair": false,
+          "required": false,
+          "reason": "Must be a whole number",
+          "reasons": [
+            "Must be a whole number"
+          ],
+          "satisfied": true
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/bullpen-structural.json
+++ b/packages/json/conformance/fixtures/bullpen-structural.json
@@ -46,8 +46,12 @@
         "type": "oneOf",
         "group": "bullpenCall",
         "branches": {
-          "phone": ["bullpenPhone"],
-          "signal": ["outfieldSignal"]
+          "phone": [
+            "bullpenPhone"
+          ],
+          "signal": [
+            "outfieldSignal"
+          ]
         }
       },
       {
@@ -81,13 +85,20 @@
           {
             "type": "enabledWhen",
             "field": "closerReady",
-            "when": { "op": "cond", "condition": "isPlayoffs" },
+            "when": {
+              "op": "cond",
+              "condition": "isPlayoffs"
+            },
             "reason": "Playoff game keeps the closer hot"
           },
           {
             "type": "enabledWhen",
             "field": "closerReady",
-            "when": { "op": "eq", "field": "inning", "value": 9 },
+            "when": {
+              "op": "eq",
+              "field": "inning",
+              "value": 9
+            },
             "reason": "Closer waits for the ninth"
           }
         ]
@@ -119,24 +130,97 @@
         "startingPitcher": "Cole",
         "bullpenPhone": "ring the pen",
         "inning": 9,
-        "pitcherCard": { "fastball": 62 },
-        "benchBats": ["Soto", "Verdugo"],
+        "pitcherCard": {
+          "fastball": 62
+        },
+        "benchBats": [
+          "Soto",
+          "Verdugo"
+        ],
         "stealCoverOn": false
       },
       "conditions": {
         "isPlayoffs": false,
-        "availablePitchers": ["Cole", "Holmes"]
+        "availablePitchers": [
+          "Cole",
+          "Holmes"
+        ]
       },
       "expectedAvailability": {
-        "startingPitcher": { "enabled": true, "fair": true, "required": true, "reason": null, "reasons": [] },
-        "bullpenPhone": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "outfieldSignal": { "enabled": false, "fair": true, "required": false, "reason": "conflicts with phone strategy", "reasons": ["conflicts with phone strategy"] },
-        "closerReady": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "inning": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pitcherCard": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "benchBats": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "stealCoverOn": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "dugoutReady": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "startingPitcher": {
+          "enabled": true,
+          "fair": true,
+          "required": true,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "outfieldSignal": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "conflicts with phone strategy",
+          "reasons": [
+            "conflicts with phone strategy"
+          ],
+          "satisfied": false
+        },
+        "closerReady": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "inning": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "pitcherCard": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "benchBats": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "stealCoverOn": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "dugoutReady": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     },
     {
@@ -146,32 +230,113 @@
         "bullpenPhone": "ring the pen",
         "outfieldSignal": "left-fielder wave",
         "inning": 8,
-        "pitcherCard": { "fastball": 62 },
-        "benchBats": ["Soto", "Verdugo"],
+        "pitcherCard": {
+          "fastball": 62
+        },
+        "benchBats": [
+          "Soto",
+          "Verdugo"
+        ],
         "stealCoverOn": true
       },
       "prev": {
         "startingPitcher": "Cole",
         "bullpenPhone": "ring the pen",
         "inning": 8,
-        "pitcherCard": { "fastball": 62 },
-        "benchBats": ["Soto", "Verdugo"],
+        "pitcherCard": {
+          "fastball": 62
+        },
+        "benchBats": [
+          "Soto",
+          "Verdugo"
+        ],
         "stealCoverOn": true
       },
       "conditions": {
         "isPlayoffs": false,
-        "availablePitchers": ["Cole", "Holmes"]
+        "availablePitchers": [
+          "Cole",
+          "Holmes"
+        ]
       },
       "expectedAvailability": {
-        "startingPitcher": { "enabled": true, "fair": true, "required": true, "reason": null, "reasons": [] },
-        "bullpenPhone": { "enabled": false, "fair": true, "required": false, "reason": "conflicts with signal strategy", "reasons": ["conflicts with signal strategy"] },
-        "outfieldSignal": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "closerReady": { "enabled": false, "fair": true, "required": false, "reason": "Playoff game keeps the closer hot", "reasons": ["Playoff game keeps the closer hot", "Closer waits for the ninth"] },
-        "inning": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pitcherCard": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "benchBats": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "stealCoverOn": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "dugoutReady": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "startingPitcher": {
+          "enabled": true,
+          "fair": true,
+          "required": true,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "conflicts with signal strategy",
+          "reasons": [
+            "conflicts with signal strategy"
+          ],
+          "satisfied": true
+        },
+        "outfieldSignal": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "closerReady": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Playoff game keeps the closer hot",
+          "reasons": [
+            "Playoff game keeps the closer hot",
+            "Closer waits for the ninth"
+          ],
+          "satisfied": false
+        },
+        "inning": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "pitcherCard": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "benchBats": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "stealCoverOn": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "dugoutReady": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     },
     {
@@ -180,24 +345,102 @@
         "startingPitcher": "Cole",
         "bullpenPhone": "ring the pen",
         "inning": 7,
-        "pitcherCard": { "fastball": 62 },
-        "benchBats": ["Soto"],
+        "pitcherCard": {
+          "fastball": 62
+        },
+        "benchBats": [
+          "Soto"
+        ],
         "stealCoverOn": true
       },
       "conditions": {
         "isPlayoffs": false,
-        "availablePitchers": ["Holmes"]
+        "availablePitchers": [
+          "Holmes"
+        ]
       },
       "expectedAvailability": {
-        "startingPitcher": { "enabled": true, "fair": false, "required": true, "reason": "Starting pitcher is not available tonight", "reasons": ["Starting pitcher is not available tonight"] },
-        "bullpenPhone": { "enabled": false, "fair": true, "required": false, "reason": "requires startingPitcher", "reasons": ["requires startingPitcher"] },
-        "outfieldSignal": { "enabled": false, "fair": true, "required": false, "reason": "conflicts with phone strategy", "reasons": ["conflicts with phone strategy"] },
-        "closerReady": { "enabled": false, "fair": true, "required": false, "reason": "Playoff game keeps the closer hot", "reasons": ["Playoff game keeps the closer hot", "Closer waits for the ninth"] },
-        "inning": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pitcherCard": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "benchBats": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "stealCoverOn": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "dugoutReady": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "startingPitcher": {
+          "enabled": true,
+          "fair": false,
+          "required": true,
+          "reason": "Starting pitcher is not available tonight",
+          "reasons": [
+            "Starting pitcher is not available tonight"
+          ],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "requires startingPitcher",
+          "reasons": [
+            "requires startingPitcher"
+          ],
+          "satisfied": true
+        },
+        "outfieldSignal": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "conflicts with phone strategy",
+          "reasons": [
+            "conflicts with phone strategy"
+          ],
+          "satisfied": false
+        },
+        "closerReady": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Playoff game keeps the closer hot",
+          "reasons": [
+            "Playoff game keeps the closer hot",
+            "Closer waits for the ninth"
+          ],
+          "satisfied": false
+        },
+        "inning": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "pitcherCard": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "benchBats": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "stealCoverOn": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "dugoutReady": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/dsl-matrix.json
+++ b/packages/json/conformance/fixtures/dsl-matrix.json
@@ -16,14 +16,31 @@
       }
     },
     "fields": {
-      "inning": { "isEmpty": "number" },
-      "outs": { "isEmpty": "number" },
-      "pitchType": { "isEmpty": "string" },
-      "sprayCard": { "isEmpty": "string" },
-      "bullpenReady": { "isEmpty": "boolean" },
-      "walkSignal": { "isEmpty": "boolean" },
-      "benchBat": { "isEmpty": "string" },
-      "starter": { "required": true, "isEmpty": "string" },
+      "inning": {
+        "isEmpty": "number"
+      },
+      "outs": {
+        "isEmpty": "number"
+      },
+      "pitchType": {
+        "isEmpty": "string"
+      },
+      "sprayCard": {
+        "isEmpty": "string"
+      },
+      "bullpenReady": {
+        "isEmpty": "boolean"
+      },
+      "walkSignal": {
+        "isEmpty": "boolean"
+      },
+      "benchBat": {
+        "isEmpty": "string"
+      },
+      "starter": {
+        "required": true,
+        "isEmpty": "string"
+      },
       "eqGate": {},
       "neqGate": {},
       "gtGate": {},
@@ -46,38 +63,214 @@
       "dugoutTablet": {}
     },
     "rules": [
-      { "type": "enabledWhen", "field": "eqGate", "when": { "op": "eq", "field": "pitchType", "value": "slider" }, "reason": "Needs a slider call" },
-      { "type": "enabledWhen", "field": "neqGate", "when": { "op": "neq", "field": "pitchType", "value": "fastball" }, "reason": "Cannot be straight heat" },
-      { "type": "enabledWhen", "field": "gtGate", "when": { "op": "gt", "field": "inning", "value": 6 }, "reason": "Seventh inning or later" },
-      { "type": "enabledWhen", "field": "gteGate", "when": { "op": "gte", "field": "outs", "value": 2 }, "reason": "Need two outs" },
-      { "type": "enabledWhen", "field": "ltGate", "when": { "op": "lt", "field": "inning", "value": 9 }, "reason": "Must be before the ninth" },
-      { "type": "enabledWhen", "field": "lteGate", "when": { "op": "lte", "field": "outs", "value": 1 }, "reason": "Need one out or fewer" },
-      { "type": "enabledWhen", "field": "presentGate", "when": { "op": "present", "field": "sprayCard" }, "reason": "Spray card must be present" },
-      { "type": "enabledWhen", "field": "absentGate", "when": { "op": "absent", "field": "sprayCard" }, "reason": "Spray card must be absent" },
-      { "type": "enabledWhen", "field": "truthyGate", "when": { "op": "truthy", "field": "bullpenReady" }, "reason": "Bullpen must be ready" },
-      { "type": "enabledWhen", "field": "falsyGate", "when": { "op": "falsy", "field": "walkSignal" }, "reason": "Walk signal must be off" },
-      { "type": "enabledWhen", "field": "inGate", "when": { "op": "in", "field": "benchBat", "values": ["Soto", "Judge"] }, "reason": "Need one of the middle-order bats" },
-      { "type": "enabledWhen", "field": "notInGate", "when": { "op": "notIn", "field": "benchBat", "values": ["Cabrera", "Volpe"] }, "reason": "Bench bat is already committed elsewhere" },
-      { "type": "enabledWhen", "field": "condGate", "when": { "op": "cond", "condition": "isPlayoffs" }, "reason": "Only active in October" },
-      { "type": "enabledWhen", "field": "condEqGate", "when": { "op": "condEq", "condition": "weatherBand", "value": "cold" }, "reason": "Only for cold-weather prep" },
-      { "type": "enabledWhen", "field": "condInGate", "when": { "op": "condIn", "condition": "weatherBand", "values": ["cold", "windy"] }, "reason": "Only for cold or windy prep" },
-      { "type": "enabledWhen", "field": "fieldInCondGate", "when": { "op": "fieldInCond", "field": "starter", "condition": "availableStarters" }, "reason": "Starter must be on tonight's card" },
-      { "type": "enabledWhen", "field": "notGate", "when": { "op": "not", "expr": { "op": "cond", "condition": "isPlayoffs" } }, "reason": "Only active outside October" },
+      {
+        "type": "enabledWhen",
+        "field": "eqGate",
+        "when": {
+          "op": "eq",
+          "field": "pitchType",
+          "value": "slider"
+        },
+        "reason": "Needs a slider call"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "neqGate",
+        "when": {
+          "op": "neq",
+          "field": "pitchType",
+          "value": "fastball"
+        },
+        "reason": "Cannot be straight heat"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "gtGate",
+        "when": {
+          "op": "gt",
+          "field": "inning",
+          "value": 6
+        },
+        "reason": "Seventh inning or later"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "gteGate",
+        "when": {
+          "op": "gte",
+          "field": "outs",
+          "value": 2
+        },
+        "reason": "Need two outs"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "ltGate",
+        "when": {
+          "op": "lt",
+          "field": "inning",
+          "value": 9
+        },
+        "reason": "Must be before the ninth"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "lteGate",
+        "when": {
+          "op": "lte",
+          "field": "outs",
+          "value": 1
+        },
+        "reason": "Need one out or fewer"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "presentGate",
+        "when": {
+          "op": "present",
+          "field": "sprayCard"
+        },
+        "reason": "Spray card must be present"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "absentGate",
+        "when": {
+          "op": "absent",
+          "field": "sprayCard"
+        },
+        "reason": "Spray card must be absent"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "truthyGate",
+        "when": {
+          "op": "truthy",
+          "field": "bullpenReady"
+        },
+        "reason": "Bullpen must be ready"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "falsyGate",
+        "when": {
+          "op": "falsy",
+          "field": "walkSignal"
+        },
+        "reason": "Walk signal must be off"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "inGate",
+        "when": {
+          "op": "in",
+          "field": "benchBat",
+          "values": [
+            "Soto",
+            "Judge"
+          ]
+        },
+        "reason": "Need one of the middle-order bats"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "notInGate",
+        "when": {
+          "op": "notIn",
+          "field": "benchBat",
+          "values": [
+            "Cabrera",
+            "Volpe"
+          ]
+        },
+        "reason": "Bench bat is already committed elsewhere"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "condGate",
+        "when": {
+          "op": "cond",
+          "condition": "isPlayoffs"
+        },
+        "reason": "Only active in October"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "condEqGate",
+        "when": {
+          "op": "condEq",
+          "condition": "weatherBand",
+          "value": "cold"
+        },
+        "reason": "Only for cold-weather prep"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "condInGate",
+        "when": {
+          "op": "condIn",
+          "condition": "weatherBand",
+          "values": [
+            "cold",
+            "windy"
+          ]
+        },
+        "reason": "Only for cold or windy prep"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "fieldInCondGate",
+        "when": {
+          "op": "fieldInCond",
+          "field": "starter",
+          "condition": "availableStarters"
+        },
+        "reason": "Starter must be on tonight's card"
+      },
+      {
+        "type": "enabledWhen",
+        "field": "notGate",
+        "when": {
+          "op": "not",
+          "expr": {
+            "op": "cond",
+            "condition": "isPlayoffs"
+          }
+        },
+        "reason": "Only active outside October"
+      },
       {
         "type": "enabledWhen",
         "field": "comboGate",
         "when": {
           "op": "and",
           "exprs": [
-            { "op": "eq", "field": "pitchType", "value": "slider" },
+            {
+              "op": "eq",
+              "field": "pitchType",
+              "value": "slider"
+            },
             {
               "op": "or",
               "exprs": [
-                { "op": "cond", "condition": "isPlayoffs" },
-                { "op": "gt", "field": "inning", "value": 7 }
+                {
+                  "op": "cond",
+                  "condition": "isPlayoffs"
+                },
+                {
+                  "op": "gt",
+                  "field": "inning",
+                  "value": 7
+                }
               ]
             },
-            { "op": "not", "expr": { "op": "truthy", "field": "walkSignal" } }
+            {
+              "op": "not",
+              "expr": {
+                "op": "truthy",
+                "field": "walkSignal"
+              }
+            }
           ]
         },
         "reason": "Complex scouting combo failed"
@@ -88,8 +281,15 @@
         "when": {
           "op": "and",
           "exprs": [
-            { "op": "present", "field": "sprayCard" },
-            { "op": "fieldInCond", "field": "starter", "condition": "availableStarters" }
+            {
+              "op": "present",
+              "field": "sprayCard"
+            },
+            {
+              "op": "fieldInCond",
+              "field": "starter",
+              "condition": "availableStarters"
+            }
           ]
         },
         "reason": "Bullpen cart waits for the card and an available starter"
@@ -99,11 +299,20 @@
         "when": {
           "op": "or",
           "exprs": [
-            { "op": "condEq", "condition": "weatherBand", "value": "windy" },
-            { "op": "truthy", "field": "walkSignal" }
+            {
+              "op": "condEq",
+              "condition": "weatherBand",
+              "value": "windy"
+            },
+            {
+              "op": "truthy",
+              "field": "walkSignal"
+            }
           ]
         },
-        "targets": ["dugoutTablet"],
+        "targets": [
+          "dugoutTablet"
+        ],
         "reason": "Review board locked during windy or intentional-walk moments"
       }
     ]
@@ -124,37 +333,242 @@
       "conditions": {
         "isPlayoffs": true,
         "weatherBand": "cold",
-        "availableStarters": ["Cole", "Holmes"]
+        "availableStarters": [
+          "Cole",
+          "Holmes"
+        ]
       },
       "expectedAvailability": {
-        "inning": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "outs": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pitchType": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "sprayCard": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "bullpenReady": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "walkSignal": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "benchBat": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "starter": { "enabled": true, "fair": true, "required": true, "reason": null, "reasons": [] },
-        "eqGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "neqGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "gtGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "gteGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "ltGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "lteGate": { "enabled": false, "fair": true, "required": false, "reason": "Need one out or fewer", "reasons": ["Need one out or fewer"] },
-        "presentGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "absentGate": { "enabled": false, "fair": true, "required": false, "reason": "Spray card must be absent", "reasons": ["Spray card must be absent"] },
-        "truthyGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "falsyGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "inGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "notInGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "condGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "condEqGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "condInGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "fieldInCondGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "notGate": { "enabled": false, "fair": true, "required": false, "reason": "Only active outside October", "reasons": ["Only active outside October"] },
-        "comboGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "bullpenCart": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "dugoutTablet": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "inning": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "outs": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "pitchType": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "sprayCard": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "bullpenReady": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "walkSignal": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "benchBat": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "starter": {
+          "enabled": true,
+          "fair": true,
+          "required": true,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "eqGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "neqGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "gtGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "gteGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "ltGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "lteGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Need one out or fewer",
+          "reasons": [
+            "Need one out or fewer"
+          ],
+          "satisfied": false
+        },
+        "presentGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "absentGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Spray card must be absent",
+          "reasons": [
+            "Spray card must be absent"
+          ],
+          "satisfied": false
+        },
+        "truthyGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "falsyGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "inGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "notInGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "condGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "condEqGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "condInGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "fieldInCondGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "notGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Only active outside October",
+          "reasons": [
+            "Only active outside October"
+          ],
+          "satisfied": false
+        },
+        "comboGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "bullpenCart": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "dugoutTablet": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     },
     {
@@ -171,37 +585,265 @@
       "conditions": {
         "isPlayoffs": false,
         "weatherBand": "windy",
-        "availableStarters": ["Holmes"]
+        "availableStarters": [
+          "Holmes"
+        ]
       },
       "expectedAvailability": {
-        "inning": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "outs": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pitchType": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "sprayCard": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "bullpenReady": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "walkSignal": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "benchBat": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "starter": { "enabled": true, "fair": true, "required": true, "reason": null, "reasons": [] },
-        "eqGate": { "enabled": false, "fair": true, "required": false, "reason": "Needs a slider call", "reasons": ["Needs a slider call"] },
-        "neqGate": { "enabled": false, "fair": true, "required": false, "reason": "Cannot be straight heat", "reasons": ["Cannot be straight heat"] },
-        "gtGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "gteGate": { "enabled": false, "fair": true, "required": false, "reason": "Need two outs", "reasons": ["Need two outs"] },
-        "ltGate": { "enabled": false, "fair": true, "required": false, "reason": "Must be before the ninth", "reasons": ["Must be before the ninth"] },
-        "lteGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "presentGate": { "enabled": false, "fair": true, "required": false, "reason": "Spray card must be present", "reasons": ["Spray card must be present"] },
-        "absentGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "truthyGate": { "enabled": false, "fair": true, "required": false, "reason": "Bullpen must be ready", "reasons": ["Bullpen must be ready"] },
-        "falsyGate": { "enabled": false, "fair": true, "required": false, "reason": "Walk signal must be off", "reasons": ["Walk signal must be off"] },
-        "inGate": { "enabled": false, "fair": true, "required": false, "reason": "Need one of the middle-order bats", "reasons": ["Need one of the middle-order bats"] },
-        "notInGate": { "enabled": false, "fair": true, "required": false, "reason": "Bench bat is already committed elsewhere", "reasons": ["Bench bat is already committed elsewhere"] },
-        "condGate": { "enabled": false, "fair": true, "required": false, "reason": "Only active in October", "reasons": ["Only active in October"] },
-        "condEqGate": { "enabled": false, "fair": true, "required": false, "reason": "Only for cold-weather prep", "reasons": ["Only for cold-weather prep"] },
-        "condInGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "fieldInCondGate": { "enabled": false, "fair": true, "required": false, "reason": "Starter must be on tonight's card", "reasons": ["Starter must be on tonight's card"] },
-        "notGate": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "comboGate": { "enabled": false, "fair": true, "required": false, "reason": "Complex scouting combo failed", "reasons": ["Complex scouting combo failed"] },
-        "bullpenCart": { "enabled": false, "fair": true, "required": false, "reason": "Bullpen cart waits for the card and an available starter", "reasons": ["Bullpen cart waits for the card and an available starter"] },
-        "dugoutTablet": { "enabled": false, "fair": true, "required": false, "reason": "Review board locked during windy or intentional-walk moments", "reasons": ["Review board locked during windy or intentional-walk moments"] }
+        "inning": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "outs": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "pitchType": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "sprayCard": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "bullpenReady": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "walkSignal": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "benchBat": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "starter": {
+          "enabled": true,
+          "fair": true,
+          "required": true,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "eqGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Needs a slider call",
+          "reasons": [
+            "Needs a slider call"
+          ],
+          "satisfied": false
+        },
+        "neqGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Cannot be straight heat",
+          "reasons": [
+            "Cannot be straight heat"
+          ],
+          "satisfied": false
+        },
+        "gtGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "gteGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Need two outs",
+          "reasons": [
+            "Need two outs"
+          ],
+          "satisfied": false
+        },
+        "ltGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Must be before the ninth",
+          "reasons": [
+            "Must be before the ninth"
+          ],
+          "satisfied": false
+        },
+        "lteGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "presentGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Spray card must be present",
+          "reasons": [
+            "Spray card must be present"
+          ],
+          "satisfied": false
+        },
+        "absentGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "truthyGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Bullpen must be ready",
+          "reasons": [
+            "Bullpen must be ready"
+          ],
+          "satisfied": false
+        },
+        "falsyGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Walk signal must be off",
+          "reasons": [
+            "Walk signal must be off"
+          ],
+          "satisfied": false
+        },
+        "inGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Need one of the middle-order bats",
+          "reasons": [
+            "Need one of the middle-order bats"
+          ],
+          "satisfied": false
+        },
+        "notInGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Bench bat is already committed elsewhere",
+          "reasons": [
+            "Bench bat is already committed elsewhere"
+          ],
+          "satisfied": false
+        },
+        "condGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Only active in October",
+          "reasons": [
+            "Only active in October"
+          ],
+          "satisfied": false
+        },
+        "condEqGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Only for cold-weather prep",
+          "reasons": [
+            "Only for cold-weather prep"
+          ],
+          "satisfied": false
+        },
+        "condInGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "fieldInCondGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Starter must be on tonight's card",
+          "reasons": [
+            "Starter must be on tonight's card"
+          ],
+          "satisfied": false
+        },
+        "notGate": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "comboGate": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Complex scouting combo failed",
+          "reasons": [
+            "Complex scouting combo failed"
+          ],
+          "satisfied": false
+        },
+        "bullpenCart": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Bullpen cart waits for the card and an available starter",
+          "reasons": [
+            "Bullpen cart waits for the card and an available starter"
+          ],
+          "satisfied": false
+        },
+        "dugoutTablet": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Review board locked during windy or intentional-walk moments",
+          "reasons": [
+            "Review board locked during windy or intentional-walk moments"
+          ],
+          "satisfied": false
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/dugout-emptiness.json
+++ b/packages/json/conformance/fixtures/dugout-emptiness.json
@@ -61,11 +61,46 @@
         "shiftOn": null
       },
       "expectedAvailability": {
-        "scoutingNote": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "benchBats": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pitcherCard": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "inning": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "shiftOn": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
+        "scoutingNote": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "benchBats": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "pitcherCard": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "inning": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "shiftOn": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
         "pregameChecklistReady": {
           "enabled": false,
           "fair": true,
@@ -77,7 +112,8 @@
             "requires pitcherCard",
             "requires inning",
             "requires shiftOn"
-          ]
+          ],
+          "satisfied": false
         }
       }
     },
@@ -85,18 +121,64 @@
       "id": "false-and-numbers-can-still-be-present",
       "values": {
         "scoutingNote": "Attack away early",
-        "benchBats": ["Verdugo"],
-        "pitcherCard": { "firstPitch": "four-seam" },
+        "benchBats": [
+          "Verdugo"
+        ],
+        "pitcherCard": {
+          "firstPitch": "four-seam"
+        },
         "inning": 1,
         "shiftOn": false
       },
       "expectedAvailability": {
-        "scoutingNote": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "benchBats": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pitcherCard": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "inning": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "shiftOn": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "pregameChecklistReady": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "scoutingNote": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "benchBats": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "pitcherCard": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "inning": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "shiftOn": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "pregameChecklistReady": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/plan-either-of-fair.json
+++ b/packages/json/conformance/fixtures/plan-either-of-fair.json
@@ -100,14 +100,24 @@
         "planId": "pro"
       },
       "conditions": {
-        "activePlans": ["pro", "starter"],
+        "activePlans": [
+          "pro",
+          "starter"
+        ],
         "billingReady": true,
         "allowLegacyPlan": false,
         "betaPlans": [],
         "betaEnabled": false
       },
       "expectedAvailability": {
-        "planId": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "planId": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     },
     {
@@ -116,14 +126,24 @@
         "planId": "legacy-gold"
       },
       "conditions": {
-        "activePlans": ["pro", "starter"],
+        "activePlans": [
+          "pro",
+          "starter"
+        ],
         "billingReady": false,
         "allowLegacyPlan": true,
         "betaPlans": [],
         "betaEnabled": false
       },
       "expectedAvailability": {
-        "planId": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "planId": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     },
     {
@@ -132,14 +152,25 @@
         "planId": "beta-x"
       },
       "conditions": {
-        "activePlans": ["pro"],
+        "activePlans": [
+          "pro"
+        ],
         "billingReady": false,
         "allowLegacyPlan": false,
-        "betaPlans": ["beta-x"],
+        "betaPlans": [
+          "beta-x"
+        ],
         "betaEnabled": true
       },
       "expectedAvailability": {
-        "planId": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "planId": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     },
     {
@@ -148,14 +179,25 @@
         "planId": "starter"
       },
       "conditions": {
-        "activePlans": ["starter"],
+        "activePlans": [
+          "starter"
+        ],
         "billingReady": true,
         "allowLegacyPlan": false,
-        "betaPlans": ["starter"],
+        "betaPlans": [
+          "starter"
+        ],
         "betaEnabled": true
       },
       "expectedAvailability": {
-        "planId": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "planId": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     },
     {
@@ -164,7 +206,9 @@
         "planId": "pro"
       },
       "conditions": {
-        "activePlans": ["pro"],
+        "activePlans": [
+          "pro"
+        ],
         "billingReady": false,
         "allowLegacyPlan": false,
         "betaPlans": [],
@@ -181,7 +225,8 @@
             "Legacy plans are not allowed",
             "Selected plan is not in beta",
             "Beta access is disabled"
-          ]
+          ],
+          "satisfied": true
         }
       }
     }

--- a/packages/json/conformance/fixtures/rain-delay-chain.json
+++ b/packages/json/conformance/fixtures/rain-delay-chain.json
@@ -22,7 +22,9 @@
       {
         "type": "disables",
         "source": "rainDelay",
-        "targets": ["starterWarmup"]
+        "targets": [
+          "starterWarmup"
+        ]
       },
       {
         "type": "requires",
@@ -46,10 +48,44 @@
         "bullpenPhone": "call the lefty"
       },
       "expectedAvailability": {
-        "rainDelay": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "starterWarmup": { "enabled": false, "fair": true, "required": false, "reason": "overridden by rainDelay", "reasons": ["overridden by rainDelay"] },
-        "moundVisitPlan": { "enabled": false, "fair": true, "required": false, "reason": "requires starterWarmup", "reasons": ["requires starterWarmup"] },
-        "bullpenPhone": { "enabled": false, "fair": true, "required": false, "reason": "requires moundVisitPlan", "reasons": ["requires moundVisitPlan"] }
+        "rainDelay": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "starterWarmup": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "overridden by rainDelay",
+          "reasons": [
+            "overridden by rainDelay"
+          ],
+          "satisfied": true
+        },
+        "moundVisitPlan": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "requires starterWarmup",
+          "reasons": [
+            "requires starterWarmup"
+          ],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "requires moundVisitPlan",
+          "reasons": [
+            "requires moundVisitPlan"
+          ],
+          "satisfied": true
+        }
       }
     },
     {
@@ -60,10 +96,38 @@
         "bullpenPhone": "call the lefty"
       },
       "expectedAvailability": {
-        "rainDelay": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "starterWarmup": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "moundVisitPlan": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "bullpenPhone": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "rainDelay": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "starterWarmup": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "moundVisitPlan": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/rotation-cascade.json
+++ b/packages/json/conformance/fixtures/rotation-cascade.json
@@ -54,12 +54,41 @@
         "bullpenPhone": "call the bridge arm"
       },
       "conditions": {
-        "availablePitchers": ["Holmes"]
+        "availablePitchers": [
+          "Holmes"
+        ]
       },
       "expectedAvailability": {
-        "startingPitcher": { "enabled": true, "fair": false, "required": true, "reason": "Starting pitcher is not available tonight", "reasons": ["Starting pitcher is not available tonight"] },
-        "catcherPlan": { "enabled": false, "fair": true, "required": false, "reason": "requires startingPitcher", "reasons": ["requires startingPitcher"] },
-        "bullpenPhone": { "enabled": false, "fair": true, "required": false, "reason": "requires catcherPlan", "reasons": ["requires catcherPlan"] }
+        "startingPitcher": {
+          "enabled": true,
+          "fair": false,
+          "required": true,
+          "reason": "Starting pitcher is not available tonight",
+          "reasons": [
+            "Starting pitcher is not available tonight"
+          ],
+          "satisfied": true
+        },
+        "catcherPlan": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "requires startingPitcher",
+          "reasons": [
+            "requires startingPitcher"
+          ],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "requires catcherPlan",
+          "reasons": [
+            "requires catcherPlan"
+          ],
+          "satisfied": true
+        }
       }
     },
     {
@@ -70,12 +99,36 @@
         "bullpenPhone": "call the bridge arm"
       },
       "conditions": {
-        "availablePitchers": ["Cole", "Holmes"]
+        "availablePitchers": [
+          "Cole",
+          "Holmes"
+        ]
       },
       "expectedAvailability": {
-        "startingPitcher": { "enabled": true, "fair": true, "required": true, "reason": null, "reasons": [] },
-        "catcherPlan": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "bullpenPhone": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "startingPitcher": {
+          "enabled": true,
+          "fair": true,
+          "required": true,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "catcherPlan": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/scoreboard-source-checks.json
+++ b/packages/json/conformance/fixtures/scoreboard-source-checks.json
@@ -5,11 +5,17 @@
   "schema": {
     "version": 1,
     "fields": {
-      "scorerEmail": { "isEmpty": "string" },
-      "password": { "isEmpty": "string" },
+      "scorerEmail": {
+        "isEmpty": "string"
+      },
+      "password": {
+        "isEmpty": "string"
+      },
       "submit": {},
       "replayBoard": {},
-      "scoutingNote": { "isEmpty": "string" }
+      "scoutingNote": {
+        "isEmpty": "string"
+      }
     },
     "rules": [
       {
@@ -20,7 +26,9 @@
           {
             "op": "check",
             "field": "scorerEmail",
-            "check": { "op": "email" }
+            "check": {
+              "op": "email"
+            }
           }
         ],
         "reason": "Need a valid scorer email and password before submit"
@@ -31,7 +39,9 @@
         "when": {
           "op": "check",
           "field": "scorerEmail",
-          "check": { "op": "email" }
+          "check": {
+            "op": "email"
+          }
         },
         "reason": "Replay board needs a valid scorer email"
       },
@@ -40,9 +50,14 @@
         "when": {
           "op": "check",
           "field": "scoutingNote",
-          "check": { "op": "minLength", "value": 5 }
+          "check": {
+            "op": "minLength",
+            "value": 5
+          }
         },
-        "targets": ["replayBoard"],
+        "targets": [
+          "replayBoard"
+        ],
         "reason": "Replay board locks once a scouting note is posted"
       }
     ]
@@ -58,11 +73,46 @@
         "scoutingNote": "tag"
       },
       "expectedAvailability": {
-        "scorerEmail": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "replayBoard": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "scoutingNote": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "scorerEmail": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "submit": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "replayBoard": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "scoutingNote": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     },
     {
@@ -75,11 +125,50 @@
         "scoutingNote": "tag"
       },
       "expectedAvailability": {
-        "scorerEmail": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": false, "fair": true, "required": false, "reason": "Need a valid scorer email and password before submit", "reasons": ["Need a valid scorer email and password before submit"] },
-        "replayBoard": { "enabled": false, "fair": true, "required": false, "reason": "Replay board needs a valid scorer email", "reasons": ["Replay board needs a valid scorer email"] },
-        "scoutingNote": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "scorerEmail": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "submit": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Need a valid scorer email and password before submit",
+          "reasons": [
+            "Need a valid scorer email and password before submit"
+          ],
+          "satisfied": true
+        },
+        "replayBoard": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Replay board needs a valid scorer email",
+          "reasons": [
+            "Replay board needs a valid scorer email"
+          ],
+          "satisfied": true
+        },
+        "scoutingNote": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     },
     {
@@ -92,11 +181,48 @@
         "scoutingNote": "posted"
       },
       "expectedAvailability": {
-        "scorerEmail": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "password": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "submit": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "replayBoard": { "enabled": false, "fair": true, "required": false, "reason": "Replay board locks once a scouting note is posted", "reasons": ["Replay board locks once a scouting note is posted"] },
-        "scoutingNote": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "scorerEmail": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "password": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "submit": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "replayBoard": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "Replay board locks once a scouting note is posted",
+          "reasons": [
+            "Replay board locks once a scouting note is posted"
+          ],
+          "satisfied": true
+        },
+        "scoutingNote": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/stale-signal-disables.json
+++ b/packages/json/conformance/fixtures/stale-signal-disables.json
@@ -19,12 +19,16 @@
       {
         "type": "disables",
         "source": "rainDelay",
-        "targets": ["catcherSignal"]
+        "targets": [
+          "catcherSignal"
+        ]
       },
       {
         "type": "disables",
         "source": "catcherSignal",
-        "targets": ["bullpenPhone"]
+        "targets": [
+          "bullpenPhone"
+        ]
       }
     ]
   },
@@ -36,9 +40,34 @@
         "catcherSignal": "wave from the third-base box"
       },
       "expectedAvailability": {
-        "rainDelay": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "catcherSignal": { "enabled": false, "fair": true, "required": false, "reason": "overridden by rainDelay", "reasons": ["overridden by rainDelay"] },
-        "bullpenPhone": { "enabled": false, "fair": true, "required": false, "reason": "overridden by catcherSignal", "reasons": ["overridden by catcherSignal"] }
+        "rainDelay": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "catcherSignal": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "overridden by rainDelay",
+          "reasons": [
+            "overridden by rainDelay"
+          ],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "overridden by catcherSignal",
+          "reasons": [
+            "overridden by catcherSignal"
+          ],
+          "satisfied": false
+        }
       }
     },
     {
@@ -47,9 +76,32 @@
         "rainDelay": "storm cell over center field"
       },
       "expectedAvailability": {
-        "rainDelay": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "catcherSignal": { "enabled": false, "fair": true, "required": false, "reason": "overridden by rainDelay", "reasons": ["overridden by rainDelay"] },
-        "bullpenPhone": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] }
+        "rainDelay": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "catcherSignal": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "overridden by rainDelay",
+          "reasons": [
+            "overridden by rainDelay"
+          ],
+          "satisfied": false
+        },
+        "bullpenPhone": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        }
       }
     },
     {
@@ -58,9 +110,32 @@
         "catcherSignal": "wave from the third-base box"
       },
       "expectedAvailability": {
-        "rainDelay": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "catcherSignal": { "enabled": true, "fair": true, "required": false, "reason": null, "reasons": [] },
-        "bullpenPhone": { "enabled": false, "fair": true, "required": false, "reason": "overridden by catcherSignal", "reasons": ["overridden by catcherSignal"] }
+        "rainDelay": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": false
+        },
+        "catcherSignal": {
+          "enabled": true,
+          "fair": true,
+          "required": false,
+          "reason": null,
+          "reasons": [],
+          "satisfied": true
+        },
+        "bullpenPhone": {
+          "enabled": false,
+          "fair": true,
+          "required": false,
+          "reason": "overridden by catcherSignal",
+          "reasons": [
+            "overridden by catcherSignal"
+          ],
+          "satisfied": false
+        }
       }
     }
   ]

--- a/packages/json/conformance/fixtures/validator-surface.json
+++ b/packages/json/conformance/fixtures/validator-surface.json
@@ -18,7 +18,10 @@
       {
         "type": "enabledWhen",
         "field": "email",
-        "when": { "op": "cond", "condition": "emailEnabled" },
+        "when": {
+          "op": "cond",
+          "condition": "emailEnabled"
+        },
         "reason": "Email entry is disabled"
       }
     ],
@@ -44,7 +47,10 @@
           "fair": true,
           "required": false,
           "reason": "Email entry is disabled",
-          "reasons": ["Email entry is disabled"]
+          "reasons": [
+            "Email entry is disabled"
+          ],
+          "satisfied": true
         }
       }
     },
@@ -62,7 +68,8 @@
           "fair": true,
           "required": false,
           "reason": null,
-          "reasons": []
+          "reasons": [],
+          "satisfied": false
         }
       }
     },
@@ -82,7 +89,8 @@
           "reason": null,
           "reasons": [],
           "valid": false,
-          "error": "Enter a valid email address"
+          "error": "Enter a valid email address",
+          "satisfied": true
         }
       }
     },
@@ -101,7 +109,8 @@
           "required": false,
           "reason": null,
           "reasons": [],
-          "valid": true
+          "valid": true,
+          "satisfied": true
         }
       }
     }

--- a/packages/reads/__tests__/reads.test.ts
+++ b/packages/reads/__tests__/reads.test.ts
@@ -398,6 +398,7 @@ describe('@umpire/reads', () => {
 
       expect(ump.check({ cpu: 'am5', motherboard: 'am5' }).motherboard).toEqual({
         enabled: true,
+        satisfied: true,
         fair: true,
         required: false,
         reason: null,
@@ -423,6 +424,7 @@ describe('@umpire/reads', () => {
 
       expect(ump.check({ cpu: 'am5', motherboard: 'lga1700' }).motherboard).toEqual({
         enabled: true,
+        satisfied: true,
         fair: false,
         required: false,
         reason: 'Selected motherboard no longer matches the CPU socket',
@@ -451,6 +453,7 @@ describe('@umpire/reads', () => {
 
       expect(ump.check({ cpu: 'am5', motherboard: 'am5' }).motherboard).toEqual({
         enabled: true,
+        satisfied: true,
         fair: true,
         required: false,
         reason: null,
@@ -458,6 +461,7 @@ describe('@umpire/reads', () => {
       })
       expect(ump.check({ motherboard: 'am5' }).motherboard).toEqual({
         enabled: false,
+        satisfied: true,
         fair: true,
         required: false,
         reason: 'Pick a CPU first',
@@ -491,6 +495,7 @@ describe('@umpire/reads', () => {
 
       expect(ump.check({}, { allowMotherboard: true }).motherboard).toEqual({
         enabled: true,
+        satisfied: false,
         fair: true,
         required: false,
         reason: null,
@@ -498,6 +503,7 @@ describe('@umpire/reads', () => {
       })
       expect(ump.check({}, { allowMotherboard: false }).motherboard).toEqual({
         enabled: false,
+        satisfied: false,
         fair: true,
         required: false,
         reason: 'Pick a supported platform first',
@@ -538,6 +544,7 @@ describe('@umpire/reads', () => {
         ).motherboard,
       ).toEqual({
         enabled: true,
+        satisfied: true,
         fair: true,
         required: false,
         reason: null,
@@ -550,6 +557,7 @@ describe('@umpire/reads', () => {
         ).motherboard,
       ).toEqual({
         enabled: true,
+        satisfied: true,
         fair: false,
         required: false,
         reason: 'Selected motherboard no longer matches the CPU socket',
@@ -585,6 +593,7 @@ describe('@umpire/reads', () => {
 
       expect(ump.check({ motherboard: 'am5' }, { cpu: 'am5' }).motherboard).toEqual({
         enabled: true,
+        satisfied: true,
         fair: true,
         required: false,
         reason: null,
@@ -592,6 +601,7 @@ describe('@umpire/reads', () => {
       })
       expect(ump.check({ motherboard: 'lga1700' }, { cpu: 'am5' }).motherboard).toEqual({
         enabled: true,
+        satisfied: true,
         fair: false,
         required: false,
         reason: 'Selected motherboard no longer matches the CPU socket',
@@ -627,6 +637,7 @@ describe('@umpire/reads', () => {
 
       expect(ump.check({}, { selectedCpu: 'am5' }).motherboard).toEqual({
         enabled: true,
+        satisfied: false,
         fair: true,
         required: false,
         reason: null,
@@ -634,6 +645,7 @@ describe('@umpire/reads', () => {
       })
       expect(ump.check({}, {}).motherboard).toEqual({
         enabled: false,
+        satisfied: false,
         fair: true,
         required: false,
         reason: 'Pick a CPU first',

--- a/packages/signals/__tests__/reactive.test.ts
+++ b/packages/signals/__tests__/reactive.test.ts
@@ -170,6 +170,7 @@ describe('reactiveUmp', () => {
 
     const email = reactive.field('email')
     expect(email.enabled).toBe(true)
+    expect(email.satisfied).toBe(false)
     expect(email.fair).toBe(true)
     expect(email.required).toBe(true)
     expect(email.reason).toBeNull()
@@ -189,6 +190,12 @@ describe('reactiveUmp', () => {
 
     // Email should be enabled
     expect(reactive.field('email').enabled).toBe(true)
+
+    expect(reactive.field('email').satisfied).toBe(false)
+
+    reactive.set('email', 'test@example.com')
+
+    expect(reactive.field('email').satisfied).toBe(true)
   })
 
   test('field(name) returns the same object on repeated calls', () => {

--- a/packages/signals/src/reactive.ts
+++ b/packages/signals/src/reactive.ts
@@ -127,6 +127,7 @@ export function reactiveUmp<
     string,
     {
       enabled: { get(): boolean }
+      satisfied: { get(): boolean }
       fair: { get(): boolean }
       required: { get(): boolean }
       reason: { get(): string | null }
@@ -137,6 +138,7 @@ export function reactiveUmp<
   for (const name of fieldNames) {
     fieldComputeds.set(name, {
       enabled: adapter.computed(() => availabilityComputed.get()[name].enabled),
+      satisfied: adapter.computed(() => availabilityComputed.get()[name].satisfied),
       fair: adapter.computed(() => availabilityComputed.get()[name].fair),
       required: adapter.computed(() => availabilityComputed.get()[name].required),
       reason: adapter.computed(() => availabilityComputed.get()[name].reason),
@@ -251,6 +253,9 @@ export function reactiveUmp<
       cached = {
         get enabled() {
           return computeds.enabled.get()
+        },
+        get satisfied() {
+          return computeds.satisfied.get()
         },
         get fair() {
           return computeds.fair.get()


### PR DESCRIPTION
## Summary
- Promote `satisfied` to a first-class `FieldStatus` property and compute it in core availability evaluation so `check()` exposes completion semantics directly.
- Update core internals (`play`, validation gating, and `scorecard` assembly) to reuse `status.satisfied` rather than recomputing satisfaction.
- Add strategy coverage tests for `check().<field>.satisfied` (present/string/array/object/number/boolean), update strict expectations, and wire `@umpire/signals` reactive field access to include `satisfied`.
- Refresh API docs for `check()` and `scorecard()` to document `FieldStatus.satisfied` as the render-path completion signal.

## Validation
- `yarn turbo run test --filter=@umpire/core`
- `yarn turbo run test --filter=@umpire/signals`
- `yarn turbo run typecheck --filter=@umpire/core`
- `yarn typecheck`
- `cd docs && yarn build`

Closes #66