### PR TITLE
🧹 AccountSettingsDemo: remove unused imports, simplify store selector

### DIFF
--- a/docs/src/components/AccountSettingsDemo.tsx
+++ b/docs/src/components/AccountSettingsDemo.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from 'react'
 import { create } from 'zustand'
 import { enabledWhen, requires, strike, umpire } from '@umpire/core'
 import { fromStore } from '@umpire/zustand'
@@ -291,7 +290,7 @@ function TeamSection({
 }
 
 export default function AccountSettingsDemo() {
-  const state = useStore((snapshot) => snapshot)
+  const state = useStore()
   const availability = umpStore.getAvailability()
   const fouls = umpStore.fouls
 


### PR DESCRIPTION
## Summary

- Removes unused `useEffect` and `useRef` imports (dead code, linting error)
- Simplifies `useStore((snapshot) => snapshot)` → `useStore()` — equivalent in Zustand v4, less noisy

## Test plan

- [ ] Verify the demo renders and updates correctly in the docs dev server
- [ ] No TS/lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)