### PR TITLE
⚡️ Trim core perf follow-up hot paths

### DIFF
--- a/.changeset/perf-followup-core-pass.md
+++ b/.changeset/perf-followup-core-pass.md
@@ -1,0 +1,5 @@
+---
+"@umpire/core": patch
+---
+
+Trim composite/challenge allocation overhead in core evaluation paths and add multi-run benchmark summaries with variance and construction/runtime totals.

--- a/packages/core/scripts/benchmark.mjs
+++ b/packages/core/scripts/benchmark.mjs
@@ -34,15 +34,94 @@ function benchmark(name, iterations, fn) {
   }
 }
 
-function printResults(results) {
+function average(values) {
+  if (values.length === 0) {
+    return 0
+  }
+
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function variance(values, mean) {
+  if (values.length === 0) {
+    return 0
+  }
+
+  return values.reduce((sum, value) => {
+    const delta = value - mean
+    return sum + delta * delta
+  }, 0) / values.length
+}
+
+function summarizeScenarioRuns(scenario, runCount) {
+  const runs = []
+
+  for (let run = 0; run < runCount; run += 1) {
+    runs.push(benchmark(scenario.name, scenario.iterations, scenario.run))
+  }
+
+  const totalMsValues = runs.map((result) => result.totalMs)
+  const avgMsValues = runs.map((result) => result.avgMs)
+  const opsPerSecValues = runs.map((result) => result.opsPerSec)
+  const meanTotalMs = average(totalMsValues)
+
+  return {
+    name: scenario.name,
+    category: scenario.category,
+    iterations: scenario.iterations,
+    runs,
+    checksum: runs[0]?.checksum ?? 0,
+    avgTotalMs: meanTotalMs,
+    varTotalMs: variance(totalMsValues, meanTotalMs),
+    avgMs: average(avgMsValues),
+    avgOpsPerSec: average(opsPerSecValues),
+  }
+}
+
+function printScenarioResults(results, runCount) {
   const table = results.map((result) => ({
     benchmark: result.name,
+    category: result.category,
+    runs: runCount,
     iterations: result.iterations,
-    total_ms: result.totalMs.toFixed(2),
+    avg_total_ms: result.avgTotalMs.toFixed(2),
+    var_total_ms: result.varTotalMs.toFixed(4),
     avg_ms: result.avgMs.toFixed(3),
-    ops_sec: result.opsPerSec.toFixed(2),
+    avg_ops_sec: result.avgOpsPerSec.toFixed(2),
     checksum: result.checksum,
   }))
+
+  console.table(table)
+}
+
+function printCategoryTotals(results, runCount) {
+  const categories = ['construction-heavy', 'runtime-heavy']
+  const table = categories.map((category) => {
+    const totalsByRun = []
+
+    for (let run = 0; run < runCount; run += 1) {
+      let total = 0
+
+      for (const result of results) {
+        if (result.category !== category) {
+          continue
+        }
+
+        total += result.runs[run]?.totalMs ?? 0
+      }
+
+      totalsByRun.push(total)
+    }
+
+    const avgTotalMs = average(totalsByRun)
+
+    return {
+      category,
+      runs: runCount,
+      avg_total_ms: avgTotalMs.toFixed(2),
+      var_total_ms: variance(totalsByRun, avgTotalMs).toFixed(4),
+    }
+  })
 
   console.table(table)
 }
@@ -321,64 +400,104 @@ const schedulerRuntime = makeSchedulerScenario(60)
 const challengeField = 'review_28'
 const minesweeper = createExpertMinesweeperScenario()
 
-const results = [
-  benchmark('create/scheduler-60-sections', 25, () => {
-    const scenario = makeSchedulerScenario(60)
-    const graph = scenario.engine.graph()
-    return graph.nodes.length + graph.edges.length
-  }),
-  benchmark('check/scheduler/pro-plan', 150, () => {
-    const availability = schedulerRuntime.engine.check(
-      schedulerRuntime.beforeValues,
-      schedulerRuntime.beforeConditions,
-    )
-    return sumAvailability(availability)
-  }),
-  benchmark('check/scheduler/basic-readonly', 150, () => {
-    const availability = schedulerRuntime.engine.check(
-      schedulerRuntime.afterValues,
-      schedulerRuntime.afterConditions,
-      schedulerRuntime.beforeValues,
-    )
-    return sumAvailability(availability)
-  }),
-  benchmark('challenge/review-lock-chain', 100, () => {
-    const trace = schedulerRuntime.engine.challenge(
-      challengeField,
-      schedulerRuntime.afterValues,
+const runCount = Number(process.env.BENCH_RUNS ?? '5')
+
+const scenarios = [
+  {
+    name: 'create/scheduler-60-sections',
+    category: 'construction-heavy',
+    iterations: 25,
+    run: () => {
+      const scenario = makeSchedulerScenario(60)
+      const graph = scenario.engine.graph()
+      return graph.nodes.length + graph.edges.length
+    },
+  },
+  {
+    name: 'check/scheduler/pro-plan',
+    category: 'runtime-heavy',
+    iterations: 150,
+    run: () => {
+      const availability = schedulerRuntime.engine.check(
+        schedulerRuntime.beforeValues,
+        schedulerRuntime.beforeConditions,
+      )
+      return sumAvailability(availability)
+    },
+  },
+  {
+    name: 'check/scheduler/basic-readonly',
+    category: 'runtime-heavy',
+    iterations: 150,
+    run: () => {
+      const availability = schedulerRuntime.engine.check(
+        schedulerRuntime.afterValues,
+        schedulerRuntime.afterConditions,
+        schedulerRuntime.beforeValues,
+      )
+      return sumAvailability(availability)
+    },
+  },
+  {
+    name: 'challenge/review-lock-chain',
+    category: 'runtime-heavy',
+    iterations: 100,
+    run: () => {
+      const trace = schedulerRuntime.engine.challenge(
+        challengeField,
+        schedulerRuntime.afterValues,
       schedulerRuntime.afterConditions,
       schedulerRuntime.beforeValues,
     )
 
-    return (
-      (trace.enabled ? 1 : 0) +
-      trace.directReasons.length +
-      trace.transitiveDeps.length +
-      (trace.oneOfResolution ? Object.keys(trace.oneOfResolution.branches).length : 0)
-    )
-  }),
-  benchmark('play/plan-downgrade', 100, () => {
-    const fouls = schedulerRuntime.engine.play(
-      {
-        values: schedulerRuntime.beforeValues,
+      return (
+        (trace.enabled ? 1 : 0) +
+        trace.directReasons.length +
+        trace.transitiveDeps.length +
+        (trace.oneOfResolution ? Object.keys(trace.oneOfResolution.branches).length : 0)
+      )
+    },
+  },
+  {
+    name: 'play/plan-downgrade',
+    category: 'runtime-heavy',
+    iterations: 100,
+    run: () => {
+      const fouls = schedulerRuntime.engine.play(
+        {
+          values: schedulerRuntime.beforeValues,
         conditions: schedulerRuntime.beforeConditions,
       },
       {
         values: schedulerRuntime.afterValues,
         conditions: schedulerRuntime.afterConditions,
       },
-    )
+      )
 
-    return fouls.length + fouls.reduce((sum, foul) => sum + foul.field.length, 0)
-  }),
-  benchmark('graph/export-scheduler', 100, () => {
-    const graph = schedulerConstructionFields.engine.graph()
-    return graph.nodes.length + graph.edges.length
-  }),
-  benchmark('check/minesweeper-expert-board', 100, () => {
-    const availability = minesweeper.engine.check(minesweeper.values, minesweeper.conditions)
-    return sumAvailability(availability)
-  }),
+      return fouls.length + fouls.reduce((sum, foul) => sum + foul.field.length, 0)
+    },
+  },
+  {
+    name: 'graph/export-scheduler',
+    category: 'construction-heavy',
+    iterations: 100,
+    run: () => {
+      const graph = schedulerConstructionFields.engine.graph()
+      return graph.nodes.length + graph.edges.length
+    },
+  },
+  {
+    name: 'check/minesweeper-expert-board',
+    category: 'runtime-heavy',
+    iterations: 100,
+    run: () => {
+      const availability = minesweeper.engine.check(minesweeper.values, minesweeper.conditions)
+      return sumAvailability(availability)
+    },
+  },
 ]
 
-printResults(results)
+const results = scenarios.map((scenario) => summarizeScenarioRuns(scenario, runCount))
+
+printScenarioResults(results, runCount)
+printCategoryTotals(results, runCount)

--- a/packages/core/src/composite.ts
+++ b/packages/core/src/composite.ts
@@ -3,16 +3,24 @@ import type { RuleEvaluation } from './types.js'
 export type CompositeConstraint = 'enabled' | 'fair'
 export type CompositeMode = 'and' | 'or'
 
-export function getCompositeFailureReasons(result: RuleEvaluation): string[] {
+export function appendCompositeFailureReasons(result: RuleEvaluation, reasons: string[]): void {
   if (result.reasons && result.reasons.length > 0) {
-    return [...result.reasons]
+    for (const reason of result.reasons) {
+      reasons.push(reason)
+    }
+
+    return
   }
 
   if (result.reason !== null) {
-    return [result.reason]
+    reasons.push(result.reason)
   }
+}
 
-  return []
+export function getCompositeFailureReasons(result: RuleEvaluation): string[] {
+  const reasons: string[] = []
+  appendCompositeFailureReasons(result, reasons)
+  return reasons
 }
 
 export function combineCompositeResults(
@@ -20,14 +28,25 @@ export function combineCompositeResults(
   mode: CompositeMode,
   results: RuleEvaluation[],
 ): RuleEvaluation {
-  const passed =
-    constraint === 'fair'
-      ? mode === 'and'
-        ? results.every((result) => result.fair !== false)
-        : results.some((result) => result.fair !== false)
-      : mode === 'and'
-        ? results.every((result) => result.enabled)
-        : results.some((result) => result.enabled)
+  let passed = mode === 'and'
+
+  for (const result of results) {
+    const currentPassed = constraint === 'fair' ? result.fair !== false : result.enabled
+
+    if (mode === 'and') {
+      if (!currentPassed) {
+        passed = false
+        break
+      }
+
+      continue
+    }
+
+    if (currentPassed) {
+      passed = true
+      break
+    }
+  }
 
   if (passed) {
     return constraint === 'fair'
@@ -42,7 +61,11 @@ export function combineCompositeResults(
         }
   }
 
-  const reasons = results.flatMap(getCompositeFailureReasons)
+  const reasons: string[] = []
+
+  for (const result of results) {
+    appendCompositeFailureReasons(result, reasons)
+  }
 
   return constraint === 'fair'
     ? {

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -1,6 +1,6 @@
 import {
+  appendCompositeFailureReasons,
   combineCompositeResults,
-  getCompositeFailureReasons,
 } from './composite.js'
 import { getInternalRuleMetadata, isFairRule, isGateRule, resolveReason } from './rules.js'
 import { isSatisfied } from './satisfaction.js'
@@ -93,28 +93,34 @@ export function evaluateRuleForField<
   const metadata = getInternalRuleMetadata(rule)
 
   if (metadata?.kind === 'anyOf') {
-    const innerResults = metadata.rules.map((innerRule) =>
-      evaluateRuleForField(
-        innerRule,
-        field,
-        fields,
-        values,
-        conditions,
-        prev,
-        availability,
-        baseRuleCache,
-      ),
-    )
+    const innerResults: RuleEvaluation[] = []
+
+    for (const innerRule of metadata.rules) {
+      innerResults.push(
+        evaluateRuleForField(
+          innerRule,
+          field,
+          fields,
+          values,
+          conditions,
+          prev,
+          availability,
+          baseRuleCache,
+        ),
+      )
+    }
 
     return combineCompositeResults(metadata.constraint, 'or', innerResults)
   }
 
   if (metadata?.kind === 'eitherOf') {
-    const branchResults = Object.values(metadata.branches).map((branchRules) =>
-      combineCompositeResults(
-        metadata.constraint,
-        'and',
-        branchRules.map((innerRule) =>
+    const branchResults: RuleEvaluation[] = []
+
+    for (const branchRules of Object.values(metadata.branches)) {
+      const innerResults: RuleEvaluation[] = []
+
+      for (const innerRule of branchRules) {
+        innerResults.push(
           evaluateRuleForField(
             innerRule,
             field,
@@ -124,9 +130,12 @@ export function evaluateRuleForField<
             prev,
             availability,
             baseRuleCache,
-          )),
-      ),
-    )
+          ),
+        )
+      }
+
+      branchResults.push(combineCompositeResults(metadata.constraint, 'and', innerResults))
+    }
 
     return combineCompositeResults(metadata.constraint, 'or', branchResults)
   }
@@ -147,7 +156,7 @@ export function evaluateRuleForField<
     enabled: result.enabled,
     fair: result.fair,
     reason: result.reason,
-    reasons: result.reasons && result.reasons.length > 0 ? [...result.reasons] : undefined,
+    reasons: result.reasons && result.reasons.length > 0 ? result.reasons : undefined,
   }
 }
 
@@ -199,7 +208,7 @@ export function evaluate<
         reason = result.reason
       }
 
-      reasons.push(...getCompositeFailureReasons(result))
+      appendCompositeFailureReasons(result, reasons)
     }
 
     if (enabled) {
@@ -225,7 +234,7 @@ export function evaluate<
           reason = result.reason
         }
 
-        reasons.push(...getCompositeFailureReasons(result))
+        appendCompositeFailureReasons(result, reasons)
       }
     }
 

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -490,18 +490,24 @@ function collectFailedDependenciesForRule<
       return []
     }
 
-    return metadata.rules.flatMap((innerRule) =>
-      collectFailedDependenciesForRule(
-        innerRule,
-        field,
-        fields,
-        values,
-        conditions,
-        prev,
-        availability,
-        baseRuleCache,
-      ),
-    )
+    const failedDependencies: Array<keyof F & string> = []
+
+    for (const innerRule of metadata.rules) {
+      failedDependencies.push(
+        ...collectFailedDependenciesForRule(
+          innerRule,
+          field,
+          fields,
+          values,
+          conditions,
+          prev,
+          availability,
+          baseRuleCache,
+        ),
+      )
+    }
+
+    return failedDependencies
   }
 
   if (metadata?.kind === 'eitherOf') {
@@ -520,18 +526,26 @@ function collectFailedDependenciesForRule<
       return []
     }
 
