### PR TITLE
✨ Add safe JSON hydration APIs for untrusted schemas

### DIFF
--- a/.changeset/json-safe-parse-hydration.md
+++ b/.changeset/json-safe-parse-hydration.md
@@ -1,0 +1,7 @@
+---
+'@umpire/json': minor
+---
+
+Add safe JSON hydration APIs for untrusted input via `parseJsonSchema(raw)` and `fromJsonSafe(raw)`, returning `{ ok, ... }` results instead of requiring try/catch at call sites.
+
+This keeps trusted-schema `fromJson(schema)` behavior unchanged while reducing userland casts and improving boundary validation ergonomics.

--- a/docs/src/components/ConfigDrivenDemo.tsx
+++ b/docs/src/components/ConfigDrivenDemo.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { strike, umpire } from '@umpire/core'
 import type { FieldDef, InputValues, Umpire } from '@umpire/core'
-import { fromJson } from '@umpire/json'
+import { fromJsonSafe } from '@umpire/json'
 import type { JsonRule, UmpireJsonSchema } from '@umpire/json'
 import { useUmpire } from '@umpire/react'
 import '../styles/components/_components.config-driven-demo.css'
@@ -163,8 +163,7 @@ const mutations: Mutation[] = [
           if (rule.type === 'enabledWhen' && rule.field === 'state') {
             return {
               ...rule,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              when: { op: 'eqIgnoreCase', field: 'country', value: 'US' } as any,
+              when: { op: 'eqIgnoreCase', field: 'country', value: 'US' } as unknown as typeof rule.when,
             }
           }
           return rule
@@ -175,8 +174,7 @@ const mutations: Mutation[] = [
       return schema.rules.some((rule) =>
         rule.type === 'enabledWhen' &&
         rule.field === 'state' &&
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (rule.when as any)?.op === 'eqIgnoreCase',
+        (rule.when as { op?: unknown })?.op === 'eqIgnoreCase',
       )
     },
   },
@@ -196,16 +194,15 @@ function parseAttempt(text: string): ParseAttempt {
     return { status: 'error', error: `JSON parse error: ${(error as Error).message}` }
   }
 
