### PR TITLE
📝 Add CONTRIBUTING.md; tighten AGENTS.md commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,31 @@
 
 ## Build And Test
 
-- Use Yarn 4 with `nodeLinker: node-modules`. Never use `npm` in this repo.
-- Bun 1.2+ is required for repo test commands; `yarn test` shells out to `bun test`.
-- Workspace package tests preload `test/preload-workspace-aliases.ts`; add matching `mock.module(...)` entries there for new exported `@umpire/*` subpaths used before build.
-- Root commands: `yarn build`, `yarn test`, `yarn typecheck`, `yarn docs`, `yarn docs:build`.
+**Always run commands from the repo root, through Yarn.** Never invoke `turbo`, `bun`, or `npm` directly — tests depend on Yarn workspace resolution and per-package `bunfig.toml` preloads; bypassing Yarn skips both.
+
+| Task                     | Command                                |
+| ------------------------ | -------------------------------------- |
+| Build everything         | `yarn build`                           |
+| Run all tests            | `yarn test`                            |
+| Run one package's tests  | `yarn workspace @umpire/<pkg> test`    |
+| Typecheck                | `yarn typecheck`                       |
+| Docs dev server          | `yarn docs`                            |
+| Docs build               | `yarn docs:build`                      |
+
+### Never
+
+- `turbo run test` or any bare `turbo` invocation — use `yarn test`, which wraps turbo with the correct config.
+- `bun test` inside a package — use `yarn workspace @umpire/<pkg> test`; it shells to `bun test` with the right preload.
+- `npm` for any reason — this repo is Yarn 4 with `nodeLinker: node-modules`. No `npm install`, no `npx`.
+
+### Implementation notes
+
+- `yarn test` → `turbo run test` → per-package `bun test`. Each package's `bunfig.toml` preloads `test/preload-workspace-aliases.ts`, which mocks `@umpire/*` subpaths so sibling packages don't need building first.
+- When adding a new exported `@umpire/*` subpath used before build, add a matching `mock.module(...)` entry to `test/preload-workspace-aliases.ts`.
 - Most packages build with `tsc`; `@umpire/devtools` builds with `tsdown`.
-- Prefer `yarn turbo run test --filter=@umpire/<package>` for a single package.
-- For docs edits, `cd docs && yarn build` is the practical end-to-end check.
+- Bun 1.2+ is required for tests. Yarn 4 is pinned via `packageManager`.
+- For docs edits, `cd docs && yarn build` is the practical end-to-end check (`docs/` is not part of the root Yarn workspaces).
+- `yarn turbo run test --filter=@umpire/<pkg>` only helps when you want dep-aware ordering; the `test` task has no `dependsOn`, so for tests it's equivalent to `yarn workspace`. Prefer the workspace form.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,31 +10,11 @@
 
 ## Build And Test
 
-**Always run commands from the repo root, through Yarn.** Never invoke `turbo`, `bun`, or `npm` directly — tests depend on Yarn workspace resolution and per-package `bunfig.toml` preloads; bypassing Yarn skips both.
+Canonical commands and single-package iteration workflows live in [`CONTRIBUTING.md`](./CONTRIBUTING.md). Check there first.
 
-| Task                     | Command                                |
-| ------------------------ | -------------------------------------- |
-| Build everything         | `yarn build`                           |
-| Run all tests            | `yarn test`                            |
-| Run one package's tests  | `yarn workspace @umpire/<pkg> test`    |
-| Typecheck                | `yarn typecheck`                       |
-| Docs dev server          | `yarn docs`                            |
-| Docs build               | `yarn docs:build`                      |
+Quick reference (root): `yarn test`, `yarn build`, `yarn typecheck`.
 
