### PR TITLE
🧹 Drop scorecard detour from ConfigDrivenDemo now that satisfied is on check()

### DIFF
--- a/docs/src/components/ConfigDrivenDemo.tsx
+++ b/docs/src/components/ConfigDrivenDemo.tsx
@@ -346,10 +346,6 @@ type LiveFormInnerProps = {
 function LiveFormInner({ ump, fieldOrder }: LiveFormInnerProps) {
   const [values, setValues] = useState<InputValues>(() => initValuesFrom(fieldOrder))
   const { check, fouls } = useUmpire(ump, values)
-  // Scorecard gives us Umpire's own `satisfied` per field — whatever `isEmpty`
-  // strategy the schema declares. Hand-rolling string-length checks would drift
-  // the moment a reader edits the JSON to use a different strategy.
-  const scorecard = useMemo(() => ump.scorecard({ values }), [ump, values])
 
   function setField(field: string, next: string) {
     setValues((current) => ({ ...current, [field]: next }))
@@ -368,7 +364,7 @@ function LiveFormInner({ ump, fieldOrder }: LiveFormInnerProps) {
   const allRequired = fieldOrder.filter((field) => check[field]?.required)
   const availableRequired = allRequired.filter((field) => check[field]?.enabled)
   const satisfiedCount = availableRequired.filter(
-    (field) => scorecard.fields[field]?.satisfied,
+    (field) => check[field]?.satisfied,
   ).length
 
   return (


### PR DESCRIPTION
Closes part of #67 — specifically the ConfigDrivenDemo bullet.

## Summary

With `FieldStatus.satisfied` landed via #68, `ConfigDrivenDemo` no longer needs to make a second `ump.scorecard({ values })` pass alongside `useUmpire`. `satisfiedCount` now reads `check[field]?.satisfied` directly — same value, one fewer evaluation pass, no stopgap comment explaining why the detour exists.

The comment I'd written justifying the detour went with it:

```ts
// Scorecard gives us Umpire's own `satisfied` per field — whatever `isEmpty`
// strategy the schema declares. Hand-rolling string-length checks would drift
// the moment a reader edits the JSON to use a different strategy.
const scorecard = useMemo(() => ump.scorecard({ values }), [ump, values])
```

The justification was specifically *"scorecard is the only place `satisfied` lives,"* which stops being true once #68 landed. Net diff: -4 lines.

## Scope

Just the ConfigDrivenDemo cleanup. #67 still has three bullets remaining:

- `PcBuilderDemo.tsx:797` (+ mirrored example in `pc-builder.mdx:160`)
- `SignupDemo.tsx:427` (the `!values[field]` proxy)

Happy to follow up in a separate PR if it's useful to land these piecemeal, or leave them for whoever picks up the rest of #67.

## Test plan

- [x] `cd docs && yarn build` — 54 pages emitted cleanly.
- [ ] Load the Config-Driven UI example in dev. Confirm the "N/M required" counter in the form panel header matches visible filled fields as they're filled/cleared.
- [ ] Toggle `accountType` between individual and business. Confirm disabled required fields don't count toward the denominator (they're filtered out by `availableRequired` before the satisfied check).
- [ ] Edit the textarea to change a field's `isEmpty` strategy (e.g., drop `isEmpty: 'string'` so `'present'` kicks in). Confirm the counter now treats `''` as satisfied, matching Umpire's internal semantics rather than the string-length proxy the demo used to hand-roll.