### PR TITLE
🐛 tighten oneOf activeBranch branch typing

### DIFF
--- a/.changeset/oneof-active-branch-literals.md
+++ b/.changeset/oneof-active-branch-literals.md
@@ -1,0 +1,7 @@
+---
+'@umpire/core': patch
+---
+
+Preserve literal branch-name typing for `oneOf(..., { activeBranch })` so `activeBranch` no longer widens to plain `string` at common call sites.
+
+This improves TypeScript ergonomics by reducing casts when returning known branch keys.

--- a/docs/src/components/FreightQuoteDemo.tsx
+++ b/docs/src/components/FreightQuoteDemo.tsx
@@ -39,7 +39,14 @@ const freightUmp = umpire<typeof fields, FreightConditions>({
     oneOf('handlingMode', {
       fragile: ['blankets', 'crateType'],
       climate: ['tempRange', 'humidity'],
-    }, { activeBranch: (v) => v.handlingMode === 'none' ? null : v.handlingMode as string | null }),
+    }, {
+      activeBranch: (v) => {
+        if (v.handlingMode === 'fragile' || v.handlingMode === 'climate') {
+          return v.handlingMode
+        }
+        return null
+      },
+    }),
     enabledWhen('discountOverride', (_v, c) => c.isAdmin, { reason: 'Admin only' }),
     enabledWhen('priceHold', (_v, c) => c.isAdmin, { reason: 'Admin only' }),
     enabledWhen('serviceLevel', (_v, c) => !c.promoActive, { reason: 'Locked by FREIGHT50 promo' }),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
     "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "files": [
     "dist",

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -169,8 +169,12 @@ type EitherOfBranches<
 type OneOfOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
+  BranchName extends string = string,
 > = RuleOptions<F, C> & {
-  activeBranch?: string | ((values: FieldValues<F>, conditions: C) => string | null | undefined)
+  activeBranch?: BranchName | ((
+    values: FieldValues<F>,
+    conditions: C,
+  ) => BranchName | null | undefined)
 }
 
 export type InternalPredicate<
@@ -917,12 +921,13 @@ function warnAmbiguousOneOf(groupName: string, branchNames: string[]): void {
 export function resolveOneOfState<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
+  BranchName extends string = string,
 >(
   groupName: string,
   branches: OneOfBranches<F>,
   values: FieldValues<F>,
   prev: FieldValues<F> | undefined,
-  activeBranch: OneOfOptions<F, C>['activeBranch'],
+  activeBranch: OneOfOptions<F, C, BranchName>['activeBranch'],
   fields?: F,
   conditions?: C,
 ): OneOfResolution {
@@ -1221,10 +1226,11 @@ export function requires<
 export function oneOf<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
+  B extends OneOfBranchesInput<F> = OneOfBranchesInput<F>,
 >(
   groupName: string,
-  branches: OneOfBranchesInput<F>,
-  options?: OneOfOptions<F, C>,
+  branches: B,
+  options?: OneOfOptions<F, C, keyof B & string>,
 ): Rule<F, C> {
   const resolvedBranches = normalizeBranches(branches)
   const seenFields = new Set<string>()

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "type-tests/**/*.ts"
+  ]
+}

--- a/packages/core/type-tests/one-of-active-branch.type-test.ts
+++ b/packages/core/type-tests/one-of-active-branch.type-test.ts
@@ -1,0 +1,46 @@
+import { oneOf, umpire } from '../src/index.js'
+
+type Fields = {
+  mode: {}
+  alpha: {}
+  beta: {}
+}
+
+const fields = {
+  mode: {},
+  alpha: {},
+  beta: {},
+} as const satisfies Fields
+
+umpire<Fields>({
+  fields,
+  rules: [
+    oneOf('strategy', {
+      first: ['alpha'],
+      second: ['beta'],
+    }, {
+      activeBranch: (values) => (values.mode === 'second' ? 'second' : 'first'),
+    }),
+  ],
+})
+
+oneOf('strategy', {
+  first: ['alpha'],
+  second: ['beta'],
+}, { activeBranch: 'first' })
+
+oneOf('strategy', {
+  first: ['alpha'],
+  second: ['beta'],
+}, {
+  // @ts-expect-error unknown static branch should fail
+  activeBranch: 'third',
+})
+
+oneOf('strategy', {
+  first: ['alpha'],
+  second: ['beta'],
+}, {
+  // @ts-expect-error dynamic branch return must be one of declared branches
+  activeBranch: () => 'third',
+})


### PR DESCRIPTION
## Summary
- Fix `oneOf(..., { activeBranch })` typing so branch names are inferred from the declared branch keys instead of widening to `string`.
- Add compile-time type assertions in `@umpire/core` to lock this behavior and fail CI typecheck on regressions.
- Update `FreightQuoteDemo` to remove the branch-name cast and use explicit branch narrowing.

## Problem
`oneOf` accepted `activeBranch` as `string | ((...) => string | null | undefined)`. That widened branch names and erased literal key information from the `branches` object.

In practice, consumers returning known branch keys still had to cast in common flows (for example in docs demos), because TypeScript could not connect callback return values back to actual branch names.

This was a type-safety and ergonomics gap:
- valid code required unnecessary casts
- invalid branch names were easier to accidentally allow at callsites
- regressions could slip in without runtime test failures because the issue is type-level

## Fix
- `oneOf` now carries branch-name literals through the API surface:
  - `oneOf` is generic over the `branches` input object type
  - `options.activeBranch` is now typed as branch-name union (or callback returning that union / `null` / `undefined`)
- `resolveOneOfState` and `OneOfOptions` were updated to preserve the same branch-name type flow.

This keeps runtime behavior unchanged while improving compile-time correctness and removing callsite casts.

## Type-regression protection
Added type tests and wired them into core typecheck:
- `packages/core/type-tests/one-of-active-branch.type-test.ts`
- `packages/core/tsconfig.typecheck.json`
- `packages/core/package.json` `typecheck` script now runs `tsc -p tsconfig.typecheck.json`

Assertions include:
- valid static/dynamic branch names compile
- invalid static branch names fail (`@ts-expect-error`)
- invalid dynamic callback returns fail (`@ts-expect-error`)

## Validation
- `yarn workspace @umpire/core typecheck`
- `yarn workspace @umpire/core test`
- `yarn docs:build`