### PR TITLE
⚡️ Reduce devtools panel lockups on heavy reads

### DIFF
--- a/.changeset/devtools-panel-perf-reads.md
+++ b/.changeset/devtools-panel-perf-reads.md
@@ -1,0 +1,5 @@
+---
+"@umpire/devtools": patch
+---
+
+Improve devtools panel responsiveness by avoiding eager reads-extension materialization, deduplicating identical register() calls, and capping initial reads tab rendering.

--- a/packages/devtools/__tests__/panel.test.ts
+++ b/packages/devtools/__tests__/panel.test.ts
@@ -1,4 +1,5 @@
 import { eitherOf, enabledWhen, umpire } from '@umpire/core'
+import type { ReadTableInspection } from '@umpire/reads'
 import { mount, register, unregister, unmount } from '../src/index.js'
 import { resetRegistry } from '../src/registry.js'
 
@@ -115,6 +116,52 @@ describe('Panel', () => {
     expect(text).toContain('Summary')
     expect(text).toContain('blocked')
     expect(text).toContain('2')
+  })
+
+  it('renders reads in the dedicated reads tab', async () => {
+    const inspection: ReadTableInspection<Record<string, unknown>, Record<string, unknown>> = {
+      bridges: [],
+      graph: {
+        edges: [],
+        nodes: ['status'],
+      },
+      nodes: {
+        status: {
+          dependsOnFields: ['email'],
+          dependsOnReads: [],
+          id: 'status',
+          value: 'ok',
+        },
+      },
+      values: {
+        status: 'ok',
+      },
+    }
+
+    register(
+      'signup',
+      demoUmp,
+      { email: 'alex@example.com' },
+      undefined,
+      { reads: inspection },
+    )
+
+    mount({ defaultTab: 'reads' })
+
+    const host = document.getElementById('umpire-devtools')
+    const root = host?.shadowRoot
+    const toggle = root?.querySelector('button[aria-expanded="false"]')
+
+    expect(toggle).not.toBeNull()
+
+    toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    await flushUi()
+
+    const text = root?.textContent ?? ''
+
+    expect(text).toContain('reads')
+    expect(text).toContain('status')
+    expect(text).toContain('ok')
   })
 
   it('renders named eitherOf branches in the challenge drawer', async () => {

--- a/packages/devtools/__tests__/registry.test.ts
+++ b/packages/devtools/__tests__/registry.test.ts
@@ -135,29 +135,7 @@ describe('registry', () => {
     )
 
     expect(snapshot().get('demo')?.reads).toEqual(inspection)
-    expect(snapshot().get('demo')?.extensions).toEqual([{
-      id: 'reads',
-      label: 'reads',
-      view: {
-        empty: 'No reads available in this inspection.',
-        sections: [{
-          items: [{
-            badge: {
-              tone: 'fair',
-              value: 'ready',
-            },
-            id: 'status',
-            rows: [
-              { label: 'fields', value: 'gate' },
-              { label: 'reads', value: 'none' },
-            ],
-            title: 'status',
-          }],
-          kind: 'items',
-          title: 'Reads',
-        }],
-      },
-    }])
+    expect(snapshot().get('demo')?.extensions).toEqual([])
   })
 
   it('uses readInput overrides when resolving read tables', () => {
@@ -196,7 +174,7 @@ describe('registry', () => {
 
     expect(inspect).toHaveBeenCalledWith({ externalGate: 'override' })
     expect(snapshot().get('demo')?.reads?.values).toEqual({ status: 'override' })
-    expect(snapshot().get('demo')?.extensions[0]?.id).toBe('reads')
+    expect(snapshot().get('demo')?.extensions).toEqual([])
   })
 
   it('uses form values as the default read table input', () => {
@@ -237,7 +215,7 @@ describe('registry', () => {
       target: 'kept',
     })
     expect(snapshot().get('demo')?.reads?.values).toEqual({ status: 'open' })
-    expect(snapshot().get('demo')?.extensions[0]?.id).toBe('reads')
+    expect(snapshot().get('demo')?.extensions).toEqual([])
   })
 
   it('ignores invalid reads options that are neither inspections nor read tables', () => {
@@ -256,6 +234,28 @@ describe('registry', () => {
 
     expect(snapshot().get('demo')?.reads).toBeNull()
     expect(snapshot().get('demo')?.extensions).toEqual([])
+  })
+
+  it('skips duplicate register calls with identical references', () => {
+    const listener = mock()
+    subscribe(listener)
+
+    const values = {
+      gate: 'open',
+      target: 'kept',
+    }
+    const conditions = { flow: 'signup' }
+
+    register('demo', demoUmp, values, conditions)
+
+    const firstVersion = getRegistryVersion()
+    const firstRenderIndex = snapshot().get('demo')?.renderIndex
+
+    register('demo', demoUmp, values, conditions)
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(getRegistryVersion()).toBe(firstVersion)
+    expect(snapshot().get('demo')?.renderIndex).toBe(firstRenderIndex)
   })
 
   it('stores resolved custom extensions from register options', () => {

--- a/packages/devtools/src/panel/Panel.tsx
+++ b/packages/devtools/src/panel/Panel.tsx
@@ -14,6 +14,7 @@ import { FoulLog } from './tabs/FoulLog.js'
 import { FieldMatrix } from './tabs/FieldMatrix.js'
 import { GraphTab } from './tabs/GraphTab.js'
 import { fontFamily, scrollPaneStyle, sectionHeadingStyle, tabStyle, theme } from './theme.js'
+import { ReadsTab } from './tabs/ReadsTab.js'
 
 type Props = {
   options: Required<MountOptions>
@@ -67,6 +68,10 @@ function resolveTabs(entry: RegistryEntry | null): PanelTab[] {
 
   if (!entry) {
     return tabs
+  }
+
+  if (entry.reads) {
+    tabs.push({ id: 'reads', label: 'reads' })
   }
 
   for (const extension of entry.extensions) {
@@ -353,6 +358,10 @@ function PanelBody({
         selectedField={selectedField}
       />
     )
+  }
+
+  if (tab === 'reads') {
+    return <ReadsTab inspection={entry.reads} />
   }
 
   const extension = entry.extensions.find((candidate) => candidate.id === tab) ?? null

--- a/packages/devtools/src/panel/tabs/ReadsTab.tsx
+++ b/packages/devtools/src/panel/tabs/ReadsTab.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'preact/hooks'
 import type { AnyReadInspection } from '../../types.js'
 import { formatValue } from '../format.js'
 import { pillStyle, scrollPaneStyle, theme } from '../theme.js'
@@ -11,6 +12,8 @@ function join(values: string[]) {
 }
 
 export function ReadsTab({ inspection }: Props) {
+  const [showAllReads, setShowAllReads] = useState(false)
+
   if (!inspection) {
     return (
       <div
@@ -28,6 +31,11 @@ export function ReadsTab({ inspection }: Props) {
       </div>
     )
   }
+
+  const MAX_READ_ITEMS = 200
+  const allReadIds = inspection.graph.nodes
+  const visibleReadIds = showAllReads ? allReadIds : allReadIds.slice(0, MAX_READ_ITEMS)
+  const hiddenCount = allReadIds.length - visibleReadIds.length
 
   return (
     <div style={scrollPaneStyle()}>
@@ -50,7 +58,7 @@ export function ReadsTab({ inspection }: Props) {
         </div>
       )}
 
-      {inspection.graph.nodes.map((readId) => {
+      {visibleReadIds.map((readId) => {
         const node = inspection.nodes[readId]
 
         return (
@@ -78,6 +86,38 @@ export function ReadsTab({ inspection }: Props) {
           </div>
         )
       })}
+
+      {hiddenCount > 0 && (
+        <div
+          style={{
+            borderTop: `1px solid ${theme.border}`,
+            display: 'grid',
+            gap: 8,
+            padding: 12,
+          }}
+        >
+          <div style={{ color: theme.fgMuted, fontSize: 11 }}>
+            Showing {visibleReadIds.length} of {allReadIds.length} reads.
+          </div>
+          <button
+            onClick={() => setShowAllReads((current) => !current)}
+            style={{
+              appearance: 'none',
+              background: theme.surface,
+              border: `1px solid ${theme.border}`,
+              borderRadius: 8,
+              color: theme.fg,
+              cursor: 'pointer',
+              fontSize: 11,
+              justifySelf: 'start',
+              padding: '6px 10px',
+            }}
+            type="button"
+          >
+            {showAllReads ? 'Show fewer reads' : `Show all reads (+${hiddenCount})`}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/devtools/src/panel/tabs/ReadsTab.tsx
+++ b/packages/devtools/src/panel/tabs/ReadsTab.tsx
@@ -11,6 +11,8 @@ function join(values: string[]) {
   return values.length > 0 ? values.join(', ') : 'none'
 }
 
+const MAX_READ_ITEMS = 200
+
 export function ReadsTab({ inspection }: Props) {
   const [showAllReads, setShowAllReads] = useState(false)
 
@@ -32,7 +34,6 @@ export function ReadsTab({ inspection }: Props) {
     )
   }
 
-  const MAX_READ_ITEMS = 200
   const allReadIds = inspection.graph.nodes
   const visibleReadIds = showAllReads ? allReadIds : allReadIds.slice(0, MAX_READ_ITEMS)
   const hiddenCount = allReadIds.length - visibleReadIds.length
@@ -87,7 +88,7 @@ export function ReadsTab({ inspection }: Props) {
         )
       })}
 
-      {hiddenCount > 0 && (
+      {allReadIds.length > MAX_READ_ITEMS && (
         <div
           style={{
             borderTop: `1px solid ${theme.border}`,

--- a/packages/devtools/src/registry.ts
+++ b/packages/devtools/src/registry.ts
@@ -88,58 +88,6 @@ function resolveReadsInspection<
   return reads.inspect(input) as AnyReadInspection
 }
 
-function join(values: string[]) {
-  return values.length > 0 ? values.join(', ') : 'none'
-}
-
-function readInspectionToExtension(
-  inspection: AnyReadInspection,
-): ResolvedDevtoolsExtension {
-  const sections: ResolvedDevtoolsExtension['view']['sections'] = []
-
-  if (inspection.bridges.length > 0) {
-    sections.push({
-      kind: 'badges',
-      title: 'Bridges',
-      badges: inspection.bridges.map((bridge) => ({
-        value: `${bridge.read} -> ${bridge.field} (${bridge.type})`,
-      })),
-    })
-  }
-
-  if (inspection.graph.nodes.length > 0) {
-    sections.push({
-      kind: 'items',
-      title: 'Reads',
-      items: inspection.graph.nodes.map((readId) => {
-        const node = inspection.nodes[readId]
-
-        return {
-          id: readId,
-          title: readId,
-          badge: {
-            tone: 'fair',
-            value: node.value,
-          },
-          rows: [
-            { label: 'fields', value: join(node.dependsOnFields) },
-            { label: 'reads', value: join(node.dependsOnReads) },
-          ],
-        }
-      }),
-    })
-  }
-
-  return {
-    id: 'reads',
-    label: 'reads',
-    view: {
-      empty: 'No reads available in this inspection.',
-      sections,
-    },
-  }
-}
-
 function resolveExtensions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -151,16 +99,10 @@ function resolveExtensions<
   conditions: C | undefined,
   previous: Snapshot<C> | null,
   scorecard: ScorecardResult<F, C>,
-  readsInspection: AnyReadInspection | null,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
 ): ResolvedDevtoolsExtension[] {
   const resolved: ResolvedDevtoolsExtension[] = []
   const seen = new Set<string>(RESERVED_EXTENSION_IDS)
-
-  if (readsInspection) {
-    resolved.push(readInspectionToExtension(readsInspection))
-    seen.add('reads')
-  }
 
   for (const extension of options?.extensions ?? []) {
     if (seen.has(extension.id)) {
@@ -228,6 +170,19 @@ export const register: RegisterFn = <
   }
 
   const existing = registry.get(id)
+
+  if (
+    existing &&
+    existing.ump === ump &&
+    existing.snapshot.values === values &&
+    existing.snapshot.conditions === conditions &&
+    existing.optionReads === options?.reads &&
+    existing.optionReadInput === options?.readInput &&
+    existing.optionExtensions === options?.extensions
+  ) {
+    return
+  }
+
   const previous = (existing?.snapshot as Snapshot<C> | null) ?? null
   const currentSnapshot: Snapshot<C> = {
     values,
@@ -247,11 +202,13 @@ export const register: RegisterFn = <
       conditions,
       previous,
       scorecard,
-      readsInspection,
       options,
     ) as RegistryEntry['extensions'],
     foulLog: [],
     id,
+    optionExtensions: options?.extensions,
+    optionReadInput: options?.readInput,
+    optionReads: options?.reads,
     previous: previous as RegistryEntry['previous'],
     reads: readsInspection,
     renderIndex,

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -124,6 +124,9 @@ export type RegistryEntry = {
   extensions: ResolvedDevtoolsExtension[]
   foulLog: DevtoolsFoulEvent[]
   id: string
+  optionExtensions?: unknown
+  optionReadInput?: unknown
+  optionReads?: unknown
   previous: AnySnapshot | null
   reads: AnyReadInspection | null
   renderIndex: number


### PR DESCRIPTION
## Summary
- stop materializing reads data as a giant synthetic extension on every register; render reads through the dedicated `ReadsTab` only when the tab is active
- dedupe `register()` calls when `ump`, values, conditions, and read/extension option references are unchanged, which avoids duplicate scorecard work in repeated render passes
- cap initial reads tab rendering to 200 rows with an explicit "show all" toggle, reducing first-open UI work on large demos
- add regression coverage for dedicated reads tab rendering and duplicate-register no-op behavior
- include a patch changeset for `@umpire/devtools`

## Validation
- `yarn turbo run test --filter=@umpire/devtools`
- `yarn test`
- `yarn typecheck`