### PR TITLE
🐛 Fix unsafe conditions cast in fromStore

### DIFF
--- a/.changeset/issue-35-fromstore-conditions.md
+++ b/.changeset/issue-35-fromstore-conditions.md
@@ -1,0 +1,5 @@
+---
+'@umpire/store': patch
+---
+
+Fix `fromStore` condition handling by removing the unsafe `undefined as unknown as C` cast and passing `undefined` when no `conditions` selector is provided.

--- a/packages/store/__tests__/fromStore.test.ts
+++ b/packages/store/__tests__/fromStore.test.ts
@@ -124,6 +124,40 @@ describe('fromStore', () => {
     us.destroy()
   })
 
+  it('works without a conditions selector for typed conditions', () => {
+    type Ctx = { requireInvite: boolean }
+
+    const conditionsFields = {
+      username: {},
+      inviteCode: {},
+    } as const
+
+    type CFields = typeof conditionsFields
+
+    const conditionsRules = [
+      enabledWhen<CFields, Ctx>('inviteCode', (_values, ctx) => {
+        return ctx.requireInvite
+      }),
+    ]
+
+    const store = createStore<{ username: string; inviteCode: string }>(() => ({
+      username: '',
+      inviteCode: '',
+    }))
+
+    const ump = umpire<CFields, Ctx>({ fields: conditionsFields, rules: conditionsRules })
+    const us = fromStore(ump, store, {
+      select: (state) => ({
+        username: state.username,
+        inviteCode: state.inviteCode,
+      }),
+    })
+
+    expect(us.field('inviteCode').enabled).toBe(false)
+
+    us.destroy()
+  })
+
   it('subscribe notifies on availability changes', () => {
     const store = createFormStore()
     const ump = umpire({ fields, rules })

--- a/packages/store/src/fromStore.ts
+++ b/packages/store/src/fromStore.ts
@@ -39,9 +39,9 @@ export function fromStore<
   options: FromStoreOptions<S, F, C>,
 ): UmpireStore<F> {
   const { select, conditions } = options
-  const readConditions = (state: S): C => (
-    conditions ? conditions(state) : (undefined as unknown as C)
-  )
+  const readConditions = (state: S): C | undefined => {
+    return conditions ? conditions(state) : undefined
+  }
 
   const initialState = store.getState()
   const initialValues = select(initialState)


### PR DESCRIPTION
## Summary
- remove the unsafe `undefined as unknown as C` cast in `@umpire/store` fromStore and return `undefined` when no `conditions` selector is provided
- keep adapter usage unchanged while aligning `fromStore` with `Umpire.check/play` optional `conditions` contract
- add a regression test for typed-conditions umpires used without a `conditions` selector and include a patch changeset for `@umpire/store`

Closes #35