-    return Object.values(metadata.branches).flatMap((branchRules) =>
-      branchRules.flatMap((innerRule) =>
-        collectFailedDependenciesForRule(
-          innerRule,
-          field,
-          fields,
-          values,
-          conditions,
-          prev,
-          availability,
-          baseRuleCache,
-        )))
+    const failedDependencies: Array<keyof F & string> = []
+
+    for (const branchRules of Object.values(metadata.branches)) {
+      for (const innerRule of branchRules) {
+        failedDependencies.push(
+          ...collectFailedDependenciesForRule(
+            innerRule,
+            field,
+            fields,
+            values,
+            conditions,
+            prev,
+            availability,
+            baseRuleCache,
+          ),
+        )
+      }
+    }
+
+    return failedDependencies
   }
 
   if (metadata?.kind !== 'requires') {
@@ -578,24 +592,32 @@ function describeCausedBy<
   availability: AvailabilityMap<F>,
   baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>,
 ): ChallengeTrace['transitiveDeps'][number]['causedBy'] {
-  return (rulesByTarget.get(field) ?? [])
-    .map((rule) =>
-      describeRuleForField(
-        rule,
-        field,
-        fields,
-        values,
-        conditions,
-        prev,
-        availability,
-        baseRuleCache,
-      ),
-    )
-    .filter((entry) => entry.passed === false)
-    .map(({ rule, ...details }) => ({
+  const causedBy: ChallengeTrace['transitiveDeps'][number]['causedBy'] = []
+
+  for (const rule of rulesByTarget.get(field) ?? []) {
+    const entry = describeRuleForField(
       rule,
+      field,
+      fields,
+      values,
+      conditions,
+      prev,
+      availability,
+      baseRuleCache,
+    )
+
+    if (entry.passed) {
+      continue
+    }
+
+    const { rule: ruleName, ...details } = entry
+    causedBy.push({
+      rule: ruleName,
       ...details,
-    }))
+    })
+  }
+
+  return causedBy
 }
 
 function buildTransitiveDeps<