-### Never
-
-- `turbo run test` or any bare `turbo` invocation — use `yarn test`, which wraps turbo with the correct config.
-- `bun test` inside a package — use `yarn workspace @umpire/<pkg> test`; it shells to `bun test` with the right preload.
-- `npm` for any reason — this repo is Yarn 4 with `nodeLinker: node-modules`. No `npm install`, no `npx`.
-
-### Implementation notes
-
-- `yarn test` → `turbo run test` → per-package `bun test`. Each package's `bunfig.toml` preloads `test/preload-workspace-aliases.ts`, which mocks `@umpire/*` subpaths so sibling packages don't need building first.
-- When adding a new exported `@umpire/*` subpath used before build, add a matching `mock.module(...)` entry to `test/preload-workspace-aliases.ts`.
-- Most packages build with `tsc`; `@umpire/devtools` builds with `tsdown`.
-- Bun 1.2+ is required for tests. Yarn 4 is pinned via `packageManager`.
-- For docs edits, `cd docs && yarn build` is the practical end-to-end check (`docs/` is not part of the root Yarn workspaces).
-- `yarn turbo run test --filter=@umpire/<pkg>` only helps when you want dep-aware ordering; the `test` task has no `dependsOn`, so for tests it's equivalent to `yarn workspace`. Prefer the workspace form.
+**Never** invoke `turbo`, `bun`, or `npm` directly — use the Yarn wrappers. Tests depend on Yarn workspace resolution and per-package `bunfig.toml` preloads; bypassing Yarn skips both.
 
 ## Architecture
 
@@ -66,7 +46,7 @@ Changesets workflow with `.changeset/config.json`:
 - ESM-only, `verbatimModuleSyntax`, `import type` and `export type`, and `.js` extensions in TypeScript import paths.
 - Keep `@umpire/core` free of runtime dependencies.
 - Package-level `AGENTS.md` files are intentionally short; keep them high-signal and keep their `.claude/rules/*` compatibility files pointing at the same content.
-- Commit messages use an emoji prefix plus a descriptive summary.
+- Workflow details (commit conventions, changesets, single-package iteration) live in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## Slop Scanner
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to Umpire
+
+Thanks for contributing! This guide covers setup, the commands you'll need, and the conventions we follow.
+
+> **For agents:** this file is the canonical reference for repo commands and workflows. `AGENTS.md` covers architecture and code-correctness constraints; commands live here.
+
+## Prerequisites
+
+- **Node 22+** (see `engines` in `package.json`).
+- **Yarn 4** — pinned via `packageManager`. Run `corepack enable` once if Yarn 4 isn't already active; Corepack ships with Node.
+- **Bun 1.2+** — tests run on Bun, not Node. Install from <https://bun.sh>.
+
+`nodeLinker: node-modules` is set in `.yarnrc.yml`; don't switch to PnP.
+
+## Build and test
+
+**Always run commands from the repo root, through Yarn.** Never invoke `turbo`, `bun`, or `npm` directly — tests depend on Yarn workspace resolution and per-package `bunfig.toml` preloads; bypassing Yarn skips both.
+
+| Task                    | Command                             |
+| ----------------------- | ----------------------------------- |
+| Build everything        | `yarn build`                        |
+| Run all tests           | `yarn test`                         |
+| Run one package's tests | `yarn workspace @umpire/<pkg> test` |
+| Typecheck               | `yarn typecheck`                    |
+| Docs dev server         | `yarn docs`                         |
+| Docs build              | `yarn docs:build`                   |
+
+### Never
+
+- `turbo run test` or any bare `turbo` invocation — use `yarn test`, which wraps turbo with the right config.
+- `bun test` inside a package — use `yarn workspace @umpire/<pkg> test`; it shells to `bun test` with the right preload.
+- `npm` for any reason — this repo is Yarn 4 only. No `npm install`, no `npx`.
+
+### How it fits together
+
+`yarn test` → `turbo run test` → per-package `bun test`. Each package's `bunfig.toml` preloads `test/preload-workspace-aliases.ts`, which mocks `@umpire/*` subpaths so sibling packages don't need building first.
+
+Most packages build with `tsc`; `@umpire/devtools` builds with `tsdown`. For docs edits, `cd docs && yarn build` is the practical end-to-end check (`docs/` is not part of the root Yarn workspaces).
+
+## Iterating on a single package
+
+`yarn workspace @umpire/<pkg> test` runs only that package's tests and forwards extra args to `bun test`:
+
+| Need                          | Command                                                                 |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| Single test file              | `yarn workspace @umpire/<pkg> test path/to/file.test.ts`                |
+| Filter by test name           | `yarn workspace @umpire/<pkg> test -t "pattern"`                        |
+| Watch mode                    | `yarn workspace @umpire/<pkg> test --watch`                             |
+| Disable workspace alias mocks | `BUN_DISABLE_WORKSPACE_MOCKS=true yarn workspace @umpire/<pkg> test`    |
+
+### Heads-up: "isolated" means test scope, not dependency isolation
+
+Each package's `bunfig.toml` preloads `test/preload-workspace-aliases.ts`, which mocks `@umpire/*` to sibling **`src/`** directories — not `dist/`. So if `@umpire/core/src` is broken, your `@umpire/react` test run will see it.
+
+This is intentional: tests run against current source without needing a build step. If you want to test a package against a frozen upstream build instead, set `BUN_DISABLE_WORKSPACE_MOCKS=true` and build the upstream package first.
+
+### Turbo filter (rarely needed for tests)
+
+`yarn turbo run test --filter=@umpire/<pkg>` only helps when you want dep-aware ordering. The `test` task in `turbo.json` has no `dependsOn`, so for tests it's equivalent to the `yarn workspace` form above. Prefer `yarn workspace` for clarity.
+
+## Coverage
+
+- `yarn test:coverage` — merged lcov via Bun.
+- `yarn test:coverage:istanbul` — istanbul-based, for tooling that doesn't read Bun lcov.
+
+## Adding a new exported `@umpire/*` subpath
+
+If you add a new exported subpath that sibling package tests import **before** the package is built, add a matching `mock.module(...)` entry to `test/preload-workspace-aliases.ts`. Otherwise tests fail at import time — the preload doesn't auto-discover subpaths.
+
+## Changesets
+
+Add a changeset with `yarn changeset` for any user-facing change. `.changeset/config.json` is configured with `updateInternalDependencies: "minor"`, so adapter packages get an automatic patch bump and republish when `core` bumps minor or major. You don't need separate changesets for downstream packages unless the change is in that package itself.
+
+## Commits
+
+Commits use an emoji prefix plus a descriptive summary. Browse `git log` for the conventions actually in use, but the common prefixes are:
+
+- ✨ `feat` — new feature
+- 🐛 `fix` — bug fix
+- ⚡️ `perf` — performance improvement
+- ♻️ `refactor` — refactor without behavior change
+- 🧹 `chore` — cleanup / non-functional tidy
+- 📝 `docs` — documentation
+- ✅ `test` — tests