-  try {
-    // `fromJson()` calls validateSchema() internally and throws on failure.
-    const schema = raw as UmpireJsonSchema
-    const { fields, rules, validators } = fromJson(schema)
-    const ump = umpire({ fields, rules, validators })
-    const fieldOrder = Object.keys(schema.fields)
-    return { status: 'ok', schema, ump, fieldOrder }
-  } catch (error) {
-    return { status: 'error', error: (error as Error).message }
+  const parsed = fromJsonSafe(raw)
+
+  if (!parsed.ok) {
+    return { status: 'error', error: parsed.errors.join('\n') }
   }
+
+  const ump = umpire({ fields: parsed.fields, rules: parsed.rules, validators: parsed.validators })
+  const fieldOrder = Object.keys(parsed.schema.fields)
+  return { status: 'ok', schema: parsed.schema, ump, fieldOrder }
 }
 
 function cls(...parts: Array<string | false | null | undefined>): string {

--- a/docs/src/content/docs/extensions/json/index.md
+++ b/docs/src/content/docs/extensions/json/index.md
@@ -13,9 +13,26 @@ It defines what can be expressed in a language-neutral schema, serializes TypeSc
 yarn add @umpire/core @umpire/json
 ```
 
+## Safe parsing from unknown JSON
+
+Use `fromJsonSafe(raw)` when your schema comes from user input, local storage, or any other untrusted source. It never throws — you get either hydrated config or errors:
+
+```ts
+import { fromJsonSafe } from '@umpire/json'
+
+const result = fromJsonSafe(raw)
+
+if (!result.ok) {
+  console.error(result.errors)
+  return
+}
+
+const { schema, fields, rules, validators } = result
+```
+
 ## `fromJson(schema)`
 
-`fromJson()` parses a portable schema and returns `{ fields, rules, validators }` you can pass straight into `umpire()`:
+`fromJson()` parses a trusted `UmpireJsonSchema` and returns `{ fields, rules, validators }` you can pass straight into `umpire()`:
 
 ```ts
 import { umpire } from '@umpire/core'

--- a/docs/src/content/docs/extensions/json/index.md
+++ b/docs/src/content/docs/extensions/json/index.md
@@ -13,9 +13,13 @@ It defines what can be expressed in a language-neutral schema, serializes TypeSc
 yarn add @umpire/core @umpire/json
 ```
 
-## Safe parsing from unknown JSON
+## Parsing from untrusted input
 
-Use `fromJsonSafe(raw)` when your schema comes from user input, local storage, or any other untrusted source. It never throws — you get either hydrated config or errors:
+When a schema arrives from user input, `localStorage`, an API response, or any other source you don't control, you need to validate it before hydrating it. Two APIs cover this — choose based on how much you want to separate those two steps.
+
+### `fromJsonSafe(raw)`
+
+The one-call path. `fromJsonSafe()` validates and hydrates in a single step. It never throws — the return type is a discriminated union:
 
 ```ts
 import { fromJsonSafe } from '@umpire/json'
@@ -23,16 +27,72 @@ import { fromJsonSafe } from '@umpire/json'
 const result = fromJsonSafe(raw)
 
 if (!result.ok) {
+  // result.errors: string[]
   console.error(result.errors)
   return
 }
 
+// result.ok === true
 const { schema, fields, rules, validators } = result
 ```
 
+The success branch includes `schema` — the validated `UmpireJsonSchema` — alongside the hydrated `fields`, `rules`, and `validators`. That means you can round-trip back through `toJson(result)` later without re-validating.
+
+**Return type:**
+
+```ts
+type FromJsonSafeResult<C> =
+  | { ok: true; schema: UmpireJsonSchema; fields: ParsedFields; rules: ParsedRules<C>; validators: ParsedValidators }
+  | { ok: false; errors: string[] }
+```
+
+The generic `C` is the conditions type and defaults to `Record<string, unknown>`. Pass it explicitly when your schema uses typed conditions:
+
+```ts
+type MyConditions = { isAdmin: boolean; plan: string }
+
+const result = fromJsonSafe<MyConditions>(raw)
+```
+
+### `parseJsonSchema(raw)`
+
+The two-step path. `parseJsonSchema()` validates only — it returns the typed `UmpireJsonSchema` if the input is valid, or an errors array if it isn't. Hydration happens separately, in a subsequent `fromJson()` call.
+
+Use this when you need to inspect or store the validated schema before deciding whether to hydrate it:
+
+```ts
+import { parseJsonSchema, fromJson } from '@umpire/json'
+
+const parsed = parseJsonSchema(raw)
+
+if (!parsed.ok) {
+  // parsed.errors: string[]
+  console.error(parsed.errors)
+  return
+}
+
+// parsed.schema is UmpireJsonSchema — fully typed, safe to inspect
+const { fields, rules, validators } = fromJson(parsed.schema)
+```
+
+**Return type:**
+
+```ts
+type JsonSchemaParseResult =
+  | { ok: true; schema: UmpireJsonSchema }
+  | { ok: false; errors: string[] }
+```
+
+Like `fromJsonSafe()`, it never throws.
+
+### Which to use
+
+- Default to `fromJsonSafe()`. It's one call and its success branch already holds everything you need to run `umpire()` and to round-trip with `toJson()`.
+- Reach for `parseJsonSchema()` when you want to hold or examine the validated schema before hydrating — for example, to diff two versions of a schema, log it, or store it separately.
+
 ## `fromJson(schema)`
 
-`fromJson()` parses a trusted `UmpireJsonSchema` and returns `{ fields, rules, validators }` you can pass straight into `umpire()`:
+`fromJson()` parses a trusted `UmpireJsonSchema` — one that has already been validated — and returns `{ fields, rules, validators }` you can pass straight into `umpire()`:
 
 ```ts
 import { umpire } from '@umpire/core'
@@ -42,6 +102,8 @@ const { fields, rules, validators } = fromJson(schema)
 
 const ump = umpire({ fields, rules, validators })
 ```
+
+Unlike `fromJsonSafe()` and `parseJsonSchema()`, `fromJson()` throws if the schema is invalid. It's the right call when you already hold a `UmpireJsonSchema` — for example, the `parsed.schema` you get back from `parseJsonSchema()`.
 
 The result is composable. Hydrate most of a form from JSON and add a few hand-written rules for app-specific logic in the same `umpire()` call — the two sets coexist without conflict.
 

--- a/packages/json/AGENTS.md
+++ b/packages/json/AGENTS.md
@@ -3,4 +3,4 @@
 - Use `fromJson(schema)` to hydrate portable Umpire configs and `toJson({ fields, rules, validators?, conditions? })` to serialize them back out.
 - If a rule or validator must round-trip through JSON, build it from `namedValidators.*()` or the `*Expr` and `*Json` helpers. Arbitrary predicates cannot be serialized cleanly.
 - `toJson()` preserves unsupported pieces in `excluded`; it should not silently drop behavior.
-- Use `validateSchema()` before hydration when JSON comes from an untrusted source.
+- For untrusted input (user input, localStorage, API responses), prefer `fromJsonSafe(raw)` — it validates and hydrates in one call and never throws. Use `parseJsonSchema(raw)` when you need the validated schema separately before hydrating. Both return `{ ok: true, ... } | { ok: false, errors: string[] }`. Reach for `validateSchema()` directly only when you need low-level access to the validation step itself.

--- a/packages/json/__tests__/parse.test.ts
+++ b/packages/json/__tests__/parse.test.ts
@@ -1,6 +1,6 @@
 import { umpire } from '@umpire/core'
 
-import { fromJson, getJsonDef, toJson, validateSchema } from '../src/index.js'
+import { fromJson, fromJsonSafe, getJsonDef, parseJsonSchema, toJson, validateSchema } from '../src/index.js'
 import type { UmpireJsonSchema } from '../src/index.js'
 
 describe('fromJson', () => {
@@ -153,6 +153,217 @@ describe('fromJson', () => {
     const parsed = fromJson(schema)
 
     expect(toJson(parsed)).toEqual(schema)
+  })
+})
+
+describe('parseJsonSchema', () => {
+  test('returns ok for a valid raw schema object', () => {
+    const raw: unknown = {
+      version: 1,
+      fields: {
+        email: { isEmpty: 'string' },
+      },
+      rules: [],
+      validators: {
+        email: { op: 'email', error: 'Must be a valid email address' },
+      },
+    }
+
+    const parsed = parseJsonSchema(raw)
+
+    expect(parsed.ok).toBe(true)
+
+    if (!parsed.ok) {
+      throw new Error('Expected parseJsonSchema to succeed')
+    }
+
+    expect(parsed.schema).toEqual(raw)
+  })
+
+  test('returns errors for invalid schema input', () => {
+    const parsed = parseJsonSchema({
+      version: 1,
+      fields: {},
+      rules: [
+        {
+          type: 'requires',
+          field: 'missing',
+          dependency: 'alsoMissing',
+        },
+      ],
+    })
+
+    expect(parsed).toEqual({
+      ok: false,
+      errors: ['[@umpire/json] Rule "requires" references unknown field "missing"'],
+    })
+  })
+
+  test.each([
+    [null, '[@umpire/json] Schema must be an object'],
+    [{ version: 1 }, '[@umpire/json] Schema must include a "fields" object'],
+    [{ version: 1, fields: [], rules: [] }, '[@umpire/json] Schema must include a "fields" object'],
+    [{ version: 1, fields: {}, rules: null }, '[@umpire/json] Schema must include a "rules" array'],
+    [{ version: 1, fields: {}, rules: [], validators: 'nope' }, '[@umpire/json] Schema "validators" must be an object when provided'],
+    [{ version: 1, fields: {}, rules: [], validators: [] }, '[@umpire/json] Schema "validators" must be an object when provided'],
+    [{ version: 2, fields: {}, rules: [] }, '[@umpire/json] Unsupported schema version "2"'],
+  ])('returns boundary errors for malformed raw schemas: %j', (raw, message) => {
+    expect(parseJsonSchema(raw)).toEqual({
+      ok: false,
+      errors: [message],
+    })
+  })
+})
+
+describe('fromJsonSafe', () => {
+  test('returns hydrated config when given a valid raw schema object', () => {
+    const raw: unknown = {
+      version: 1,
+      fields: {
+        email: { isEmpty: 'string' },
+      },
+      rules: [],
+      validators: {
+        email: { op: 'email', error: 'Must be a valid email address' },
+      },
+    }
+
+    const parsed = fromJsonSafe(raw)
+
+    expect(parsed.ok).toBe(true)
+
+    if (!parsed.ok) {
+      throw new Error('Expected fromJsonSafe to succeed')
+    }
+
+    const runtime = umpire({ fields: parsed.fields, rules: parsed.rules, validators: parsed.validators })
+    expect(runtime.check({ email: 'invalid' }).email.valid).toBe(false)
+    expect(parsed.schema).toEqual(raw)
+  })
+
+  test('returns errors for invalid schema input', () => {
+    const parsed = fromJsonSafe({
+      version: 1,
+      fields: {},
+      rules: [
+        {
+          type: 'requires',
+          field: 'missing',
+          dependency: 'alsoMissing',
+        },
+      ],
+    })
+
+    expect(parsed).toEqual({
+      ok: false,
+      errors: ['[@umpire/json] Rule "requires" references unknown field "missing"'],
+    })
+  })
+
+  test.each([
+    [
+      {
+        version: 1,
+        fields: [],
+        rules: [],
+      },
+      '[@umpire/json] Schema must include a "fields" object',
+    ],
+    [
+      {
+        version: 1,
+        fields: { email: null },
+        rules: [],
+      },
+      '[@umpire/json] Field "email" definition must be an object',
+    ],
+    [
+      {
+        version: 1,
+        fields: { email: {} },
+        rules: [],
+        validators: { email: null },
+      },
+      '[@umpire/json] Validator for field "email" must be an object',
+    ],
+    [
+      {
+        version: 1,
+        fields: {},
+        rules: [],
+        validators: [],
+      },
+      '[@umpire/json] Schema "validators" must be an object when provided',
+    ],
+    [
+      {
+        version: 1,
+        fields: {},
+        rules: [],
+        conditions: [],
+      },
+      '[@umpire/json] Schema "conditions" must be an object when provided',
+    ],
+    [
+      {
+        version: 1,
+        fields: {},
+        rules: [],
+        excluded: {},
+      },
+      '[@umpire/json] Schema "excluded" must be an array when provided',
+    ],
+  ])('returns boundary errors for malformed schema sections: %j', (raw, message) => {
+    expect(fromJsonSafe(raw)).toEqual({
+      ok: false,
+      errors: [message],
+    })
+  })
+
+  test('matches fromJson output shape and behavior for valid schemas', () => {
+    const schema: UmpireJsonSchema = {
+      version: 1,
+      fields: {
+        accountType: { isEmpty: 'string' },
+        companyName: { isEmpty: 'string' },
+        email: { isEmpty: 'string' },
+      },
+      rules: [
+        {
+          type: 'enabledWhen',
+          field: 'companyName',
+          when: { op: 'eq', field: 'accountType', value: 'business' },
+          reason: 'Business accounts only',
+        },
+      ],
+      validators: {
+        email: { op: 'email', error: 'Must be a valid email address' },
+      },
+    }
+
+    const safe = fromJsonSafe(schema)
+    const typed = fromJson(schema)
+
+    expect(safe.ok).toBe(true)
+
+    if (!safe.ok) {
+      throw new Error('Expected fromJsonSafe to succeed')
+    }
+
+    const safeRuntime = umpire({ fields: safe.fields, rules: safe.rules, validators: safe.validators })
+    const typedRuntime = umpire(typed)
+
+    const values = {
+      accountType: 'business',
+      companyName: '',
+      email: 'invalid',
+    }
+
+    expect(Object.keys(safe.fields)).toEqual(Object.keys(typed.fields))
+    expect(toJson({ fields: safe.fields, rules: safe.rules, validators: safe.validators })).toEqual(
+      toJson(typed),
+    )
+    expect(safeRuntime.check(values)).toEqual(typedRuntime.check(values))
   })
 })
 

--- a/packages/json/__tests__/parse.test.ts
+++ b/packages/json/__tests__/parse.test.ts
@@ -207,6 +207,7 @@ describe('parseJsonSchema', () => {
     [{ version: 1, fields: {}, rules: [], validators: 'nope' }, '[@umpire/json] Schema "validators" must be an object when provided'],
     [{ version: 1, fields: {}, rules: [], validators: [] }, '[@umpire/json] Schema "validators" must be an object when provided'],
     [{ version: 2, fields: {}, rules: [] }, '[@umpire/json] Unsupported schema version "2"'],
+    [{ fields: {}, rules: [] }, '[@umpire/json] Schema must include a "version" field'],
   ])('returns boundary errors for malformed raw schemas: %j', (raw, message) => {
     expect(parseJsonSchema(raw)).toEqual({
       ok: false,

--- a/packages/json/__tests__/serialize.test.ts
+++ b/packages/json/__tests__/serialize.test.ts
@@ -4,10 +4,13 @@ import {
   disables,
   eitherOf,
   enabledWhen,
+  fairWhen,
   isEmptyObject,
   isEmptyString,
   oneOf,
   requires,
+  type FieldDef,
+  type Rule,
 } from '@umpire/core'
 
 import { fromJson, hydrateIsEmptyStrategy, namedValidators, toJson } from '../src/index.js'
@@ -443,6 +446,131 @@ describe('toJson', () => {
           type: 'eitherOf',
           description: 'eitherOf() contains inner rules that cannot be serialized one-to-one into JSON',
           key: 'rule:eitherOf:auth',
+        }),
+      ]),
+    )
+  })
+
+  test('serializes disables() predicate sources when they map to portable validators', () => {
+    const fields = {
+      email: {},
+      submit: {},
+    }
+
+    const result = toJson({
+      fields,
+      rules: [disables(check('email', namedValidators.email()), ['submit'])],
+    })
+
+    expect(result.rules).toEqual([
+      {
+        type: 'disables',
+        when: {
+          op: 'check',
+          field: 'email',
+          check: { op: 'email' },
+        },
+        targets: ['submit'],
+      },
+    ])
+  })
+
+  test('serializes fairWhen() checks against other fields as check expressions', () => {
+    const fields = {
+      email: {},
+      submit: {},
+    }
+
+    const result = toJson({
+      fields,
+      rules: [fairWhen('submit', check('email', namedValidators.email()))],
+    })
+
+    expect(result.rules).toEqual([
+      {
+        type: 'fairWhen',
+        field: 'submit',
+        when: {
+          op: 'check',
+          field: 'email',
+          check: { op: 'email' },
+        },
+      },
+    ])
+  })
+
+  test('excludes dynamic reason callbacks across rule kinds', () => {
+    const fields = {
+      email: {},
+      submit: {},
+      mode: {},
+    }
+
+    const result = toJson({
+      fields,
+      rules: [
+        enabledWhen('submit', check('email', namedValidators.email()), { reason: () => 'dynamic' }),
+        requires('submit', 'email', { reason: () => 'dynamic' }),
+        fairWhen('email', namedValidators.email(), { reason: () => 'dynamic' }),
+        disables('mode', ['submit'], { reason: () => 'dynamic' }),
+      ],
+    })
+
+    expect(result.rules).toEqual([])
+    expect(result.excluded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'enabledWhen' }),
+        expect.objectContaining({ type: 'requires' }),
+        expect.objectContaining({ type: 'fairWhen' }),
+        expect.objectContaining({ type: 'disables' }),
+      ]),
+    )
+  })
+
+  test('excludes oneOf overrides and non-serializable anyOf branches', () => {
+    const fields = {
+      email: {},
+      submit: {},
+      mode: {},
+    }
+
+    const result = toJson({
+      fields,
+      rules: [
+        oneOf('modeSelect', { email: ['email'], submit: ['submit'] }, { activeBranch: 'email' }),
+        anyOf(enabledWhen('submit', (values) => values.mode === 'open')),
+      ],
+    })
+
+    expect(result.rules).toEqual([])
+    expect(result.excluded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'oneOf' }),
+        expect.objectContaining({ type: 'anyOf' }),
+      ]),
+    )
+  })
+
+  test('excludes rules that cannot be inspected', () => {
+    const fields = {
+      email: {},
+    }
+
+    const opaqueRule = {
+      type: 'opaqueRule',
+      targets: ['email'],
+      sources: [],
+      evaluate: () => ({ enabled: true }),
+    } as unknown as Rule<Record<string, FieldDef>, Record<string, unknown>>
+
+    const result = toJson({ fields, rules: [opaqueRule] })
+
+    expect(result.rules).toEqual([])
+    expect(result.excluded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'opaqueRule',
+          description: 'Rule "opaqueRule" could not be inspected for JSON serialization',
         }),
       ]),
     )

--- a/packages/json/__tests__/validate.test.ts
+++ b/packages/json/__tests__/validate.test.ts
@@ -348,4 +348,50 @@ describe('validateSchema', () => {
       validateSchema(schema as unknown as UmpireJsonSchema),
     ).toThrow(expectedMessage)
   })
+
+  test('accepts nested anyOf/eitherOf composites with matching targets and constraints', () => {
+    expect(() =>
+      validateSchema({
+        version: 1,
+        fields: {
+          submit: {},
+          email: {},
+          password: {},
+          ssoToken: {},
+        },
+        rules: [
+          {
+            type: 'anyOf',
+            rules: [
+              {
+                type: 'eitherOf',
+                group: 'auth',
+                branches: {
+                  password: [
+                    {
+                      type: 'enabledWhen',
+                      field: 'submit',
+                      when: { op: 'present', field: 'email' },
+                    },
+                  ],
+                  sso: [
+                    {
+                      type: 'enabledWhen',
+                      field: 'submit',
+                      when: { op: 'present', field: 'ssoToken' },
+                    },
+                  ],
+                },
+              },
+              {
+                type: 'enabledWhen',
+                field: 'submit',
+                when: { op: 'present', field: 'password' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).not.toThrow()
+  })
 })

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -15,7 +15,7 @@ export {
   requiresExpr,
 } from './builders.js'
 export { compileExpr, getExprFieldRefs } from './expr.js'
-export { fromJson } from './parse.js'
+export { fromJson, fromJsonSafe, parseJsonSchema } from './parse.js'
 export { getJsonDef } from './json-def.js'
 export { toJson } from './serialize.js'
 export { hydrateIsEmptyStrategy } from './strategies.js'
@@ -37,4 +37,11 @@ export type {
   UmpireJsonSchema,
 } from './schema.js'
 export type { JsonExprBuilder, PortableRuleOptions } from './builders.js'
+export type {
+  FromJsonSafeResult,
+  JsonSchemaParseResult,
+  ParsedFields,
+  ParsedRules,
+  ParsedValidators,
+} from './parse.js'
 export type { ToJsonConfig } from './serialize.js'

--- a/packages/json/src/parse.ts
+++ b/packages/json/src/parse.ts
@@ -31,12 +31,38 @@ import type {
 import { hydrateIsEmptyStrategy } from './strategies.js'
 import { validateSchema } from './validate.js'
 
-type ParsedFields = Record<string, FieldDef>
-type ParsedRules<C extends Record<string, unknown>> = Rule<ParsedFields, C>[]
-type ParsedValidators = ValidationMap<ParsedFields>
+export type ParsedFields = Record<string, FieldDef>
+export type ParsedRules<C extends Record<string, unknown>> = Rule<ParsedFields, C>[]
+export type ParsedValidators = ValidationMap<ParsedFields>
 type ParsedSchemaMeta = {
   conditions?: Record<string, JsonConditionDef>
   excluded?: ExcludedRule[]
+}
+
+export type JsonSchemaParseResult =
+  | { ok: true; schema: UmpireJsonSchema }
+  | { ok: false; errors: string[] }
+
+export type FromJsonSafeResult<C extends Record<string, unknown> = Record<string, unknown>> =
+  | {
+      ok: true
+      schema: UmpireJsonSchema
+      fields: ParsedFields
+      rules: ParsedRules<C>
+      validators: ParsedValidators
+    }
+  | { ok: false; errors: string[] }
+
+export function parseJsonSchema(raw: unknown): JsonSchemaParseResult {
+  try {
+    validateSchema(raw)
+    return { ok: true, schema: raw }
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [error instanceof Error ? error.message : String(error)],
+    }
+  }
 }
 
 type NamedFairPredicate<C extends Record<string, unknown>> = ((
@@ -67,7 +93,7 @@ function compileFairExpr<C extends Record<string, unknown>>(
 }
 
 function parseFieldDefs(fields: UmpireJsonSchema['fields']): ParsedFields {
-  const parsed: ParsedFields = {}
+  const parsed: ParsedFields = Object.create(null) as ParsedFields
 
   for (const [field, definition] of Object.entries(fields)) {
     parsed[field] = {
@@ -107,7 +133,7 @@ function parseValidatorDef(definition: JsonValidatorDef) {
 }
 
 function parseValidators(validators: UmpireJsonSchema['validators']): ParsedValidators {
-  const parsed = {} as ParsedValidators
+  const parsed = Object.create(null) as ParsedValidators
 
   for (const [field, definition] of Object.entries(validators ?? {})) {
     parsed[field] = parseValidatorDef(definition)
@@ -172,7 +198,7 @@ function parseRule<C extends Record<string, unknown>>(
         reason: rule.reason,
       }), rule)
     case 'eitherOf': {
-      const parsedBranches: Record<string, Array<Rule<ParsedFields, C>>> = {}
+      const parsedBranches = Object.create(null) as Record<string, Array<Rule<ParsedFields, C>>>
 
       for (const [branchName, branchRules] of Object.entries(rule.branches)) {
         parsedBranches[branchName] = branchRules.map((innerRule) => parseRule<C>(innerRule, schema))
@@ -200,6 +226,16 @@ export function fromJson<C extends Record<string, unknown> = Record<string, unkn
 } {
   validateSchema(schema)
 
+  return hydrateValidatedSchema<C>(schema)
+}
+
+function hydrateValidatedSchema<C extends Record<string, unknown> = Record<string, unknown>>(
+  schema: UmpireJsonSchema,
+): {
+  fields: ParsedFields
+  rules: ParsedRules<C>
+  validators: ParsedValidators
+} {
   const meta: ParsedSchemaMeta = {
     conditions: schema.conditions,
     excluded: schema.excluded,
@@ -210,6 +246,26 @@ export function fromJson<C extends Record<string, unknown> = Record<string, unkn
   const validators = parseValidators(schema.validators)
 
   return {
+    fields,
+    rules,
+    validators,
+  }
+}
+
+export function fromJsonSafe<C extends Record<string, unknown> = Record<string, unknown>>(
+  raw: unknown,
+): FromJsonSafeResult<C> {
+  const parsedSchema = parseJsonSchema(raw)
+
+  if (!parsedSchema.ok) {
+    return parsedSchema
+  }
+
+  const { fields, rules, validators } = hydrateValidatedSchema<C>(parsedSchema.schema)
+
+  return {
+    ok: true,
+    schema: parsedSchema.schema,
     fields,
     rules,
     validators,

--- a/packages/json/src/validate.ts
+++ b/packages/json/src/validate.ts
@@ -11,11 +11,19 @@ import { isJsonIsEmptyStrategy } from './strategies.js'
 
 type JsonRuleConstraint = 'enabled' | 'fair'
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 function isJsonPrimitive(value: unknown): boolean {
   return value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
 }
 
 function validateFieldDef(field: string, definition: JsonFieldDef) {
+  if (!isRecord(definition)) {
+    throw new Error(`[@umpire/json] Field "${field}" definition must be an object`)
+  }
+
   if (definition.default !== undefined && !isJsonPrimitive(definition.default)) {
     throw new Error(`[@umpire/json] Field "${field}" has a non-serializable default value`)
   }
@@ -59,6 +67,10 @@ function assertField(field: string, fieldNames: Set<string>, context: string) {
 function validateValidator(field: string, validator: JsonValidatorDef, fieldNames: Set<string>) {
   if (!fieldNames.has(field)) {
     throw new Error(`[@umpire/json] Validator references unknown field "${field}"`)
+  }
+
+  if (!isRecord(validator)) {
+    throw new Error(`[@umpire/json] Validator for field "${field}" must be an object`)
   }
 
   assertValidValidatorSpec(validator)
@@ -245,26 +257,52 @@ function validateRule(
   }
 }
 
-export function validateSchema(schema: UmpireJsonSchema): void {
+export function validateSchema(schema: unknown): asserts schema is UmpireJsonSchema {
+  if (!isRecord(schema)) {
+    throw new Error('[@umpire/json] Schema must be an object')
+  }
+
   if (schema.version !== 1) {
     throw new Error(`[@umpire/json] Unsupported schema version "${String(schema.version)}"`)
   }
 
-  const fieldNames = new Set(Object.keys(schema.fields ?? {}))
+  if (!isRecord(schema.fields)) {
+    throw new Error('[@umpire/json] Schema must include a "fields" object')
+  }
 
-  for (const [field, definition] of Object.entries(schema.fields ?? {})) {
+  if (!Array.isArray(schema.rules)) {
+    throw new Error('[@umpire/json] Schema must include a "rules" array')
+  }
+
+  if (schema.validators !== undefined && !isRecord(schema.validators)) {
+    throw new Error('[@umpire/json] Schema "validators" must be an object when provided')
+  }
+
+  if (schema.conditions !== undefined && !isRecord(schema.conditions)) {
+    throw new Error('[@umpire/json] Schema "conditions" must be an object when provided')
+  }
+
+  if (schema.excluded !== undefined && !Array.isArray(schema.excluded)) {
+    throw new Error('[@umpire/json] Schema "excluded" must be an array when provided')
+  }
+
+  const typedSchema = schema as unknown as UmpireJsonSchema
+
+  const fieldNames = new Set(Object.keys(typedSchema.fields))
+
+  for (const [field, definition] of Object.entries(typedSchema.fields)) {
     validateFieldDef(field, definition)
   }
 
-  for (const rule of schema.rules ?? []) {
-    validateRule(rule, fieldNames, schema.conditions)
+  for (const rule of typedSchema.rules) {
+    validateRule(rule, fieldNames, typedSchema.conditions)
   }
 
-  for (const [field, validator] of Object.entries(schema.validators ?? {})) {
+  for (const [field, validator] of Object.entries(typedSchema.validators ?? {})) {
     validateValidator(field, validator, fieldNames)
   }
 
-  for (const rule of schema.excluded ?? []) {
+  for (const rule of typedSchema.excluded ?? []) {
     validateExcludedRule(rule)
   }
 }

--- a/packages/json/src/validate.ts
+++ b/packages/json/src/validate.ts
@@ -262,6 +262,10 @@ export function validateSchema(schema: unknown): asserts schema is UmpireJsonSch
     throw new Error('[@umpire/json] Schema must be an object')
   }
 
+  if (schema.version === undefined) {
+    throw new Error('[@umpire/json] Schema must include a "version" field')
+  }
+
   if (schema.version !== 1) {
     throw new Error(`[@umpire/json] Unsupported schema version "${String(schema.version)}"`)
   }


### PR DESCRIPTION
## Summary
- add `parseJsonSchema(raw)` and `fromJsonSafe(raw)` to `@umpire/json`, keeping `fromJson(schema)` unchanged while returning non-throwing `{ ok, ... }` results for untrusted input
- harden schema boundary validation and update docs + `ConfigDrivenDemo` to use the safe parse path by default for raw JSON
- expand `@umpire/json` test coverage for parse/hydration boundaries, serialization edge paths, and nested `anyOf`/`eitherOf` validation behavior

## Verification
- `yarn workspace @umpire/json test`
- `yarn workspace @umpire/json typecheck`
- `yarn workspace @umpire/json build`
- `yarn docs:build`
- `yarn typecheck`