@@ -626,12 +648,7 @@ function buildTransitiveDeps<
         availability,
         baseRuleCache,
       )) {
-        const dependencySatisfied = isSatisfied(values[dependency], fields[dependency])
         const dependencyAvailability = availability[dependency]
-
-        if (dependencySatisfied && dependencyAvailability.enabled && dependencyAvailability.fair) {
-          continue
-        }
 
         if (visited.has(dependency)) {
           continue
@@ -964,10 +981,12 @@ export function umpire<
     const recommendations: Foul<NormalizeFields<FInput>>[] = []
 
     for (const field of fieldNames) {
+      const beforeStatus = beforeAvailability[field]
+      const afterStatus = afterAvailability[field]
       const disabledTransition =
-        beforeAvailability[field].enabled && !afterAvailability[field].enabled
+        beforeStatus.enabled && !afterStatus.enabled
       const foulTransition =
-        beforeAvailability[field].fair && afterAvailability[field].fair === false
+        beforeStatus.fair && afterStatus.fair === false
 
       if (!disabledTransition && !foulTransition) {
         continue
@@ -976,7 +995,7 @@ export function umpire<
       const currentValue = after.values[field]
       const suggestedValue = fields[field].default
 
-      if (!afterAvailability[field].satisfied) {
+      if (!afterStatus.satisfied) {
         continue
       }
 
@@ -986,7 +1005,7 @@ export function umpire<
 
       recommendations.push({
         field,
-        reason: afterAvailability[field].reason ?? (disabledTransition ? 'field disabled' : 'field fouled'),
+        reason: afterStatus.reason ?? (disabledTransition ? 'field disabled' : 'field fouled'),
         suggestedValue,
       })
     }
@@ -1029,7 +1048,8 @@ export function umpire<
     const typedPrev = prev as FieldValues<NormalizeFields<FInput>> | undefined
     const availability = checkAvailability(typedValues, resolvedConditions, typedPrev)
     const baseRuleCache = new Map<Rule<NormalizeFields<FInput>, C>, Map<string, RuleEvaluation>>()
-    const directReasons = (rulesByTarget.get(field) ?? [])
+    const targetRules = rulesByTarget.get(field) ?? []
+    const directReasons = targetRules
       .map((rule) =>
         describeRuleForField(
           rule,
@@ -1043,7 +1063,7 @@ export function umpire<
         ),
       )
 
-    const oneOfRule = (rulesByTarget.get(field) ?? []).find((rule) => {
+    const oneOfRule = targetRules.find((rule) => {
       const metadata = getInternalRuleMetadata(rule)
       return metadata?.kind === 'oneOf'
     })


### PR DESCRIPTION
## Summary
- trim allocation-heavy composite evaluation paths in `evaluate()`/`evaluateRuleForField()` by replacing array-heavy helpers with push-based loops and reason appenders
- reduce repeated traversal/allocation work in `challenge()`/`play()` dependency and reason assembly while keeping output shape and ordering stable
- upgrade `@umpire/core` benchmark reporting to run N passes (default 5) with per-scenario avg/variance plus construction-heavy vs runtime-heavy totals, and include a core patch changeset

## Benchmark impact
Before numbers are from the pre-change benchmark run. After numbers are from this branch using the new default 5-run average (`BENCH_RUNS=5`).

### Key takeaways
- ✅ Runtime-heavy total improved from **~268.69ms** to **262.83ms** (about **-2.2%** overall).
- ✅ The targeted runtime paths (`check/*`, `challenge/review-lock-chain`) all improved; biggest runtime win was `check/minesweeper-expert-board` (**-5.6%**).
- ⚖️ `play/plan-downgrade` is effectively flat (**+0.2%**) and within normal run-to-run noise.
- ✅ Construction-heavy paths also improved, with strong wins in `create/scheduler-60-sections` (**-8.2%**) and `graph/export-scheduler` (**-10.8%**).

| Benchmark | Before avg ms | After avg ms (5-run) | Delta |
|---|---:|---:|---:|
| create/scheduler-60-sections | 2.246 | 2.061 | -8.2% |
| check/scheduler/pro-plan | 0.378 | 0.369 | -2.4% |
| check/scheduler/basic-readonly | 0.424 | 0.408 | -3.8% |
| challenge/review-lock-chain | 0.411 | 0.404 | -1.7% |
| play/plan-downgrade | 0.806 | 0.808 | +0.2% |
| graph/export-scheduler | 0.037 | 0.033 | -10.8% |
| check/minesweeper-expert-board | 0.267 | 0.252 | -5.6% |

Category totals (new benchmark summary):
- construction-heavy: **54.82ms avg total**
- runtime-heavy: **262.83ms avg total**

## Validation
- `yarn turbo run test --filter=@umpire/core`
- `yarn typecheck`
- `yarn workspace @umpire/core bench`