### PR TITLE
🧹 Use check.satisfied for remaining issue #67 demo updates

### DIFF
--- a/docs/src/components/PcBuilderDemo.tsx
+++ b/docs/src/components/PcBuilderDemo.tsx
@@ -794,7 +794,7 @@ export default function PcBuilderDemo() {
   )
 
   const cpuBrand = selectedCpu?.brand
-  const hasRamSelection = scorecard.fields.ram.satisfied
+  const hasRamSelection = check.ram.satisfied
   const sawTransitiveCascade = hintMarkers.sawTransitiveCascade || hasLiveTransitiveCascade
   const sawAppliedResets = hintMarkers.sawAppliedResets
   const hintInput: HintInput = {

--- a/docs/src/components/SignupDemo.tsx
+++ b/docs/src/components/SignupDemo.tsx
@@ -424,7 +424,7 @@ export default function SignupDemo() {
                             ? av.reason ?? '—'
                             : field === 'submit'
                               ? (av.enabled ? '✓' : av.reason ?? '—')
-                              : error ?? (av.required && !values[field as SignupField] ? 'empty' : '✓')}
+                              : error ?? (av.required && !av.satisfied ? 'empty' : '✓')}
                         </td>
                       </tr>
                     )

--- a/docs/src/content/docs/examples/pc-builder.mdx
+++ b/docs/src/content/docs/examples/pc-builder.mdx
@@ -157,7 +157,7 @@ And the active hint stays derived while the hint input is powered by coach outpu
 ```ts
 const hintInput = {
   cpuBrand: buildReads.selections.cpu?.brand,
-  hasRamSelection: scorecard.fields.ram.satisfied,
+  hasRamSelection: check.ram.satisfied,
   sawTransitiveCascade: hintMarkers.sawTransitiveCascade || hasLiveTransitiveCascade,
   sawAppliedResets: hintMarkers.sawAppliedResets,
 }


### PR DESCRIPTION
## Summary
- switch PC Builder hint input to use check.ram.satisfied
- update the PC Builder docs snippet to match
- use av.satisfied for Signup empty/complete status

## Validation
- cd docs && yarn build

## Notes
- ConfigDrivenDemo changes from #67 stay out of scope here because they were already handled in #70.