### PR TITLE
⚾️  add `strike` to core

### DIFF
--- a/.changeset/strike-helper-rollout.md
+++ b/.changeset/strike-helper-rollout.md
@@ -1,0 +1,7 @@
+---
+'@umpire/core': minor
+---
+
+Add a first-class `strike(values, fouls)` helper for applying foul suggestions to values in one pure operation.
+
+`strike` now preserves referential stability by returning the original values object when there are no fouls or when all suggestions are already applied.

--- a/docs/src/components/AccountSettingsDemo.tsx
+++ b/docs/src/components/AccountSettingsDemo.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useStore } from 'zustand'
 import { createStore } from 'zustand/vanilla'
-import { enabledWhen, requires, umpire } from '@umpire/core'
+import { enabledWhen, requires, strike, umpire } from '@umpire/core'
 import { fromStore } from '@umpire/zustand'
 
 const fields = {
@@ -341,21 +341,27 @@ export default function AccountSettingsDemo() {
     }
 
     model.store.setState((current) => {
+      const currentValues = selectValues(current)
+      const nextValues = strike(currentValues, fouls)
+
+      if (nextValues === currentValues) {
+        return current
+      }
+
+      const nextTeamSize = String(nextValues.teamSize ?? '')
+      const nextTeamDomain = String(nextValues.teamDomain ?? '')
+
+      if (nextTeamSize === current.team.size && nextTeamDomain === current.team.domain) {
+        return current
+      }
+
       const next = {
         ...current,
         team: {
           ...current.team,
+          size: nextTeamSize,
+          domain: nextTeamDomain,
         },
-      }
-
-      for (const foul of fouls) {
-        if (foul.field === 'teamSize') {
-          next.team.size = String(foul.suggestedValue ?? '')
-        }
-
-        if (foul.field === 'teamDomain') {
-          next.team.domain = String(foul.suggestedValue ?? '')
-        }
       }
 
       return next

--- a/docs/src/components/CalendarDemo.tsx
+++ b/docs/src/components/CalendarDemo.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { DateRange, Month } from '@daywatch/cal'
 import { useCalendar } from '@daywatch/cal-react'
-import { disables, enabledWhen, oneOf, requires, umpire } from '@umpire/core'
+import { disables, enabledWhen, oneOf, requires, strike, umpire } from '@umpire/core'
 // Swap back to `@umpire/react` and remove the leading devtools id from the
 // hook call below if you want the plain React adapter again.
 import { useUmpireWithDevtools as useUmpire } from '@umpire/devtools/react'
@@ -498,20 +498,7 @@ export default function CalendarDemo() {
   }
 
   function applyResets() {
-    setValues((current) => {
-      const next = { ...current }
-      let changed = false
-
-      for (const foul of fouls) {
-        const suggestedValue = foul.suggestedValue as CalendarValues[typeof foul.field]
-        if (!Object.is(next[foul.field], suggestedValue)) {
-          ;(next as Record<string, unknown>)[foul.field] = suggestedValue
-          changed = true
-        }
-      }
-
-      return changed ? next : current
-    })
+    setValues((current) => strike(current, fouls))
   }
 
   const explicitDates = toStringList(values.dates)

--- a/docs/src/components/ConfigDrivenDemo.tsx
+++ b/docs/src/components/ConfigDrivenDemo.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { umpire } from '@umpire/core'
+import { strike, umpire } from '@umpire/core'
 import type { FieldDef, InputValues, Umpire } from '@umpire/core'
 import { fromJson } from '@umpire/json'
 import type { JsonRule, UmpireJsonSchema } from '@umpire/json'
@@ -352,13 +352,7 @@ function LiveFormInner({ ump, fieldOrder }: LiveFormInnerProps) {
   }
 
   function applyResets() {
-    setValues((current) => {
-      const next = { ...current }
-      for (const foul of fouls) {
-        next[foul.field as string] = foul.suggestedValue as string
-      }
-      return next
-    })
+    setValues((current) => strike(current, fouls))
   }
 
   const allRequired = fieldOrder.filter((field) => check[field]?.required)

--- a/docs/src/components/FreightQuoteDemo.tsx
+++ b/docs/src/components/FreightQuoteDemo.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource preact */
 import { useRef } from 'preact/hooks'
-import { enabledWhen, oneOf, requires, umpire } from '@umpire/core'
+import { enabledWhen, oneOf, requires, strike, umpire } from '@umpire/core'
 import { register } from '@umpire/devtools/slim'
 import { reactiveUmp, type ReactiveUmpire, type SignalProtocol } from '@umpire/signals'
 import { computed, effect, signal } from '@preact/signals'
@@ -510,8 +510,9 @@ export default function FreightQuoteDemo() {
                 type="button"
                 class="c-umpire-demo__reset-button"
                 onClick={() => {
-                  for (const foul of fouls) {
-                    reactive.set(foul.field, foul.suggestedValue)
+                  const next = strike(reactive.values, fouls)
+                  if (next !== reactive.values) {
+                    reactive.update(next)
                   }
                 }}
               >

--- a/docs/src/components/LearnDemos.tsx
+++ b/docs/src/components/LearnDemos.tsx
@@ -9,6 +9,7 @@ import {
   enabledWhen,
   oneOf,
   requires,
+  strike,
   umpire,
 } from '@umpire/core'
 import { snapshotValue } from '@umpire/core/snapshot'
@@ -635,15 +636,7 @@ export function PlayDemo() {
   }
 
   function applyResets() {
-    setValues((current) => {
-      const next = { ...current }
-
-      for (const foul of fouls) {
-        next[foul.field] = foul.suggestedValue
-      }
-
-      return next
-    })
+    setValues((current) => strike(current, fouls))
   }
 
   return (

--- a/docs/src/components/PcBuilderDemo.tsx
+++ b/docs/src/components/PcBuilderDemo.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { requires, umpire, type Snapshot } from '@umpire/core'
+import { requires, strike, umpire, type Snapshot } from '@umpire/core'
 import { register } from '@umpire/devtools/slim'
 import { createReads, enabledWhenRead, fairWhenRead, ReadInputType } from '@umpire/reads'
 import { createCoach } from '../lib/createCoach'
@@ -846,17 +846,13 @@ export default function PcBuilderDemo() {
   }
 
   function applyResets() {
-    const resetTargets = fouls.filter((foul) => !Object.is(values[foul.field], foul.suggestedValue))
+    const nextValues = strike(values, fouls) as PcValues
 
-    if (resetTargets.length === 0) {
+    if (nextValues === values) {
       return
     }
 
-    const nextValues = { ...values }
-
-    for (const foul of resetTargets) {
-      nextValues[foul.field] = foul.suggestedValue as PcValues[typeof foul.field]
-    }
+    const firstResetFoul = fouls.find((foul) => !Object.is(values[foul.field], foul.suggestedValue))
 
     setLastTransition({
       before: { values },
@@ -866,7 +862,9 @@ export default function PcBuilderDemo() {
       sawTransitiveCascade: hasLiveTransitiveCascade,
       sawAppliedResets: true,
     }))
-    setCurrentStep(getStepIndexForField(resetTargets[0].field as PcField))
+    if (firstResetFoul) {
+      setCurrentStep(getStepIndexForField(firstResetFoul.field as PcField))
+    }
   }
 
   function stepFouls(step: StepDefinition) {

--- a/docs/src/components/ReactAdapterDemo.tsx
+++ b/docs/src/components/ReactAdapterDemo.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { enabledWhen, requires, umpire } from '@umpire/core'
+import { enabledWhen, requires, strike, umpire } from '@umpire/core'
 import { useUmpire } from '@umpire/react'
 
 // -- Field definitions --
@@ -87,13 +87,7 @@ export default function ReactAdapterDemo() {
   // fouls are reset recommendations — when a field had a value but becomes disabled,
   // umpire suggests clearing it. applyResets acts on those suggestions.
   function applyResets() {
-    setValues((current) => {
-      const next = { ...current }
-      for (const foul of fouls) {
-        next[foul.field] = foul.suggestedValue
-      }
-      return next
-    })
+    setValues((current) => strike(current, fouls))
   }
 
   return (

--- a/docs/src/components/SignalsFineGrainedDemo.tsx
+++ b/docs/src/components/SignalsFineGrainedDemo.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource preact */
 import { useRef } from 'preact/hooks'
-import { enabledWhen, requires, umpire } from '@umpire/core'
+import { enabledWhen, requires, strike, umpire } from '@umpire/core'
 import { reactiveUmp, type ReactiveUmpire, type SignalProtocol } from '@umpire/signals'
 import { computed, effect, signal } from '@preact/signals'
 import '../styles/components/_components.signals-demo.css'
@@ -257,8 +257,9 @@ export default function SignalsFineGrainedDemo() {
                 type="button"
                 class="c-umpire-demo__reset-button"
                 onClick={() => {
-                  for (const foul of fouls) {
-                    reactive.set(foul.field, foul.suggestedValue ?? '')
+                  const next = strike(reactive.values, fouls)
+                  if (next !== reactive.values) {
+                    reactive.update(next)
                   }
                 }}
               >

--- a/docs/src/components/SignupDemo.tsx
+++ b/docs/src/components/SignupDemo.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { z } from 'zod'
-import { check, disables, eitherOf, enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
+import { check, disables, eitherOf, enabledWhen, fairWhen, requires, strike, umpire } from '@umpire/core'
 // useUmpireWithDevtools powers the named instance in the optional panel on this page.
 // Swap back to: import { useUmpire } from '@umpire/react'  (remove leading id arg)
 import { useUmpireWithDevtools } from '@umpire/devtools/react'
@@ -219,13 +219,7 @@ export default function SignupDemo() {
 
   function applyResets() {
     setSubmissionIssues([])
-    setValues((current) => {
-      const next = { ...current }
-      for (const foul of fouls) {
-        ;(next as Record<string, unknown>)[foul.field] = foul.suggestedValue
-      }
-      return next
-    })
+    setValues((current) => strike(current, fouls))
   }
 
   function submit() {

--- a/docs/src/components/printer-demo.ts
+++ b/docs/src/components/printer-demo.ts
@@ -1,5 +1,5 @@
 import { createStore } from 'zustand/vanilla'
-import { disables, enabledWhen, requires, umpire } from '@umpire/core'
+import { disables, enabledWhen, requires, strike, umpire } from '@umpire/core'
 import { fromStore, type UmpireStore } from '@umpire/zustand'
 
 // ---------------------------------------------------------------------------
@@ -486,14 +486,28 @@ export function mount(root: HTMLElement) {
   }
 
   resetButton?.addEventListener('click', () => {
-    const patch: Partial<PrintState> = {}
-    for (const foul of umpStore.fouls) {
-      ;(patch as Record<string, unknown>)[foul.field] = coerceSuggestedValue(
-        foul.field,
-        foul.suggestedValue,
-      )
-    }
-    store.setState(patch)
+    const current = store.getState()
+    const next = strike(toInputValues(current), umpStore.fouls.map((foul) => ({
+      ...foul,
+      suggestedValue: coerceSuggestedValue(foul.field, foul.suggestedValue),
+    })))
+
+    store.setState({
+      printer: (next.printer as PrinterType | undefined) ?? current.printer,
+      copies: typeof next.copies === 'string' ? next.copies : current.copies,
+      colorMode: typeof next.colorMode === 'string' ? next.colorMode : current.colorMode,
+      duplex: next.duplex === true,
+      paperSize: typeof next.paperSize === 'string' ? next.paperSize : current.paperSize,
+      orientation: typeof next.orientation === 'string' ? next.orientation : current.orientation,
+      fitToPage: next.fitToPage === true,
+      quality: typeof next.quality === 'string' ? next.quality : current.quality,
+      bannerMode: next.bannerMode === true,
+      paperType: typeof next.paperType === 'string' ? next.paperType : current.paperType,
+      collate: next.collate === true,
+      staple: next.staple === true,
+      holePunch: next.holePunch === true,
+      pageRange: typeof next.pageRange === 'string' ? next.pageRange : current.pageRange,
+    })
   })
 
   const unsubscribeStore = store.subscribe((state) => {

--- a/docs/src/components/zustand-demo.ts
+++ b/docs/src/components/zustand-demo.ts
@@ -5,7 +5,7 @@
  * small DOM helpers that prove the whole thing works framework-free.
  */
 import { createStore } from 'zustand/vanilla'
-import { enabledWhen, requires, umpire } from '@umpire/core'
+import { enabledWhen, requires, strike, umpire } from '@umpire/core'
 import { fromStore, type UmpireStore } from '@umpire/zustand'
 
 // ---------------------------------------------------------------------------
@@ -140,11 +140,17 @@ export function mount(root: HTMLElement) {
   // -- Wire apply resets button --
   $('.c-umpire-demo__reset-button', root)?.addEventListener('click', () => {
     const fouls = umpStore.fouls
-    const patch: Partial<DemoState> = {}
-    for (const foul of fouls) {
-      (patch as Record<string, unknown>)[foul.field] = foul.suggestedValue
-    }
-    store.setState(patch)
+    const current = store.getState()
+    const nextValues = strike(
+      {
+        email: current.email,
+        password: current.password,
+        companyName: current.companyName,
+        companySize: current.companySize,
+      },
+      fouls,
+    )
+    store.setState(nextValues)
   })
 
   // -- Subscribe to store changes → update the left panel --

--- a/packages/core/__tests__/strike.test.ts
+++ b/packages/core/__tests__/strike.test.ts
@@ -33,4 +33,17 @@ describe('strike', () => {
     })
     expect(next).not.toBe(values)
   })
+
+  test('returns the same object when all suggestions are already applied', () => {
+    const values = {
+      plan: 'personal',
+      companyName: undefined,
+    }
+
+    const next = strike(values, [
+      { field: 'companyName', reason: 'business plan required', suggestedValue: undefined },
+    ])
+
+    expect(next).toBe(values)
+  })
 })

--- a/packages/core/__tests__/strike.test.ts
+++ b/packages/core/__tests__/strike.test.ts
@@ -1,0 +1,36 @@
+import { strike } from '../src/strike.js'
+
+describe('strike', () => {
+  test('returns the same object when there are no fouls', () => {
+    const values = { team: 'home', score: 3 }
+
+    const next = strike(values, [])
+
+    expect(next).toBe(values)
+  })
+
+  test('applies suggested values by field', () => {
+    const values = {
+      plan: 'business',
+      companyName: 'Acme',
+      companySize: '50',
+    }
+
+    const next = strike(values, [
+      { field: 'companyName', reason: 'business plan required', suggestedValue: undefined },
+      { field: 'companySize', reason: 'business plan required', suggestedValue: '' },
+    ])
+
+    expect(next).toEqual({
+      plan: 'business',
+      companyName: undefined,
+      companySize: '',
+    })
+    expect(values).toEqual({
+      plan: 'business',
+      companyName: 'Acme',
+      companySize: '50',
+    })
+    expect(next).not.toBe(values)
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export { isEmptyArray, isEmptyObject, isEmptyPresent, isEmptyString } from './em
 export { field } from './field.js'
 export { foulMap } from './foul-map.js'
 export { isSatisfied } from './satisfaction.js'
+export { strike } from './strike.js'
 export { isNamedCheck } from './validation.js'
 export {
   defineRule,

--- a/packages/core/src/strike.ts
+++ b/packages/core/src/strike.ts
@@ -1,0 +1,18 @@
+import type { FieldDef, FieldValues, Foul } from './types.js'
+
+export function strike<F extends Record<string, FieldDef>>(
+  values: FieldValues<F>,
+  fouls: readonly Foul<F>[],
+): FieldValues<F> {
+  if (fouls.length === 0) {
+    return values
+  }
+
+  const next = { ...values }
+
+  for (const foul of fouls) {
+    next[foul.field] = foul.suggestedValue as FieldValues<F>[keyof F & string]
+  }
+
+  return next
+}

--- a/packages/core/src/strike.ts
+++ b/packages/core/src/strike.ts
@@ -8,11 +8,21 @@ export function strike<F extends Record<string, FieldDef>>(
     return values
   }
 
-  const next = { ...values }
+  let next: FieldValues<F> | undefined
 
   for (const foul of fouls) {
-    next[foul.field] = foul.suggestedValue as FieldValues<F>[keyof F & string]
+    const suggestedValue = foul.suggestedValue as FieldValues<F>[keyof F & string]
+
+    if (Object.is(values[foul.field], suggestedValue)) {
+      continue
+    }
+
+    if (!next) {
+      next = { ...values }
+    }
+
+    next[foul.field] = suggestedValue
   }
 
-  return next
+  return next ?? values
 }


### PR DESCRIPTION
This pattern is all too common in the docs demos, and although I have endeavoured to keep core idealogically pure, it does make sense to provided an opinionated helper to show auto-clear fouls.

Naturally, nobody is forcing end-users from using this! This just is the "default" and easiest behaviour.

I stayed thematic with this to make it easier to remember. Business logic can be boring, library logic is allowed to be fun and sometimes baseball-themed. ⚾️