### PR DESCRIPTION
## Summary

Split the contributor guide so commands and workflows live in a new `CONTRIBUTING.md` (human-first, agents welcome) and `AGENTS.md` stays focused on architecture and code-correctness constraints. Motivation: agents (Claude, OpenCode, Codex) have been tripping on the test conventions — invoking `turbo` or `bun` directly instead of going through Yarn. The previous `AGENTS.md` Build And Test section was narrative and actively suggested `yarn turbo run test --filter=...` for single packages, which agents over-generalized into bare `turbo`.

### `CONTRIBUTING.md` (new)

- Prerequisites — Yarn 4 via corepack, Bun 1.2+, Node 22
- Full Build And Test command table + explicit **Never** block (no bare `turbo`, `bun`, or `npm`)
- **Iterating on a single package** — `yarn workspace @umpire/<pkg> test` with filename arg, `-t` filter, `--watch`, and `BUN_DISABLE_WORKSPACE_MOCKS=true`
- Heads-up that "isolated" testing = test scope, not dep isolation: the per-package `bunfig.toml` preload mocks `@umpire/*` to sibling `src/` (not `dist/`), so a broken upstream `src/` will break your package's tests
- Coverage commands, changesets workflow, commit-emoji conventions
- Preload reminder when adding a new `@umpire/*` subpath

### `AGENTS.md` changes

- Build And Test is now a short quick-reference plus the guardrail "Never invoke `turbo`, `bun`, or `npm` directly" — full detail points at `CONTRIBUTING.md`
- Commit-emoji note moved out of Contributor Notes into `CONTRIBUTING.md`
- Architecture, Behavior To Preserve, Releases, and Slop Scanner sections unchanged

## Test plan

- [ ] Render `CONTRIBUTING.md` on GitHub and skim for clarity
- [ ] Verify the command table reads correctly and the `yarn workspace @umpire/<pkg> test` row matches actual behaviour
- [ ] Spot-check one or two agent sessions after merge to confirm they pick up the new phrasing (no more bare `turbo`)
- [ ] Confirm `CLAUDE.md` and `.cursor/rules/umpire.md` symlinks still point at `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)