### PR TITLE
✨ Type outer surfaces and reduce docs cast pressure

### DIFF
--- a/.changeset/green-apes-wave.md
+++ b/.changeset/green-apes-wave.md
@@ -1,0 +1,8 @@
+---
+'@umpire/signals': minor
+'@umpire/solid': minor
+---
+
+Tighten adapter typing so field and condition keys carry their value types end-to-end.
+
+`reactiveUmp()` now type-checks external `signals` and `conditions` option entries against the umpire field and condition shapes, and `fromSolidStore()` now requires keyed `values`/`set()` signatures that align with those same field types.

--- a/docs/src/components/CalendarDemo.tsx
+++ b/docs/src/components/CalendarDemo.tsx
@@ -224,12 +224,16 @@ function toStringList(value: unknown) {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 }
 
+function isExceptBetweenValue(value: unknown): value is ExceptBetweenValue {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
 function toExceptBetween(value: unknown): ExceptBetweenValue {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+  if (!isExceptBetweenValue(value)) {
     return {}
   }
 
-  const { start, end } = value as ExceptBetweenValue
+  const { start, end } = value
   return { start, end }
 }
 
@@ -306,11 +310,11 @@ function buildPreviewRange(
   }
 
   if (availability.fromDate.enabled && values.fromDate) {
-    range.fromDate = values.fromDate as string
+    range.fromDate = values.fromDate
   }
 
   if (availability.toDate.enabled && values.toDate) {
-    range.toDate = values.toDate as string
+    range.toDate = values.toDate
   }
 
   if (availability.fixedBetween.enabled && values.fixedBetween) {
@@ -384,7 +388,8 @@ export default function CalendarDemo() {
   }
 
   function updateStringField(field: StringField, nextValue: string) {
-    updateField(field, (nextValue || undefined) as CalendarValues[typeof field])
+    const nextValueOrUndefined = nextValue || undefined
+    updateField(field, nextValueOrUndefined)
 
     if ((field === 'fromDate' || field === 'toDate') && nextValue) {
       setFocusDate(nextValue)
@@ -394,7 +399,7 @@ export default function CalendarDemo() {
   function updateNumberField(field: NumberField, nextValue: string) {
     const trimmed = nextValue.trim()
     const parsed = trimmed ? Number(trimmed) : undefined
-    updateField(field, parsed as CalendarValues[typeof field])
+    updateField(field, parsed)
   }
 
   function toggleNumberList(field: NumberListField, item: number) {
@@ -405,7 +410,7 @@ export default function CalendarDemo() {
         ? current.filter((value) => value !== item)
         : [...current, item].sort((left, right) => left - right)
 
-      return (next.length > 0 ? next : undefined) as CalendarValues[typeof field]
+      return next.length > 0 ? next : undefined
     })
   }
 
@@ -435,7 +440,7 @@ export default function CalendarDemo() {
         return currentValue
       }
 
-      return [...current, parsed].sort((left, right) => left - right) as CalendarValues[typeof field]
+      return [...current, parsed].sort((left, right) => left - right)
     })
 
     reset()
@@ -455,7 +460,7 @@ export default function CalendarDemo() {
         return currentValue
       }
 
-      return [...current, trimmed] as CalendarValues[typeof field]
+      return [...current, trimmed]
     })
 
     if (field === 'dates') {
@@ -469,7 +474,7 @@ export default function CalendarDemo() {
     updateFieldWith(field, (currentValue) => {
       const current = toNumberList(currentValue)
       const next = current.filter((value) => value !== item)
-      return (next.length > 0 ? next : undefined) as CalendarValues[typeof field]
+      return next.length > 0 ? next : undefined
     })
   }
 
@@ -477,7 +482,7 @@ export default function CalendarDemo() {
     updateFieldWith(field, (currentValue) => {
       const current = toStringList(currentValue)
       const next = current.filter((value) => value !== item)
-      return (next.length > 0 ? next : undefined) as CalendarValues[typeof field]
+      return next.length > 0 ? next : undefined
     })
   }
 
@@ -489,7 +494,7 @@ export default function CalendarDemo() {
         [part]: nextValue || undefined,
       }
 
-      return (next.start || next.end ? next : undefined) as CalendarValues['exceptBetween']
+      return next.start || next.end ? next : undefined
     })
 
     if (nextValue) {
@@ -568,7 +573,8 @@ export default function CalendarDemo() {
               week.days.map((day) => {
                 const isActive = activeDates.has(day.date)
                 const isExcluded = hasExceptions && activeBaseDates.has(day.date) && !isActive
-                const isOutOfBounds = isOutsideBounds(day.date, values.fromDate as string | undefined, values.toDate as string | undefined)
+                const { fromDate, toDate } = values
+                const isOutOfBounds = isOutsideBounds(day.date, fromDate, toDate)
                 return (
                   <div
                     key={day.date}

--- a/docs/src/components/printer-demo.ts
+++ b/docs/src/components/printer-demo.ts
@@ -719,10 +719,16 @@ function normalizeVisibleSelectValue(
   return options[0]?.value ?? ''
 }
 
+function isPrinterType(value: unknown): value is PrinterType {
+  return printers.some((printer) => printer === value)
+}
+
 function coerceSuggestedValue(field: PrintField, suggestedValue: unknown) {
   switch (field) {
     case 'printer':
-      return (suggestedValue as PrinterType | undefined) ?? initialState.printer
+      return isPrinterType(suggestedValue)
+        ? suggestedValue
+        : initialState.printer
     case 'duplex':
     case 'fitToPage':
     case 'bannerMode':

--- a/docs/src/components/printer-demo.ts
+++ b/docs/src/components/printer-demo.ts
@@ -98,6 +98,10 @@ type FieldGroupKey = 'general' | 'printerSpecific' | 'paper' | 'finishing'
 type Option = { value: string; label: string }
 type AvailabilityMap = ReturnType<typeof printerUmp.check>
 
+function buildRecord<K extends PropertyKey, V>(entries: readonly (readonly [K, V])[]) {
+  return Object.fromEntries(entries) as Record<K, V>
+}
+
 const fieldOrder = [
   'printer',
   'copies',
@@ -401,18 +405,20 @@ const printerUmp = umpire({
   ],
 })
 
-const printerAvailability = {} as Record<PrinterType, AvailabilityMap>
-for (const printer of printers) {
-  printerAvailability[printer] = printerUmp.check(
-    toInputValues({
-      ...initialState,
-      printer,
-      copies: '1',
-      bannerMode: false,
-      collate: false,
-    }),
-  )
-}
+const printerAvailability = buildRecord(
+  printers.map((printer) => [
+    printer,
+    printerUmp.check(
+      toInputValues({
+        ...initialState,
+        printer,
+        copies: '1',
+        bannerMode: false,
+        collate: false,
+      }),
+    ),
+  ] as const),
+)
 
 const printerScopedFields = new Set<PrintField>()
 for (const field of fieldOrder) {
@@ -422,23 +428,25 @@ for (const field of fieldOrder) {
   }
 }
 
-const selectOptionsByPrinter = {} as Record<PrinterType, Record<DynamicSelectField, Option[]>>
-for (const printer of printers) {
-  selectOptionsByPrinter[printer] = {
-    paperSize: paperSizesByPrinter[printer].map((value) => ({
-      value,
-      label: paperSizeLabels[value] ?? value,
-    })),
-    colorMode: printerAvailability[printer].colorMode.enabled ? colorModeOptions : [],
-    quality: printerAvailability[printer].quality.enabled
-      ? qualityByPrinter[printer].map((value) => ({
-          value,
-          label: qualityLabels[value] ?? value,
-        }))
-      : [],
-    paperType: printerAvailability[printer].paperType.enabled ? paperTypeOptions : [],
-  }
-}
+const selectOptionsByPrinter = buildRecord(
+  printers.map((printer) => [
+    printer,
+    {
+      paperSize: paperSizesByPrinter[printer].map((value) => ({
+        value,
+        label: paperSizeLabels[value] ?? value,
+      })),
+      colorMode: printerAvailability[printer].colorMode.enabled ? colorModeOptions : [],
+      quality: printerAvailability[printer].quality.enabled
+        ? qualityByPrinter[printer].map((value) => ({
+            value,
+            label: qualityLabels[value] ?? value,
+          }))
+        : [],
+      paperType: printerAvailability[printer].paperType.enabled ? paperTypeOptions : [],
+    },
+  ] as const),
+)
 
 // ---------------------------------------------------------------------------
 // Mount
@@ -474,14 +482,14 @@ export function mount(root: HTMLElement) {
   for (const field of selectFields) {
     const select = $(`[data-field-control="${field}"]`, root) as HTMLSelectElement | null
     select?.addEventListener('change', () => {
-      store.setState({ [field]: select.value } as Pick<PrintState, typeof field>)
+      setStateField(store, field, select.value)
     })
   }
 
   for (const field of checkboxFields) {
     const input = $(`[data-field-control="${field}"]`, root) as HTMLInputElement | null
     input?.addEventListener('change', () => {
-      store.setState({ [field]: input.checked } as Pick<PrintState, typeof field>)
+      setStateField(store, field, input.checked)
     })
   }
 
@@ -681,11 +689,22 @@ function syncControlValue(
   control.value = typeof nextValue === 'string' ? nextValue : ''
 }
 
+function setStateField<K extends Exclude<PrintField, 'printer'>>(
+  store: { setState: (patch: Pick<PrintState, K>) => void },
+  field: K,
+  value: PrintState[K],
+) {
+  const patch = { [field]: value } satisfies Pick<PrintState, K>
+  store.setState(patch)
+}
+
 function buildPrinterTransitionPatch(
   state: PrintState,
   nextPrinter: PrinterType,
 ): Partial<PrintState> {
-  const patch: Partial<PrintState> = { printer: nextPrinter }
+  const patch: Partial<Pick<PrintState, DynamicSelectField>> & Pick<PrintState, 'printer'> = {
+    printer: nextPrinter,
+  }
 
   for (const field of dynamicSelectFields) {
     if (!isFieldVisibleForPrinter(field, nextPrinter)) {
@@ -694,7 +713,7 @@ function buildPrinterTransitionPatch(
 
     const nextValue = normalizeVisibleSelectValue(field, nextPrinter, state[field])
     if (nextValue !== state[field]) {
-      ;(patch as Record<string, unknown>)[field] = nextValue
+      patch[field] = nextValue
     }
   }
 

--- a/docs/src/content/docs/adapters/solid.mdx
+++ b/docs/src/content/docs/adapters/solid.mdx
@@ -22,6 +22,7 @@ Use `useUmpire()` when your component already owns the values and just wants der
 
 ```ts
 import type { Accessor } from 'solid-js'
+import type { AvailabilityMap, FieldDef, Foul, InputValues, Umpire } from '@umpire/core'
 import { useUmpire } from '@umpire/solid'
 
 function useUmpire<
@@ -29,7 +30,7 @@ function useUmpire<
   C extends Record<string, unknown>,
 >(
   ump: Umpire<F, C>,
-  values: Accessor<InputValues<F>>,
+  values: Accessor<InputValues>,
   conditions?: Accessor<C>,
 ): {
   check: Accessor<AvailabilityMap<F>>
@@ -125,6 +126,7 @@ Use `fromSolidStore()` when the form lives in shared Solid state and child compo
 
 ```ts
 import type { Accessor } from 'solid-js'
+import type { FieldDef, FieldValues, Umpire } from '@umpire/core'
 import { fromSolidStore } from '@umpire/solid'
 
 function fromSolidStore<
@@ -133,8 +135,8 @@ function fromSolidStore<
 >(
   ump: Umpire<F, C>,
   options: {
-    values: InputValues<F>
-    set(name: keyof F & string, value: unknown): void
+    values: FieldValues<F>
+    set<K extends keyof F & string>(name: K, value: FieldValues<F>[K]): void
     conditions?: Partial<{ [K in keyof C & string]: Accessor<C[K]> }>
   },
 ): SolidStoreUmpire<F>
@@ -164,7 +166,7 @@ type EventFields = typeof eventUmp extends Umpire<infer F, any> ? F : never
 
 const EventFormContext = createContext<{
   values: { allDay: boolean; startTime: string; endTime: string }
-  set(name: keyof EventFields & string, value: unknown): void
+  set: SolidStoreUmpire<EventFields>['set']
   form: SolidStoreUmpire<EventFields>
 }>()
 
@@ -175,13 +177,17 @@ function EventFormProvider(props: { children: JSX.Element }) {
     endTime: '10:00',
   })
 
+  function setEventValue<K extends keyof typeof values>(name: K, value: (typeof values)[K]) {
+    setValues(name, value)
+  }
+
   const form = fromSolidStore(eventUmp, {
     values,
-    set: (name, value) => setValues(name, value as never),
+    set: setEventValue,
   })
 
   return (
-    <EventFormContext.Provider value={{ values, set: (name, value) => setValues(name, value as never), form }}>
+    <EventFormContext.Provider value={{ values, set: setEventValue, form }}>
       {props.children}
     </EventFormContext.Provider>
   )

--- a/docs/src/content/docs/adapters/solid.mdx
+++ b/docs/src/content/docs/adapters/solid.mdx
@@ -75,9 +75,16 @@ function SignupForm(props: { plan: Accessor<SignupConditions['plan']> }) {
     () => ({ plan: props.plan() }),
   )
 
+  function applyFoul<K extends keyof typeof values>(
+    field: K,
+    value: (typeof values)[K],
+  ) {
+    setValues(field, value)
+  }
+
   function applyResets() {
     for (const foul of fouls()) {
-      setValues(foul.field, foul.suggestedValue as never)
+      applyFoul(foul.field, foul.suggestedValue)
     }
   }
 

--- a/docs/src/content/docs/adapters/solid.mdx
+++ b/docs/src/content/docs/adapters/solid.mdx
@@ -126,7 +126,7 @@ Use `fromSolidStore()` when the form lives in shared Solid state and child compo
 
 ```ts
 import type { Accessor } from 'solid-js'
-import type { FieldDef, FieldValues, Umpire } from '@umpire/core'
+import type { FieldDef, FieldValues, FieldsOf, Umpire } from '@umpire/core'
 import { fromSolidStore } from '@umpire/solid'
 
 function fromSolidStore<
@@ -162,7 +162,7 @@ const eventUmp = umpire({
   ],
 })
 
-type EventFields = typeof eventUmp extends Umpire<infer F, any> ? F : never
+type EventFields = FieldsOf<typeof eventUmp>
 
 const EventFormContext = createContext<{
   values: { allDay: boolean; startTime: string; endTime: string }

--- a/docs/src/content/docs/adapters/solid.mdx
+++ b/docs/src/content/docs/adapters/solid.mdx
@@ -147,7 +147,7 @@ function fromSolidStore<
 ```tsx
 import { createContext, useContext } from 'solid-js'
 import { createStore } from 'solid-js/store'
-import { enabledWhen, umpire } from '@umpire/core'
+import { enabledWhen, type FieldsOf, umpire } from '@umpire/core'
 import { fromSolidStore, type SolidStoreUmpire } from '@umpire/solid'
 
 const eventUmp = umpire({
@@ -162,22 +162,22 @@ const eventUmp = umpire({
   ],
 })
 
-type EventFields = FieldsOf<typeof eventUmp>
+type EventForm = SolidStoreUmpire<FieldsOf<typeof eventUmp>>
+type EventValues = ReturnType<typeof eventUmp.init>
 
 const EventFormContext = createContext<{
-  values: { allDay: boolean; startTime: string; endTime: string }
-  set: SolidStoreUmpire<EventFields>['set']
-  form: SolidStoreUmpire<EventFields>
+  values: EventValues
+  set: EventForm['set']
+  form: EventForm
 }>()
 
 function EventFormProvider(props: { children: JSX.Element }) {
-  const [values, setValues] = createStore({
-    allDay: false,
+  const [values, setValues] = createStore(eventUmp.init({
     startTime: '09:00',
     endTime: '10:00',
-  })
+  }))
 
-  function setEventValue<K extends keyof typeof values>(name: K, value: (typeof values)[K]) {
+  const setEventValue: EventForm['set'] = (name, value) => {
     setValues(name, value)
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export type {
   ValidationValidator,
   ValidationEntry,
   ValidationMap,
+  FieldsOf,
 } from './types.js'
 export type { FieldBuilder, FieldInput, FieldRef, NormalizeField, NormalizeFields } from './field.js'
 export type {

--- a/packages/core/src/strike.ts
+++ b/packages/core/src/strike.ts
@@ -11,9 +11,7 @@ export function strike<F extends Record<string, FieldDef>>(
   let next: FieldValues<F> | undefined
 
   for (const foul of fouls) {
-    const suggestedValue = foul.suggestedValue as FieldValues<F>[keyof F & string]
-
-    if (Object.is(values[foul.field], suggestedValue)) {
+    if (Object.is(values[foul.field], foul.suggestedValue)) {
       continue
     }
 
@@ -21,7 +19,7 @@ export function strike<F extends Record<string, FieldDef>>(
       next = { ...values }
     }
 
-    next[foul.field] = suggestedValue
+    next[foul.field] = foul.suggestedValue
   }
 
   return next ?? values

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -89,10 +89,12 @@ export type Snapshot<C extends Record<string, unknown>> = {
 }
 
 export type Foul<F extends Record<string, FieldDef>> = {
-  field: keyof F & string
-  reason: string
-  suggestedValue: unknown
-}
+  [K in keyof F & string]: {
+    field: K
+    reason: string
+    suggestedValue: FieldValue<F[K]> | undefined
+  }
+}[keyof F & string]
 
 export type RuleTraceDependency = {
   kind: string

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -264,3 +264,5 @@ export interface Umpire<
   ): ChallengeTrace
   graph(): UmpireGraph
 }
+
+export type FieldsOf<U> = U extends Umpire<infer F, any> ? F : never

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -993,7 +993,9 @@ export function umpire<
       }
 
       const currentValue = after.values[field]
-      const suggestedValue = fields[field].default
+      const suggestedValue = fields[field].default as
+        | FieldValues<NormalizeFields<FInput>>[typeof field]
+        | undefined
 
       if (!afterStatus.satisfied) {
         continue

--- a/packages/core/type-tests/fields-of.type-test.ts
+++ b/packages/core/type-tests/fields-of.type-test.ts
@@ -1,0 +1,27 @@
+import { umpire } from '../src/index.js'
+import type { FieldsOf } from '../src/index.js'
+
+const ump = umpire({
+  fields: {
+    plan: { default: 'free' as const },
+    seats: { default: 1 },
+    notes: { default: '' },
+  },
+  rules: [],
+})
+
+type UmpFields = FieldsOf<typeof ump>
+
+const fields: UmpFields = {
+  plan: { default: 'free' },
+  seats: { default: 1 },
+  notes: { default: '' },
+}
+
+const planDefault: UmpFields['plan']['default'] = fields.plan.default
+
+// @ts-expect-error plan default must stay the inferred literal
+const invalidPlan: UmpFields['plan']['default'] = 'pro'
+
+void planDefault
+void invalidPlan

--- a/packages/core/type-tests/foul-suggested-value.type-test.ts
+++ b/packages/core/type-tests/foul-suggested-value.type-test.ts
@@ -1,0 +1,88 @@
+import { strike, umpire } from '../src/index.js'
+import type { FieldDef, Foul } from '../src/index.js'
+
+type Fields = {
+  plan: FieldDef<'free' | 'pro'>
+  seats: FieldDef<number>
+  notes: FieldDef<string>
+}
+
+declare const foul: Foul<Fields>
+
+if (foul.field === 'plan') {
+  const value: 'free' | 'pro' | undefined = foul.suggestedValue
+
+  // @ts-expect-error plan suggestedValue is not a number
+  const invalid: number = foul.suggestedValue
+}
+
+if (foul.field === 'seats') {
+  const value: number | undefined = foul.suggestedValue
+
+  // @ts-expect-error seats suggestedValue is not a string
+  const invalid: string = foul.suggestedValue
+}
+
+if (foul.field === 'notes') {
+  const value: string | undefined = foul.suggestedValue
+
+  // @ts-expect-error notes suggestedValue is not a number
+  const invalid: number = foul.suggestedValue
+}
+
+const validFoul: Foul<Fields> = {
+  field: 'seats',
+  reason: 'reset seats',
+  suggestedValue: 5,
+}
+
+const validUndefinedFoul: Foul<Fields> = {
+  field: 'notes',
+  reason: 'clear notes',
+  suggestedValue: undefined,
+}
+
+const typed = umpire({
+  fields: {
+    plan: { default: 'free' as const },
+    seats: { default: 1 },
+    notes: { default: '' },
+  },
+  rules: [],
+})
+
+const played = typed.play(
+  { values: { plan: 'free', seats: 1, notes: 'hello' } },
+  { values: { plan: 'free', seats: 1, notes: 'hello' } },
+)
+
+const maybePlayedFoul = played[0]
+if (maybePlayedFoul && maybePlayedFoul.field === 'notes') {
+  const value: string | undefined = maybePlayedFoul.suggestedValue
+
+  // @ts-expect-error notes suggestedValue is not boolean
+  const invalid: boolean = maybePlayedFoul.suggestedValue
+
+  void value
+}
+
+const struck = strike<Fields>(
+  { plan: 'free', seats: 1, notes: 'hello' },
+  [{ field: 'seats', reason: 'reset seats', suggestedValue: 3 }],
+)
+
+const struckSeats: number | undefined = struck.seats
+
+// @ts-expect-error seats foul suggestedValue must be number | undefined
+strike<Fields>({}, [{ field: 'seats', reason: 'wrong type', suggestedValue: '3' }])
+
+// @ts-expect-error seats suggestedValue must be number | undefined
+const invalidFoul: Foul<Fields> = {
+  field: 'seats',
+  reason: 'wrong type',
+  suggestedValue: '5',
+}
+
+void validFoul
+void validUndefinedFoul
+void invalidFoul

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -39,7 +39,7 @@
     "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
     "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "files": [
     "dist",

--- a/packages/signals/src/reactive.ts
+++ b/packages/signals/src/reactive.ts
@@ -1,6 +1,7 @@
 import type {
   AvailabilityMap,
   FieldDef,
+  FieldValues,
   InputValues,
   FieldStatus,
   Foul,
@@ -17,12 +18,16 @@ export type ReactiveField = {
   readonly [K in keyof FieldStatus]: FieldStatus[K]
 }
 
+type ReactiveValues<F extends Record<string, FieldDef>> = {
+  [K in keyof F & string]: FieldValues<F>[K]
+}
+
 export interface ReactiveUmpire<F extends Record<string, FieldDef>> {
   field(name: keyof F & string): ReactiveField
   foul(name: keyof F & string): Foul<F> | undefined
-  set(name: keyof F & string, value: unknown): void
-  update(partial: Partial<Record<keyof F & string, unknown>>): void
-  readonly values: Record<keyof F & string, unknown>
+  set<K extends keyof F & string>(name: K, value: FieldValues<F>[K]): void
+  update(partial: FieldValues<F>): void
+  readonly values: ReactiveValues<F>
   readonly fouls: Foul<F>[]
   dispose(): void
 }
@@ -147,11 +152,11 @@ export function reactiveUmp<
   }
 
   // --- 5. Aggregate values computed ---
-  const valuesComputed = adapter.computed<Record<keyof F & string, unknown>>(
+  const valuesComputed = adapter.computed<ReactiveValues<F>>(
     () => {
-      const result = {} as Record<keyof F & string, unknown>
+      const result = {} as ReactiveValues<F>
       for (const name of fieldNames) {
-        result[name] = fieldSignals.get(name)!.get()
+        result[name] = fieldSignals.get(name)!.get() as ReactiveValues<F>[typeof name]
       }
       return result
     },
@@ -274,13 +279,13 @@ export function reactiveUmp<
       return cached
     },
 
-    set(name: keyof F & string, value: unknown) {
+    set<K extends keyof F & string>(name: K, value: FieldValues<F>[K]) {
       const sig = fieldSignals.get(name)
       if (!sig) throw new Error(`[@umpire/signals] Unknown field "${name}"`)
       sig.set(value)
     },
 
-    update(partial: Partial<Record<keyof F & string, unknown>>) {
+    update(partial: FieldValues<F>) {
       const fn = () => {
         for (const [name, value] of Object.entries(partial)) {
           const sig = fieldSignals.get(name)

--- a/packages/signals/src/reactive.ts
+++ b/packages/signals/src/reactive.ts
@@ -22,6 +22,19 @@ type ReactiveValues<F extends Record<string, FieldDef>> = {
   [K in keyof F & string]: FieldValues<F>[K]
 }
 
+type ReactiveSignal<T> = {
+  get(): T
+  set(value: T): void
+}
+
+type ReactiveFieldSignals<F extends Record<string, FieldDef>> = Partial<{
+  [K in keyof F & string]: ReactiveSignal<FieldValues<F>[K]>
+}>
+
+type ReactiveConditionSignals<C extends Record<string, unknown>> = Partial<{
+  [K in keyof C & string]: { get(): C[K] }
+}>
+
 export interface ReactiveUmpire<F extends Record<string, FieldDef>> {
   field(name: keyof F & string): ReactiveField
   foul(name: keyof F & string): Foul<F> | undefined
@@ -32,11 +45,12 @@ export interface ReactiveUmpire<F extends Record<string, FieldDef>> {
   dispose(): void
 }
 
-export type ReactiveUmpOptions<F extends Record<string, FieldDef>> = {
-  signals?: Partial<
-    Record<keyof F & string, { get(): unknown; set(value: unknown): void }>
-  >
-  conditions?: Record<string, { get(): unknown }>
+export type ReactiveUmpOptions<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  signals?: ReactiveFieldSignals<F>
+  conditions?: ReactiveConditionSignals<C>
 }
 
 // ---------------------------------------------------------------------------
@@ -49,14 +63,14 @@ export function reactiveUmp<
 >(
   ump: Umpire<F, C>,
   adapter: SignalProtocol,
-  options?: ReactiveUmpOptions<F>,
+  options?: ReactiveUmpOptions<F, C>,
 ): ReactiveUmpire<F> {
   const fieldNames = ump.graph().nodes as Array<keyof F & string>
 
   // --- 1. One writable signal per field ---
   const fieldSignals = new Map<
-    string,
-    { get(): unknown; set(value: unknown): void }
+    keyof F & string,
+    ReactiveSignal<FieldValues<F>[keyof F & string]>
   >()
 
   const initValues = ump.init()
@@ -64,14 +78,17 @@ export function reactiveUmp<
   for (const name of fieldNames) {
     const external = options?.signals?.[name]
     if (external) {
-      fieldSignals.set(name, external)
+      fieldSignals.set(name, external as ReactiveSignal<FieldValues<F>[typeof name]>)
     } else {
-      fieldSignals.set(name, adapter.signal(initValues[name]))
+      fieldSignals.set(
+        name,
+        adapter.signal(initValues[name]) as ReactiveSignal<FieldValues<F>[typeof name]>,
+      )
     }
   }
 
   // --- 2. Conditions signals ---
-  const conditionSignals = options?.conditions ?? {}
+  const conditionSignals: ReactiveConditionSignals<C> = options?.conditions ?? {}
 
   // --- 3. Lazy proxy for fine-grained predicate tracking ---
   function createValuesProxy(): InputValues {
@@ -99,7 +116,7 @@ export function reactiveUmp<
     return new Proxy({} as C, {
       get(_target, prop) {
         if (typeof prop !== 'string') return undefined
-        const sig = conditionSignals[prop]
+        const sig = conditionSignals[prop as keyof C & string]
         return sig ? sig.get() : undefined
       },
       has(_target, prop) {
@@ -189,7 +206,10 @@ export function reactiveUmp<
 
     function readSnapshotConditions() {
       return snapshotValue(Object.fromEntries(
-        Object.keys(conditionSignals).map((name) => [name, conditionSignals[name].get()]),
+        Object.keys(conditionSignals).map((name) => [
+          name,
+          conditionSignals[name as keyof C & string]!.get(),
+        ]),
       ) as C)
     }
 
@@ -288,7 +308,7 @@ export function reactiveUmp<
     update(partial: FieldValues<F>) {
       const fn = () => {
         for (const [name, value] of Object.entries(partial)) {
-          const sig = fieldSignals.get(name)
+          const sig = fieldSignals.get(name as keyof F & string)
           if (sig) sig.set(value)
         }
       }

--- a/packages/signals/tsconfig.typecheck.json
+++ b/packages/signals/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "type-tests/**/*.ts"
+  ]
+}

--- a/packages/signals/type-tests/reactive-writes.type-test.ts
+++ b/packages/signals/type-tests/reactive-writes.type-test.ts
@@ -1,0 +1,102 @@
+import { umpire } from '@umpire/core'
+import type { SignalProtocol } from '../src/protocol.js'
+import { reactiveUmp } from '../src/reactive.js'
+
+const adapter: SignalProtocol = {
+  signal<T>(initial: T) {
+    let value = initial
+    return {
+      get() {
+        return value
+      },
+      set(next: T) {
+        value = next
+      },
+    }
+  },
+  computed<T>(fn: () => T) {
+    return {
+      get() {
+        return fn()
+      },
+    }
+  },
+}
+
+const form = reactiveUmp(umpire({
+  fields: {
+    count: { default: 0 },
+    label: { default: '' },
+    enabled: { default: true },
+  },
+  rules: [],
+}), adapter)
+
+form.set('count', 1)
+form.set('label', 'hello')
+form.set('enabled', false)
+
+// @ts-expect-error count expects number
+form.set('count', '1')
+
+// @ts-expect-error label expects string
+form.set('label', 1)
+
+// @ts-expect-error enabled expects boolean
+form.set('enabled', 'false')
+
+// @ts-expect-error field name must be known
+form.set('missing', 'value')
+
+form.update({
+  count: 2,
+  label: 'updated',
+})
+
+// @ts-expect-error update count expects number
+form.update({ count: '2' })
+
+// @ts-expect-error update enabled expects boolean
+form.update({ enabled: 'false' })
+
+const count: number | undefined = form.values.count
+const label: string | undefined = form.values.label
+const enabled: boolean | undefined = form.values.enabled
+
+// @ts-expect-error count is not boolean
+const invalidCount: boolean = form.values.count
+
+// @ts-expect-error unknown key should not be accepted
+form.update({ missing: 'x' })
+
+// @ts-expect-error values should not expose unknown keys
+const missing = form.values.missing
+
+const maybeFoul = form.foul('count')
+if (maybeFoul && maybeFoul.field === 'count') {
+  const foulValue: number | undefined = maybeFoul.suggestedValue
+
+  // @ts-expect-error count foul suggestedValue is not string
+  const invalidFoulValue: string = maybeFoul.suggestedValue
+
+  void foulValue
+  void invalidFoulValue
+}
+
+const allFouls = form.fouls
+const firstFoul = allFouls[0]
+if (firstFoul && firstFoul.field === 'enabled') {
+  const foulValue: boolean | undefined = firstFoul.suggestedValue
+
+  // @ts-expect-error enabled foul suggestedValue is not number
+  const invalidFoulValue: number = firstFoul.suggestedValue
+
+  void foulValue
+  void invalidFoulValue
+}
+
+void count
+void label
+void enabled
+void invalidCount
+void missing

--- a/packages/signals/type-tests/reactive-writes.type-test.ts
+++ b/packages/signals/type-tests/reactive-writes.type-test.ts
@@ -1,4 +1,4 @@
-import { umpire } from '@umpire/core'
+import { enabledWhen, umpire } from '@umpire/core'
 import type { SignalProtocol } from '../src/protocol.js'
 import { reactiveUmp } from '../src/reactive.js'
 
@@ -31,6 +31,49 @@ const form = reactiveUmp(umpire({
   },
   rules: [],
 }), adapter)
+
+const conditionedUmp = umpire<
+  {
+    count: { default: number }
+    label: { default: string }
+    enabled: { default: boolean }
+  },
+  { plan: 'free' | 'pro'; stage: number }
+>({
+  fields: {
+    count: { default: 0 },
+    label: { default: '' },
+    enabled: { default: true },
+  },
+  rules: [
+    enabledWhen('enabled', (_values, conditions) => conditions.plan === 'pro' && conditions.stage > 0),
+  ],
+})
+
+const optionsForm = reactiveUmp(
+  conditionedUmp,
+  adapter,
+  {
+    signals: {
+      count: {
+        get: () => 1,
+        set: (_next) => {},
+      },
+      label: {
+        get: () => 'label',
+        // @ts-expect-error label signal set must accept string
+        set: (_next: number) => {},
+      },
+    },
+    conditions: {
+      plan: { get: () => 'free' },
+      // @ts-expect-error stage condition must return number
+      stage: { get: () => '1' },
+    },
+  },
+)
+
+void optionsForm
 
 form.set('count', 1)
 form.set('label', 'hello')

--- a/packages/solid/__tests__/fromSolidStore.test.ts
+++ b/packages/solid/__tests__/fromSolidStore.test.ts
@@ -208,6 +208,74 @@ describe('fromSolidStore', () => {
     }
   })
 
+  it('preserves non-string value types when writing back', () => {
+    const typedFields = {
+      count: { default: 0 },
+      active: { default: true },
+      label: { default: '' },
+    } satisfies Record<string, FieldDef>
+
+    const ump = umpire({
+      fields: typedFields,
+      rules: [],
+    })
+
+    const { value, dispose } = withRoot(() => {
+      const [count, setCount] = createSignal(0)
+      const [active, setActive] = createSignal(true)
+      const [label, setLabel] = createSignal('init')
+
+      const values = {
+        get count() {
+          return count()
+        },
+        get active() {
+          return active()
+        },
+        get label() {
+          return label()
+        },
+      }
+
+      return {
+        count,
+        active,
+        label,
+        form: fromSolidStore(ump, {
+          values,
+          set(field, next) {
+            switch (field) {
+              case 'count':
+                setCount(next)
+                return
+              case 'active':
+                setActive(next)
+                return
+              case 'label':
+                setLabel(next)
+                return
+            }
+          },
+        }),
+      }
+    })
+
+    try {
+      value.form.set('count', 7)
+      value.form.set('active', false)
+      value.form.update({ count: 11, active: true, label: 'done' })
+
+      expect(value.count()).toBe(11)
+      expect(typeof value.count()).toBe('number')
+      expect(value.active()).toBe(true)
+      expect(typeof value.active()).toBe('boolean')
+      expect(value.label()).toBe('done')
+    } finally {
+      value.form.dispose()
+      dispose()
+    }
+  })
+
   it('supports fine-grained condition accessors', () => {
     type Conditions = { premium: boolean }
 

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -19,7 +19,7 @@
     "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
     "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "files": [
     "dist",

--- a/packages/solid/src/fromSolidStore.ts
+++ b/packages/solid/src/fromSolidStore.ts
@@ -1,5 +1,5 @@
 import type { Accessor } from 'solid-js'
-import type { FieldDef, InputValues, Umpire } from '@umpire/core'
+import type { FieldDef, FieldValues, Umpire } from '@umpire/core'
 import {
   reactiveUmp,
   type ReactiveUmpOptions,
@@ -11,8 +11,8 @@ export type FromSolidStoreOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 > = {
-  values: InputValues
-  set(name: keyof F & string, value: unknown): void
+  values: FieldValues<F>
+  set<K extends keyof F & string>(name: K, value: FieldValues<F>[K]): void
   conditions?: Partial<{ [K in keyof C & string]: Accessor<C[K]> }>
 }
 
@@ -27,24 +27,25 @@ export function fromSolidStore<
 ): SolidStoreUmpire<F> {
   const fieldNames = ump.graph().nodes as Array<keyof F & string>
 
-  const signals = Object.fromEntries(
-    fieldNames.map((name) => [
-      name,
-      {
-        get: () => options.values[name],
-        set: (value: unknown) => options.set(name, value),
-      },
-    ]),
-  ) as NonNullable<ReactiveUmpOptions<F>['signals']>
+  const signals = {} as NonNullable<ReactiveUmpOptions<F, C>['signals']>
 
-  let conditions: NonNullable<ReactiveUmpOptions<F>['conditions']> | undefined
+  for (const name of fieldNames) {
+    signals[name] = {
+      get: () => options.values[name] as FieldValues<F>[typeof name],
+      set: (value) => options.set(name, value as FieldValues<F>[typeof name]),
+    }
+  }
+
+  let conditions: NonNullable<ReactiveUmpOptions<F, C>['conditions']> | undefined
   if (options.conditions) {
     conditions = {}
     for (const [name, accessor] of Object.entries(options.conditions)) {
       if (!accessor) {
         continue
       }
-      conditions[name] = { get: accessor as Accessor<unknown> }
+      conditions[name as keyof C & string] = {
+        get: accessor as Accessor<C[keyof C & string]>,
+      }
     }
   }
 

--- a/packages/solid/tsconfig.typecheck.json
+++ b/packages/solid/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "type-tests/**/*.ts"
+  ]
+}

--- a/packages/solid/type-tests/from-solid-store.type-test.ts
+++ b/packages/solid/type-tests/from-solid-store.type-test.ts
@@ -1,0 +1,85 @@
+import { enabledWhen, umpire } from '@umpire/core'
+import type { FieldDef, FieldValues } from '@umpire/core'
+import { fromSolidStore } from '../src/fromSolidStore.js'
+
+type Fields = {
+  count: FieldDef<number>
+  active: FieldDef<boolean>
+  label: FieldDef<string>
+}
+
+type Conditions = {
+  tier: 'free' | 'pro'
+  stage: number
+}
+
+const typedUmp = umpire<Fields, Conditions>({
+  fields: {
+    count: { default: 0 },
+    active: { default: true },
+    label: { default: '' },
+  },
+  rules: [
+    enabledWhen('label', (_values, conditions) => conditions.tier === 'pro' && conditions.stage > 0),
+  ],
+})
+
+const values: FieldValues<Fields> = {
+  count: 1,
+  active: false,
+  label: 'ready',
+}
+
+const form = fromSolidStore(typedUmp, {
+  values,
+  set(name, value) {
+    values[name] = value
+  },
+  conditions: {
+    tier: () => 'pro',
+    stage: () => 1,
+  },
+})
+
+form.set('count', 2)
+form.set('active', true)
+form.set('label', 'updated')
+
+// @ts-expect-error count expects number
+form.set('count', '2')
+
+// @ts-expect-error unknown field should be rejected
+form.set('missing', 1)
+
+form.update({
+  active: false,
+  label: 'next',
+})
+
+// @ts-expect-error active expects boolean
+form.update({ active: 'false' })
+
+const count: number | undefined = form.values.count
+const active: boolean | undefined = form.values.active
+const label: string | undefined = form.values.label
+
+// @ts-expect-error count is not string
+const invalidCount: string = form.values.count
+
+fromSolidStore(typedUmp, {
+  values,
+  set(name, value) {
+    values[name] = value
+  },
+  conditions: {
+    tier: () => 'pro',
+    stage: () => 1,
+    // @ts-expect-error unknown condition key should be rejected
+    missing: () => 'x',
+  },
+})
+
+void count
+void active
+void label
+void invalidCount


### PR DESCRIPTION
## Summary
- type `Foul` and reactive adapter write/read surfaces end-to-end so `suggestedValue`, `set`, `update`, and options signals/conditions are keyed by field/condition types
- tighten `@umpire/solid` store adapter typing and add new type-test harnesses for `@umpire/signals`, `@umpire/solid`, and `@umpire/core` (`FieldsOf` + foul narrowing coverage)
- simplify docs/examples by replacing assertion-heavy typing with inference-forward helpers across the solid adapter docs, calendar demo, and printer demo

## Verification
- `yarn workspace @umpire/core typecheck`
- `yarn workspace @umpire/core test`
- `yarn workspace @umpire/core build`
- `yarn workspace @umpire/signals typecheck`
- `yarn workspace @umpire/signals test`
- `yarn workspace @umpire/solid typecheck`
- `yarn workspace @umpire/solid test`
- `yarn docs:build`
- `yarn typecheck`
- `yarn test`