### PR TITLE
🧹 Global `eslint` and `prettier` config & init

### DIFF
--- a/.changeset/khaki-ducks-write.md
+++ b/.changeset/khaki-ducks-write.md
@@ -1,0 +1,21 @@
+---
+'@umpire/tanstack-store': patch
+'@umpire/eslint-plugin': patch
+'@umpire/devtools': patch
+'@umpire/signals': patch
+'@umpire/testing': patch
+'@umpire/zustand': patch
+'@umpire/pinia': patch
+'@umpire/react': patch
+'@umpire/reads': patch
+'@umpire/redux': patch
+'@umpire/solid': patch
+'@umpire/store': patch
+'@umpire/core': patch
+'@umpire/json': patch
+'@umpire/vuex': patch
+'@umpire/dsl': patch
+'@umpire/zod': patch
+---
+
+code formatting & type adjustments for better consistency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,43 @@ jobs:
         env:
           BUN_DISABLE_WORKSPACE_MOCKS: 'true'
         run: bun test ./smoke/build.ts
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn turbo run lint
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Check formatting
+        run: yarn turbo run format:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         # `yarn install --immutable` in CI fails on the resulting PR because the
         # lockfile still references the old version constraints.
         with:
-          title: "🐪 Version Packages"
+          title: '🐪 Version Packages'
           version: yarn changeset version && yarn install
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN != '' && secrets.CHANGESETS_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+yarn turbo run lint
+yarn format:check
+yarn typecheck
+yarn test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 yarn turbo run lint
 yarn format:check
 yarn typecheck
-yarn test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+docs/
+**/dist/
+**/node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 docs/
+.changeset/
 **/dist/
 **/node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "all",
-  "printWidth": 100
+  "trailingComma": "all"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Quick reference (root): `yarn test`, `yarn build`, `yarn typecheck`.
 ## Releases and Versioning
 
 Changesets workflow with `.changeset/config.json`:
+
 - `updateInternalDependencies: "minor"` ensures adapter packages get a patch bump when `core` bumps minor or major, triggering a new publish with updated dep ranges.
 - All packages are kept in sync: when a referenced package bumps, dependents are re-published automatically.
 - This maintains consistency without requiring a full major cascade on every internal change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,12 +41,12 @@ Most packages build with `tsc`; `@umpire/devtools` builds with `tsdown`. For doc
 
 `yarn workspace @umpire/<pkg> test` runs only that package's tests and forwards extra args to `bun test`:
 
-| Need                          | Command                                                                 |
-| ----------------------------- | ----------------------------------------------------------------------- |
-| Single test file              | `yarn workspace @umpire/<pkg> test path/to/file.test.ts`                |
-| Filter by test name           | `yarn workspace @umpire/<pkg> test -t "pattern"`                        |
-| Watch mode                    | `yarn workspace @umpire/<pkg> test --watch`                             |
-| Disable workspace alias mocks | `BUN_DISABLE_WORKSPACE_MOCKS=true yarn workspace @umpire/<pkg> test`    |
+| Need                          | Command                                                              |
+| ----------------------------- | -------------------------------------------------------------------- |
+| Single test file              | `yarn workspace @umpire/<pkg> test path/to/file.test.ts`             |
+| Filter by test name           | `yarn workspace @umpire/<pkg> test -t "pattern"`                     |
+| Watch mode                    | `yarn workspace @umpire/<pkg> test --watch`                          |
+| Disable workspace alias mocks | `BUN_DISABLE_WORKSPACE_MOCKS=true yarn workspace @umpire/<pkg> test` |
 
 ### Heads-up: "isolated" means test scope, not dependency isolation
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ import { enabledWhen, requires, umpire } from '@umpire/core'
 
 const signupUmp = umpire({
   fields: {
-    email:           { required: true, isEmpty: (v) => !v },
-    password:        { required: true, isEmpty: (v) => !v },
+    email: { required: true, isEmpty: (v) => !v },
+    password: { required: true, isEmpty: (v) => !v },
     confirmPassword: { required: true, isEmpty: (v) => !v },
-    referralCode:    {},
-    companyName:     {},
-    companySize:     {},
+    referralCode: {},
+    companyName: {},
+    companySize: {},
   },
   rules: [
     requires('confirmPassword', 'password'),
@@ -73,23 +73,23 @@ const fouls = signupUmp.play(
 
 ## Packages
 
-| Package | Purpose |
-| --- | --- |
-| [`@umpire/core`](./packages/core/README.md) | Pure logic engine with zero runtime dependencies |
-| [`@umpire/dsl`](./packages/dsl/README.md) | Pure expression DSL (`expr.*`, `compileExpr`, `getExprFieldRefs`) |
-| [`@umpire/react`](./packages/react/README.md) | `useUmpire()` hook for React |
-| [`@umpire/solid`](./packages/solid/README.md) | `useUmpire()` hook for Solid |
-| [`@umpire/signals`](./packages/signals/README.md) | Signal adapter via `SignalProtocol` (Jotai, Preact, Alien Signals, TC39) |
-| [`@umpire/store`](./packages/store/README.md) | Generic store adapter — bring your own `getState()` + `subscribe(next, prev)` |
-| [`@umpire/zustand`](./packages/zustand/README.md) | Zustand adapter (satisfies the store contract natively) |
-| [`@umpire/redux`](./packages/redux/README.md) | Redux / Redux Toolkit adapter |
-| [`@umpire/tanstack-store`](./packages/tanstack-store/README.md) | TanStack Store adapter |
-| [`@umpire/pinia`](./packages/pinia/README.md) | Pinia adapter (Vue 3) |
-| [`@umpire/vuex`](./packages/vuex/README.md) | Vuex 4 adapter (Vue 3) |
-| [`@umpire/zod`](./packages/zod/README.md) | Availability-aware Zod schemas — disabled fields produce no errors |
-| [`@umpire/reads`](./packages/reads/README.md) | Derived read tables and read-backed rule bridges |
-| [`@umpire/testing`](./packages/testing/README.md) | Invariant probes for rule configurations |
-| [`@umpire/devtools`](./packages/devtools/README.md) | In-app inspector panel — scorecard, traces, foul log, graph view |
+| Package                                                         | Purpose                                                                       |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [`@umpire/core`](./packages/core/README.md)                     | Pure logic engine with zero runtime dependencies                              |
+| [`@umpire/dsl`](./packages/dsl/README.md)                       | Pure expression DSL (`expr.*`, `compileExpr`, `getExprFieldRefs`)             |
+| [`@umpire/react`](./packages/react/README.md)                   | `useUmpire()` hook for React                                                  |
+| [`@umpire/solid`](./packages/solid/README.md)                   | `useUmpire()` hook for Solid                                                  |
+| [`@umpire/signals`](./packages/signals/README.md)               | Signal adapter via `SignalProtocol` (Jotai, Preact, Alien Signals, TC39)      |
+| [`@umpire/store`](./packages/store/README.md)                   | Generic store adapter — bring your own `getState()` + `subscribe(next, prev)` |
+| [`@umpire/zustand`](./packages/zustand/README.md)               | Zustand adapter (satisfies the store contract natively)                       |
+| [`@umpire/redux`](./packages/redux/README.md)                   | Redux / Redux Toolkit adapter                                                 |
+| [`@umpire/tanstack-store`](./packages/tanstack-store/README.md) | TanStack Store adapter                                                        |
+| [`@umpire/pinia`](./packages/pinia/README.md)                   | Pinia adapter (Vue 3)                                                         |
+| [`@umpire/vuex`](./packages/vuex/README.md)                     | Vuex 4 adapter (Vue 3)                                                        |
+| [`@umpire/zod`](./packages/zod/README.md)                       | Availability-aware Zod schemas — disabled fields produce no errors            |
+| [`@umpire/reads`](./packages/reads/README.md)                   | Derived read tables and read-backed rule bridges                              |
+| [`@umpire/testing`](./packages/testing/README.md)               | Invariant probes for rule configurations                                      |
+| [`@umpire/devtools`](./packages/devtools/README.md)             | In-app inspector panel — scorecard, traces, foul log, graph view              |
 
 ## Why Umpire?
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,38 @@
+import tseslint from 'typescript-eslint'
+import umpirePlugin from '@umpire/eslint-plugin'
+import prettierConfig from 'eslint-config-prettier'
+
+export default tseslint.config(
+  {
+    ignores: ['**/dist/**', '**/node_modules/**'],
+  },
+  // TypeScript + complexity for packages
+  {
+    files: ['packages/**/*.{ts,tsx}'],
+    extends: tseslint.configs.recommended,
+    rules: {
+      complexity: ['warn', 15],
+      // {} is used intentionally as a generic type throughout umpire's type system
+      '@typescript-eslint/no-empty-object-type': 'off',
+      // Real issues but numerous; tracked as warnings to drive gradual cleanup
+      '@typescript-eslint/no-unused-vars': 'warn',
+    },
+  },
+  // TypeScript parser for docs source — enables umpire plugin without full TS-ESLint rules
+  {
+    files: ['docs/src/**/*.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+    },
+  },
+  // Umpire plugin for packages + docs TS/JS source
+  {
+    files: ['packages/**/*.{ts,tsx,js}', 'docs/src/**/*.{ts,js}'],
+    ...umpirePlugin.configs.recommended,
+  },
+  // Prettier compat for packages only — docs excluded intentionally
+  {
+    files: ['packages/**/*.{ts,tsx,js}'],
+    ...prettierConfig,
+  },
+)

--- a/examples/codepen-starter.html
+++ b/examples/codepen-starter.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <title>Umpire starter</title>
-</head>
-<body>
-  <!--
+  <head>
+    <title>Umpire starter</title>
+  </head>
+  <body>
+    <!--
     Umpire + React CDN starter
 
     Two scripts:
@@ -14,20 +14,20 @@
     Swap unpkg URLs to a pinned version once you know which one you want, e.g.:
       https://unpkg.com/@umpire/core@0.1.0-alpha.9/dist/index.iife.js
   -->
-  <script src="https://unpkg.com/react/umd/react.production.min.js"></script>
-  <script src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
-  <script src="https://unpkg.com/@umpire/core/dist/index.iife.js"></script>
-  <script src="https://unpkg.com/@umpire/react/dist/index.iife.js"></script>
+    <script src="https://unpkg.com/react/umd/react.production.min.js"></script>
+    <script src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/@umpire/core/dist/index.iife.js"></script>
+    <script src="https://unpkg.com/@umpire/react/dist/index.iife.js"></script>
 
-  <div id="root"></div>
+    <div id="root"></div>
 
-  <script>
-    const { umpire, enabledWhen, requires } = Umpire
-    const { useUmpire } = UmpireReact
-    const { useState } = React
+    <script>
+      const { umpire, enabledWhen, requires } = Umpire
+      const { useUmpire } = UmpireReact
+      const { useState } = React
 
-    // Start here — define your fields and rules
-    // const ump = umpire({ fields: { ... }, rules: [ ... ] })
-  </script>
-</body>
+      // Start here — define your fields and rules
+      // const ump = umpire({ fields: { ... }, rules: [ ... ] })
+    </script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
-    "typecheck": "turbo run typecheck"
+    "typecheck": "turbo run typecheck",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
@@ -32,6 +33,7 @@
     "@umpire/eslint-plugin": "workspace:^",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
+    "husky": "^9.1.7",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-instrument": "^6.0.3",
     "istanbul-lib-report": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
     "@happy-dom/global-registrator": "^20.0.10",
+    "@types/bun": "^1.3.12",
     "@umpire/eslint-plugin": "workspace:^",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -20,16 +20,24 @@
     "test:coverage": "turbo run test --force -- --coverage --coverage-reporter=lcov --coverage-dir=coverage && bun ./scripts/merge-lcov.mjs",
     "test:coverage:istanbul": "bun ./scripts/test-coverage-istanbul.ts",
     "test:smoke": "yarn workspace @umpire/devtools test:smoke",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
     "@happy-dom/global-registrator": "^20.0.10",
+    "@umpire/eslint-plugin": "workspace:^",
+    "eslint": "^10.2.1",
+    "eslint-config-prettier": "^10.1.8",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-instrument": "^6.0.3",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.2.0",
+    "prettier": "^3.8.3",
     "turbo": "^2.5.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.58.2"
   }
 }

--- a/packages/core/BENCHMARKS.md
+++ b/packages/core/BENCHMARKS.md
@@ -16,15 +16,15 @@ Observed on April 3, 2026 from a local development run.
 
 These numbers come from repeated in-process runs, so they should be read as steady-state performance rather than cold-start latency. They are most useful as a regression baseline.
 
-| Benchmark | Iterations | Avg ms | Ops/sec | Checksum |
-| --- | ---: | ---: | ---: | ---: |
-| `create/scheduler-60-sections` | 25 | 1.954 | 511.71 | 62400 |
-| `check/scheduler/pro-plan` | 150 | 0.442 | 2263.04 | 117780 |
-| `check/scheduler/basic-readonly` | 150 | 0.427 | 2340.05 | 147829 |
-| `challenge/review-lock-chain` | 100 | 0.318 | 3148.46 | 606 |
-| `play/plan-downgrade` | 100 | 0.688 | 1454.52 | 226543 |
-| `graph/export-scheduler` | 100 | 0.308 | 3245.48 | 242400 |
-| `check/minesweeper-expert-board` | 100 | 0.261 | 3836.33 | 48480 |
+| Benchmark                        | Iterations | Avg ms | Ops/sec | Checksum |
+| -------------------------------- | ---------: | -----: | ------: | -------: |
+| `create/scheduler-60-sections`   |         25 |  1.954 |  511.71 |    62400 |
+| `check/scheduler/pro-plan`       |        150 |  0.442 | 2263.04 |   117780 |
+| `check/scheduler/basic-readonly` |        150 |  0.427 | 2340.05 |   147829 |
+| `challenge/review-lock-chain`    |        100 |  0.318 | 3148.46 |      606 |
+| `play/plan-downgrade`            |        100 |  0.688 | 1454.52 |   226543 |
+| `graph/export-scheduler`         |        100 |  0.308 | 3245.48 |   242400 |
+| `check/minesweeper-expert-board` |        100 |  0.261 | 3836.33 |    48480 |
 
 ## Notes
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,7 +7,6 @@
 - e570cac: Add browser/CDN builds via tsdown
 
   Both `@umpire/core` and `@umpire/react` now ship bundled browser artifacts alongside the existing ESM build:
-
   - `dist/index.browser.js` — minified ESM for `<script type="module">` and esm.sh
   - `dist/index.iife.js` — IIFE with `window.Umpire` / `window.UmpireReact` globals
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -17,11 +17,11 @@ import { enabledWhen, requires, umpire } from '@umpire/core'
 
 const signupUmp = umpire({
   fields: {
-    email:           { required: true, isEmpty: (v) => !v },
-    password:        { required: true, isEmpty: (v) => !v },
+    email: { required: true, isEmpty: (v) => !v },
+    password: { required: true, isEmpty: (v) => !v },
     confirmPassword: { required: true, isEmpty: (v) => !v },
-    companyName:     {},
-    companySize:     {},
+    companyName: {},
+    companySize: {},
   },
   rules: [
     requires('confirmPassword', 'password'),

--- a/packages/core/__tests__/challenge.test.ts
+++ b/packages/core/__tests__/challenge.test.ts
@@ -48,9 +48,13 @@ describe('challenge', () => {
         requires<TestFields, TestConditions>('submit', 'email', {
           reason: 'Enter a valid email address',
         }),
-        enabledWhen<TestFields, TestConditions>('submit', (values) => values.password === 'secret', {
-          reason: 'Enter a password',
-        }),
+        enabledWhen<TestFields, TestConditions>(
+          'submit',
+          (values) => values.password === 'secret',
+          {
+            reason: 'Enter a password',
+          },
+        ),
       ],
     })
 
@@ -173,8 +177,14 @@ describe('challenge', () => {
           expect.objectContaining({
             rule: 'anyOf',
             inner: [
-              expect.objectContaining({ rule: 'requires', dependency: 'startTime' }),
-              expect.objectContaining({ rule: 'enabledWhen', reason: 'fallback failed' }),
+              expect.objectContaining({
+                rule: 'requires',
+                dependency: 'startTime',
+              }),
+              expect.objectContaining({
+                rule: 'enabledWhen',
+                reason: 'fallback failed',
+              }),
             ],
           }),
         ],
@@ -218,7 +228,10 @@ describe('challenge', () => {
       method: 'auto-detected',
       branches: {
         hourList: { fields: ['everyHour'], anySatisfied: false },
-        interval: { fields: ['startTime', 'endTime', 'repeatEvery'], anySatisfied: true },
+        interval: {
+          fields: ['startTime', 'endTime', 'repeatEvery'],
+          anySatisfied: true,
+        },
       },
     })
     expect(challenge.directReasons).toEqual([
@@ -244,8 +257,12 @@ describe('challenge', () => {
       },
       rules: [
         anyOf<TestFields>(
-          enabledWhen<TestFields>('submit', () => false, { reason: 'first failed' }),
-          enabledWhen<TestFields>('submit', () => false, { reason: 'second failed' }),
+          enabledWhen<TestFields>('submit', () => false, {
+            reason: 'first failed',
+          }),
+          enabledWhen<TestFields>('submit', () => false, {
+            reason: 'second failed',
+          }),
         ),
       ],
     })
@@ -257,8 +274,16 @@ describe('challenge', () => {
         rule: 'anyOf',
         passed: false,
         inner: [
-          expect.objectContaining({ rule: 'enabledWhen', reason: 'first failed', passed: false }),
-          expect.objectContaining({ rule: 'enabledWhen', reason: 'second failed', passed: false }),
+          expect.objectContaining({
+            rule: 'enabledWhen',
+            reason: 'first failed',
+            passed: false,
+          }),
+          expect.objectContaining({
+            rule: 'enabledWhen',
+            reason: 'second failed',
+            passed: false,
+          }),
         ],
       }),
     ])
@@ -350,9 +375,7 @@ describe('challenge', () => {
       rules: [
         disables<TestFields>('dates', ['startTime']),
         eitherOf<TestFields>('endTimePaths', {
-          scheduled: [
-            requires('endTime', 'startTime'),
-          ],
+          scheduled: [requires('endTime', 'startTime')],
           fallback: [
             enabledWhen('endTime', () => false, { reason: 'fallback failed' }),
           ],
@@ -379,13 +402,19 @@ describe('challenge', () => {
               scheduled: {
                 passed: false,
                 inner: [
-                  expect.objectContaining({ rule: 'requires', dependency: 'startTime' }),
+                  expect.objectContaining({
+                    rule: 'requires',
+                    dependency: 'startTime',
+                  }),
                 ],
               },
               fallback: {
                 passed: false,
                 inner: [
-                  expect.objectContaining({ rule: 'enabledWhen', reason: 'fallback failed' }),
+                  expect.objectContaining({
+                    rule: 'enabledWhen',
+                    reason: 'fallback failed',
+                  }),
                 ],
               },
             },
@@ -415,12 +444,8 @@ describe('challenge', () => {
       rules: [
         disables<TestFields>('dates', ['endTime']),
         eitherOf<TestFields>('endTimePaths', {
-          scheduled: [
-            requires('endTime', 'startTime'),
-          ],
-          fallback: [
-            enabledWhen('endTime', () => true),
-          ],
+          scheduled: [requires('endTime', 'startTime')],
+          fallback: [enabledWhen('endTime', () => true)],
         }),
         requires<TestFields>('submit', 'endTime'),
       ],
@@ -438,7 +463,9 @@ describe('challenge', () => {
         reason: 'overridden by dates',
       }),
     ])
-    expect(challenge.transitiveDeps.map((entry) => entry.field)).not.toContain('startTime')
+    expect(challenge.transitiveDeps.map((entry) => entry.field)).not.toContain(
+      'startTime',
+    )
   })
 
   test('surfaces preserved field metadata for check()-based predicates', () => {
@@ -461,7 +488,10 @@ describe('challenge', () => {
         ),
         requires<TestFields>(
           'submit',
-          check('password', (value) => typeof value === 'string' && value.length >= 8),
+          check(
+            'password',
+            (value) => typeof value === 'string' && value.length >= 8,
+          ),
           { reason: 'Enter a longer password' },
         ),
         disables<TestFields>(
@@ -581,11 +611,16 @@ describe('challenge', () => {
             const matches = values.cpu === values.motherboard
 
             return new Map([
-              ['motherboard', {
-                enabled: true,
-                fair: matches,
-                reason: matches ? null : 'Selected motherboard no longer matches the CPU socket',
-              }],
+              [
+                'motherboard',
+                {
+                  enabled: true,
+                  fair: matches,
+                  reason: matches
+                    ? null
+                    : 'Selected motherboard no longer matches the CPU socket',
+                },
+              ],
             ])
           },
         }),

--- a/packages/core/__tests__/check.test.ts
+++ b/packages/core/__tests__/check.test.ts
@@ -32,14 +32,21 @@ describe('evaluate', () => {
       delta: {},
     }
     const rules = [
-      enabledWhen<TestFields, TestConditions>('beta', (values) => values.alpha === 'on', {
-        reason: 'alpha must be on',
-      }),
+      enabledWhen<TestFields, TestConditions>(
+        'beta',
+        (values) => values.alpha === 'on',
+        {
+          reason: 'alpha must be on',
+        },
+      ),
     ]
 
     const topoOrder = createOrder(fields, rules)
 
-    expect(evaluate(fields, rules, topoOrder, { alpha: 'on' }, {} as TestConditions).beta).toEqual({
+    expect(
+      evaluate(fields, rules, topoOrder, { alpha: 'on' }, {} as TestConditions)
+        .beta,
+    ).toEqual({
       enabled: true,
       satisfied: false,
       fair: true,
@@ -48,7 +55,8 @@ describe('evaluate', () => {
       reasons: [],
     })
     expect(
-      evaluate(fields, rules, topoOrder, { alpha: 'off' }, {} as TestConditions).beta,
+      evaluate(fields, rules, topoOrder, { alpha: 'off' }, {} as TestConditions)
+        .beta,
     ).toEqual({
       enabled: false,
       satisfied: false,
@@ -195,18 +203,29 @@ describe('evaluate', () => {
           const matches = values.alpha === values.beta
 
           return new Map([
-            ['beta', {
-              enabled: true,
-              fair: matches,
-              reason: matches ? null : 'socket mismatch',
-            }],
+            [
+              'beta',
+              {
+                enabled: true,
+                fair: matches,
+                reason: matches ? null : 'socket mismatch',
+              },
+            ],
           ])
         },
       }),
     ]
     const topoOrder = createOrder(fields, rules)
 
-    expect(evaluate(fields, rules, topoOrder, { alpha: 'am5', beta: 'am5' }, {} as TestConditions).beta).toEqual({
+    expect(
+      evaluate(
+        fields,
+        rules,
+        topoOrder,
+        { alpha: 'am5', beta: 'am5' },
+        {} as TestConditions,
+      ).beta,
+    ).toEqual({
       enabled: true,
       satisfied: true,
       fair: true,
@@ -215,7 +234,13 @@ describe('evaluate', () => {
       reasons: [],
     })
     expect(
-      evaluate(fields, rules, topoOrder, { alpha: 'am5', beta: 'lga1700' }, {} as TestConditions).beta,
+      evaluate(
+        fields,
+        rules,
+        topoOrder,
+        { alpha: 'am5', beta: 'lga1700' },
+        {} as TestConditions,
+      ).beta,
     ).toEqual({
       enabled: true,
       satisfied: true,
@@ -237,17 +262,23 @@ describe('evaluate', () => {
       type: 'silent',
       targets: ['beta'],
       sources: [],
-      evaluate: () => new Map([
-        ['beta', {
-          enabled: false,
-          reason: null,
-        }],
-      ]),
+      evaluate: () =>
+        new Map([
+          [
+            'beta',
+            {
+              enabled: false,
+              reason: null,
+            },
+          ],
+        ]),
     }
     const rules = [anyOf(silentRule, silentRule)]
     const topoOrder = createOrder(fields, rules)
 
-    expect(evaluate(fields, rules, topoOrder, {}, {} as TestConditions).beta).toEqual({
+    expect(
+      evaluate(fields, rules, topoOrder, {}, {} as TestConditions).beta,
+    ).toEqual({
       enabled: false,
       satisfied: false,
       fair: true,
@@ -268,13 +299,17 @@ describe('evaluate', () => {
       type: 'silent-fair',
       targets: ['delta'],
       sources: [],
-      evaluate: () => new Map([
-        ['delta', {
-          enabled: true,
-          fair: false,
-          reason: null,
-        }],
-      ]),
+      evaluate: () =>
+        new Map([
+          [
+            'delta',
+            {
+              enabled: true,
+              fair: false,
+              reason: null,
+            },
+          ],
+        ]),
       _umpire: {
         kind: 'fairWhen' as const,
         predicate: (() => false) as never,
@@ -377,13 +412,17 @@ describe('evaluate', () => {
       type: 'empty-reasons',
       targets: ['alpha'],
       sources: [],
-      evaluate: () => new Map([
-        ['alpha', {
-          enabled: false,
-          reason: 'empty reasons',
-          reasons: [],
-        }],
-      ]),
+      evaluate: () =>
+        new Map([
+          [
+            'alpha',
+            {
+              enabled: false,
+              reason: 'empty reasons',
+              reasons: [],
+            },
+          ],
+        ]),
     }
 
     expect(
@@ -419,10 +458,38 @@ describe('evaluate', () => {
     const result = evaluate(fields, rules, topoOrder, {}, {} as TestConditions)
 
     expect(result).toEqual({
-      alpha: { enabled: true, satisfied: false, fair: true, required: true, reason: null, reasons: [] },
-      beta: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
-      gamma: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
-      delta: { enabled: true, satisfied: false, fair: true, required: true, reason: null, reasons: [] },
+      alpha: {
+        enabled: true,
+        satisfied: false,
+        fair: true,
+        required: true,
+        reason: null,
+        reasons: [],
+      },
+      beta: {
+        enabled: true,
+        satisfied: false,
+        fair: true,
+        required: false,
+        reason: null,
+        reasons: [],
+      },
+      gamma: {
+        enabled: true,
+        satisfied: false,
+        fair: true,
+        required: false,
+        reason: null,
+        reasons: [],
+      },
+      delta: {
+        enabled: true,
+        satisfied: false,
+        fair: true,
+        required: true,
+        reason: null,
+        reasons: [],
+      },
     })
   })
 })

--- a/packages/core/__tests__/edge-cases.test.ts
+++ b/packages/core/__tests__/edge-cases.test.ts
@@ -1,5 +1,12 @@
 import { field } from '../src/field.js'
-import { anyOf, check, disables, enabledWhen, oneOf, requires } from '../src/rules.js'
+import {
+  anyOf,
+  check,
+  disables,
+  enabledWhen,
+  oneOf,
+  requires,
+} from '../src/rules.js'
 import { umpire } from '../src/umpire.js'
 
 type TestFields = {
@@ -22,10 +29,38 @@ describe('edge cases', () => {
     })
 
     expect(ump.check({})).toEqual({
-      alpha: { enabled: true, satisfied: false, fair: true, required: true, reason: null, reasons: [] },
-      beta: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
-      gamma: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
-      delta: { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] },
+      alpha: {
+        enabled: true,
+        satisfied: false,
+        fair: true,
+        required: true,
+        reason: null,
+        reasons: [],
+      },
+      beta: {
+        enabled: true,
+        satisfied: false,
+        fair: true,
+        required: false,
+        reason: null,
+        reasons: [],
+      },
+      gamma: {
+        enabled: true,
+        satisfied: false,
+        fair: true,
+        required: false,
+        reason: null,
+        reasons: [],
+      },
+      delta: {
+        enabled: true,
+        satisfied: false,
+        fair: true,
+        required: false,
+        reason: null,
+        reasons: [],
+      },
     })
   })
 
@@ -40,8 +75,12 @@ describe('edge cases', () => {
       rules: [
         enabledWhen<TestFields>('beta', (values) => values.alpha === 'ready'),
         anyOf<TestFields>(
-          enabledWhen<TestFields>('gamma', () => true, { reason: 'first failed' }),
-          enabledWhen<TestFields>('gamma', () => false, { reason: 'second failed' }),
+          enabledWhen<TestFields>('gamma', () => true, {
+            reason: 'first failed',
+          }),
+          enabledWhen<TestFields>('gamma', () => false, {
+            reason: 'second failed',
+          }),
         ),
         requires<TestFields>('delta', 'beta'),
       ],
@@ -63,7 +102,9 @@ describe('edge cases', () => {
         delta: {},
       },
       rules: [
-        enabledWhen<TestFields>('delta', () => false, { reason: 'first failure' }),
+        enabledWhen<TestFields>('delta', () => false, {
+          reason: 'first failure',
+        }),
         requires<TestFields>('delta', 'beta', { reason: 'second failure' }),
       ],
     })
@@ -109,7 +150,10 @@ describe('edge cases', () => {
           delta: {},
         },
         rules: [
-          enabledWhen<TestFields>('alpha', check('missing' as keyof TestFields & string, () => true)),
+          enabledWhen<TestFields>(
+            'alpha',
+            check('missing' as keyof TestFields & string, () => true),
+          ),
         ],
       }),
     ).toThrow('Unknown field "missing" referenced by enabledWhen rule')
@@ -167,10 +211,7 @@ describe('edge cases', () => {
           gamma: field<string>('gamma'),
           delta,
         },
-        rules: [
-          disables(beta, [delta]),
-          requires(delta, beta),
-        ],
+        rules: [disables(beta, [delta]), requires(delta, beta)],
       }),
     ).toThrow(
       'Contradictory rules: "delta" can never be enabled because it requires "beta", but is disabled whenever "beta" is satisfied',
@@ -191,7 +232,10 @@ describe('edge cases', () => {
             first: ['alpha'],
             second: ['beta'],
           }),
-          requires<TestFields>('alpha', check('beta', (value) => value === 'ready')),
+          requires<TestFields>(
+            'alpha',
+            check('beta', (value) => value === 'ready'),
+          ),
         ],
       }),
     ).toThrow(
@@ -234,13 +278,17 @@ describe('edge cases', () => {
           delta: {},
         },
         rules: [
-          oneOf<TestFields, { mode: string }>('strategy', {
-            first: ['alpha'],
-            second: ['beta'],
-          }, {
-            activeBranch: (_values, conditions) =>
-              conditions.mode === 'all-open' ? null : 'first',
-          }),
+          oneOf<TestFields, { mode: string }>(
+            'strategy',
+            {
+              first: ['alpha'],
+              second: ['beta'],
+            },
+            {
+              activeBranch: (_values, conditions) =>
+                conditions.mode === 'all-open' ? null : 'first',
+            },
+          ),
           requires<TestFields, { mode: string }>('alpha', 'beta'),
         ],
       }),
@@ -249,15 +297,18 @@ describe('edge cases', () => {
 
   test('precomputes rule target lookups at construction time', () => {
     let targetReads = 0
-    const countedRule = new Proxy(enabledWhen<TestFields>('alpha', () => true), {
-      get(target, prop, receiver) {
-        if (prop === 'targets') {
-          targetReads += 1
-        }
+    const countedRule = new Proxy(
+      enabledWhen<TestFields>('alpha', () => true),
+      {
+        get(target, prop, receiver) {
+          if (prop === 'targets') {
+            targetReads += 1
+          }
 
-        return Reflect.get(target, prop, receiver)
+          return Reflect.get(target, prop, receiver)
+        },
       },
-    })
+    )
 
     const ump = umpire<TestFields>({
       fields: {

--- a/packages/core/__tests__/edge-cases.test.ts
+++ b/packages/core/__tests__/edge-cases.test.ts
@@ -144,6 +144,8 @@ describe('edge cases', () => {
           delta: {},
         },
         rules: [
+          // intentionally disabled because we're breaking this on purpose haha
+          // eslint-disable-next-line @umpire/no-contradicting-rules
           disables<TestFields>('beta', ['delta']),
           requires<TestFields>('delta', 'beta'),
         ],

--- a/packages/core/__tests__/emptiness.test.ts
+++ b/packages/core/__tests__/emptiness.test.ts
@@ -41,7 +41,9 @@ describe('emptiness helpers', () => {
     expect(isEmptyObject([])).toBe(true)
     expect(isEmptyObject(undefined)).toBe(true)
     expect(isSatisfied({}, { isEmpty: isEmptyObject })).toBe(false)
-    expect(isSatisfied({ theme: 'dark' }, { isEmpty: isEmptyObject })).toBe(true)
+    expect(isSatisfied({ theme: 'dark' }, { isEmpty: isEmptyObject })).toBe(
+      true,
+    )
   })
 
   test('re-exports eitherOf from the public entrypoint', () => {

--- a/packages/core/__tests__/fair-when.test.ts
+++ b/packages/core/__tests__/fair-when.test.ts
@@ -6,7 +6,9 @@ describe('fairWhen', () => {
   test('marks a present value as fouled without disabling the field', () => {
     const ump = umpire({
       fields: {
-        cpu: field<string>().required().isEmpty((value) => !value),
+        cpu: field<string>()
+          .required()
+          .isEmpty((value) => !value),
         motherboard: field<string>()
           .required()
           .isEmpty((value) => !value)
@@ -115,7 +117,9 @@ describe('fairWhen', () => {
         fairWhen('motherboard', (value, values) => value === values.cpu, {
           reason: 'Motherboard no longer matches the selected CPU',
         }),
-        requires('ram', 'motherboard', { reason: 'Pick a valid motherboard first' }),
+        requires('ram', 'motherboard', {
+          reason: 'Pick a valid motherboard first',
+        }),
       ],
     })
 
@@ -158,8 +162,12 @@ describe('fairWhen', () => {
       },
       rules: [
         anyOf(
-          fairWhen('selection', (value) => value === 'alpha', { reason: 'Must be alpha' }),
-          fairWhen('selection', (value) => value === 'omega', { reason: 'Must be omega' }),
+          fairWhen('selection', (value) => value === 'alpha', {
+            reason: 'Must be alpha',
+          }),
+          fairWhen('selection', (value) => value === 'omega', {
+            reason: 'Must be omega',
+          }),
         ),
       ],
     })
@@ -214,7 +222,9 @@ describe('field()', () => {
       toggle: false,
       details: 'auto',
     })
-    expect(ump.init({ details: 'manual', missing: 'ignored' } as never)).toEqual({
+    expect(
+      ump.init({ details: 'manual', missing: 'ignored' } as never),
+    ).toEqual({
       toggle: false,
       details: 'manual',
     })
@@ -229,8 +239,12 @@ describe('field()', () => {
   })
 
   test('lets named builders target top-level rules', () => {
-    const cpu = field<string>('cpu').required().isEmpty((value) => !value)
-    const motherboard = field<string>('motherboard').required().isEmpty((value) => !value)
+    const cpu = field<string>('cpu')
+      .required()
+      .isEmpty((value) => !value)
+    const motherboard = field<string>('motherboard')
+      .required()
+      .isEmpty((value) => !value)
 
     const ump = umpire({
       fields: {
@@ -261,7 +275,9 @@ describe('field()', () => {
   })
 
   test('supports named builders in attached requires() rules', () => {
-    const cpu = field<string>('cpu').required().isEmpty((value) => !value)
+    const cpu = field<string>('cpu')
+      .required()
+      .isEmpty((value) => !value)
     const motherboard = field<string>('motherboard')
       .required()
       .isEmpty((value) => !value)
@@ -295,18 +311,22 @@ describe('field()', () => {
         },
         rules: [],
       }),
-    ).toThrow('Named field builder "motherboard" does not match field key "board"')
+    ).toThrow(
+      'Named field builder "motherboard" does not match field key "board"',
+    )
   })
 
   test('throws when an unnamed builder is passed directly to a top-level rule', () => {
-    expect(() =>
-      requires(field<string>(), 'cpu'),
-    ).toThrow('Named field builder required when passing a field() value to a rule')
+    expect(() => requires(field<string>(), 'cpu')).toThrow(
+      'Named field builder required when passing a field() value to a rule',
+    )
   })
 
   test('throws when an unnamed builder is used in an attached requires() rule', () => {
     expect(() =>
       field<string>('motherboard').requires(field<string>()),
-    ).toThrow('Named field builder required when passing a field() value to a rule')
+    ).toThrow(
+      'Named field builder required when passing a field() value to a rule',
+    )
   })
 })

--- a/packages/core/__tests__/field-status-satisfied.test.ts
+++ b/packages/core/__tests__/field-status-satisfied.test.ts
@@ -1,4 +1,9 @@
-import { isEmptyArray, isEmptyObject, isEmptyPresent, isEmptyString } from '../src/emptiness.js'
+import {
+  isEmptyArray,
+  isEmptyObject,
+  isEmptyPresent,
+  isEmptyString,
+} from '../src/emptiness.js'
 import { umpire } from '../src/umpire.js'
 
 describe('check() field status satisfied', () => {
@@ -9,7 +14,9 @@ describe('check() field status satisfied', () => {
         stringField: { isEmpty: isEmptyString },
         arrayField: { isEmpty: isEmptyArray },
         objectField: { isEmpty: isEmptyObject },
-        numberField: { isEmpty: (value) => typeof value !== 'number' || Number.isNaN(value) },
+        numberField: {
+          isEmpty: (value) => typeof value !== 'number' || Number.isNaN(value),
+        },
         booleanField: { isEmpty: (value) => typeof value !== 'boolean' },
       },
       rules: [],

--- a/packages/core/__tests__/graph.test.ts
+++ b/packages/core/__tests__/graph.test.ts
@@ -1,5 +1,18 @@
-import { check, defineRule, disables, eitherOf, enabledWhen, oneOf, requires } from '../src/rules.js'
-import { buildGraph, detectCycles, exportGraph, topologicalSort } from '../src/graph.js'
+import {
+  check,
+  defineRule,
+  disables,
+  eitherOf,
+  enabledWhen,
+  oneOf,
+  requires,
+} from '../src/rules.js'
+import {
+  buildGraph,
+  detectCycles,
+  exportGraph,
+  topologicalSort,
+} from '../src/graph.js'
 
 type TestFields = {
   alpha: {}
@@ -23,7 +36,9 @@ describe('graph utilities', () => {
       requires<TestFields>('beta', 'alpha'),
     ])
 
-    expect(() => detectCycles(graph)).toThrow(/Cycle detected: (alpha → beta → alpha|beta → alpha → beta)/)
+    expect(() => detectCycles(graph)).toThrow(
+      /Cycle detected: (alpha → beta → alpha|beta → alpha → beta)/,
+    )
   })
 
   test('detects a transitive cycle', () => {
@@ -117,7 +132,10 @@ describe('graph utilities', () => {
       epsilon: {},
     }
     const graph = buildGraph(fields, [
-      enabledWhen<TestFields>('beta', check('alpha', (value) => value === 'ready')),
+      enabledWhen<TestFields>(
+        'beta',
+        check('alpha', (value) => value === 'ready'),
+      ),
       requires<TestFields>('alpha', 'beta'),
     ])
 
@@ -151,11 +169,14 @@ describe('graph utilities', () => {
         constraint: 'fair',
         evaluate(values) {
           return new Map([
-            ['beta', {
-              enabled: true,
-              fair: values.alpha === values.beta,
-              reason: values.alpha === values.beta ? null : 'socket mismatch',
-            }],
+            [
+              'beta',
+              {
+                enabled: true,
+                fair: values.alpha === values.beta,
+                reason: values.alpha === values.beta ? null : 'socket mismatch',
+              },
+            ],
           ])
         },
       }),
@@ -213,11 +234,12 @@ describe('graph utilities', () => {
     }
     const graph = buildGraph(fields, [
       eitherOf<TestFields>('betaPaths', {
-        dependency: [
-          requires('beta', 'alpha'),
-        ],
+        dependency: [requires('beta', 'alpha')],
         conditional: [
-          enabledWhen('beta', check('gamma', (value) => value === 'ready')),
+          enabledWhen(
+            'beta',
+            check('gamma', (value) => value === 'ready'),
+          ),
         ],
       }),
     ])
@@ -250,9 +272,18 @@ describe('graph utilities', () => {
       requires<TestFields>('beta', 'alpha'),
       requires<TestFields>('beta', 'alpha'),
       requires<TestFields>('alpha', 'alpha'),
-      enabledWhen<TestFields>('beta', check('alpha', (value) => value === 'ready')),
-      enabledWhen<TestFields>('beta', check('alpha', (value) => value === 'ready')),
-      enabledWhen<TestFields>('alpha', check('alpha', (value) => value === 'ready')),
+      enabledWhen<TestFields>(
+        'beta',
+        check('alpha', (value) => value === 'ready'),
+      ),
+      enabledWhen<TestFields>(
+        'beta',
+        check('alpha', (value) => value === 'ready'),
+      ),
+      enabledWhen<TestFields>(
+        'alpha',
+        check('alpha', (value) => value === 'ready'),
+      ),
     ])
 
     expect(graph.edges).toEqual([
@@ -316,7 +347,9 @@ describe('graph utilities', () => {
 
     graph.edges = new Proxy(graph.edges, {
       get(_target, prop) {
-        throw new Error(`graph.edges should not be accessed during ordering work (${String(prop)})`)
+        throw new Error(
+          `graph.edges should not be accessed during ordering work (${String(prop)})`,
+        )
       },
     })
 

--- a/packages/core/__tests__/helpers/minesweeper-engine.ts
+++ b/packages/core/__tests__/helpers/minesweeper-engine.ts
@@ -30,9 +30,14 @@ export type GameConditions = {
 // ── Helpers ────────────────────────────────────────────────────────────
 
 const OFFSETS = [
-  [-1, -1], [0, -1], [1, -1],
-  [-1,  0],          [1,  0],
-  [-1,  1], [0,  1], [1,  1],
+  [-1, -1],
+  [0, -1],
+  [1, -1],
+  [-1, 0],
+  [1, 0],
+  [-1, 1],
+  [0, 1],
+  [1, 1],
 ] as const
 
 export function cellKey(x: number, y: number): string {
@@ -161,7 +166,9 @@ export function checkWin(board: Board, values: Values): boolean {
 
 // ── Umpire integration ────────────────────────────────────────────────
 
-export function createMinesweeperUmpire(board: Board): Umpire<Record<string, FieldDef>, GameConditions> {
+export function createMinesweeperUmpire(
+  board: Board,
+): Umpire<Record<string, FieldDef>, GameConditions> {
   const keys = Object.keys(board)
 
   const fields: Record<string, FieldDef> = {}
@@ -169,11 +176,15 @@ export function createMinesweeperUmpire(board: Board): Umpire<Record<string, Fie
     fields[key] = { default: undefined }
   }
 
-  const rules = keys.flatMap(key => [
+  const rules = keys.flatMap((key) => [
     // Gate 1: game must be in play
-    enabledWhen(key, (_: unknown, c: GameConditions) => c.gameStatus === 'playing', {
-      reason: 'GAME_OVER',
-    }),
+    enabledWhen(
+      key,
+      (_: unknown, c: GameConditions) => c.gameStatus === 'playing',
+      {
+        reason: 'GAME_OVER',
+      },
+    ),
 
     // Gate 2: cell not already revealed
     enabledWhen(key, (values: Values) => values[key] !== 'revealed', {
@@ -181,15 +192,22 @@ export function createMinesweeperUmpire(board: Board): Umpire<Record<string, Fie
     }),
 
     // Gate 3: flag interaction gating
-    enabledWhen(key, (values: Values, c: GameConditions) => {
-      if (c.flagMode) return true       // flag mode: can always interact (unflag)
-      return values[key] !== 'flagged'  // reveal mode: blocked by flag
-    }, {
-      reason: 'FLAGGED',
-    }),
+    enabledWhen(
+      key,
+      (values: Values, c: GameConditions) => {
+        if (c.flagMode) return true // flag mode: can always interact (unflag)
+        return values[key] !== 'flagged' // reveal mode: blocked by flag
+      },
+      {
+        reason: 'FLAGGED',
+      },
+    ),
   ])
 
-  return umpire({ fields, rules }) as Umpire<Record<string, FieldDef>, GameConditions>
+  return umpire({ fields, rules }) as Umpire<
+    Record<string, FieldDef>,
+    GameConditions
+  >
 }
 
 // ── Convenience: build a ready-to-play board ──────────────────────────

--- a/packages/core/__tests__/minesweeper.test.ts
+++ b/packages/core/__tests__/minesweeper.test.ts
@@ -32,7 +32,10 @@ import {
 
 // ── Shared fixtures ────────────────────────────────────────────────────
 
-const MINES: Array<[number, number]> = [[1, 1], [2, 3]]
+const MINES: Array<[number, number]> = [
+  [1, 1],
+  [2, 3],
+]
 let board: Board
 
 beforeEach(() => {
@@ -40,7 +43,10 @@ beforeEach(() => {
 })
 
 const playing: GameConditions = { gameStatus: 'playing', flagMode: false }
-const playingFlagMode: GameConditions = { gameStatus: 'playing', flagMode: true }
+const playingFlagMode: GameConditions = {
+  gameStatus: 'playing',
+  flagMode: true,
+}
 const lost: GameConditions = { gameStatus: 'lost', flagMode: false }
 const won: GameConditions = { gameStatus: 'won', flagMode: false }
 
@@ -231,7 +237,7 @@ describe('minesweeper × umpire', () => {
 
     // Cell was enabled+flagged before, now disabled+revealed.
     // play() should report a foul recommending cleanup.
-    const c30Foul = fouls.find(f => f.field === cellKey(3, 0))
+    const c30Foul = fouls.find((f) => f.field === cellKey(3, 0))
     expect(c30Foul).toBeDefined()
     expect(c30Foul!.suggestedValue).toBeUndefined()
   })

--- a/packages/core/__tests__/oneOf.test.ts
+++ b/packages/core/__tests__/oneOf.test.ts
@@ -127,7 +127,10 @@ describe('oneOf resolution', () => {
             first: ['alpha'],
             second: ['beta'],
           },
-          { activeBranch: (values) => (values.mode === 'second' ? 'second' : 'first') },
+          {
+            activeBranch: (values) =>
+              values.mode === 'second' ? 'second' : 'first',
+          },
         ),
       ],
     })
@@ -171,7 +174,10 @@ describe('oneOf resolution', () => {
             vsLefty: ['alpha'],
             vsRighty: ['beta'],
           },
-          { activeBranch: (_values, conditions) => conditions.pitcher === 'L' ? 'vsLefty' : 'vsRighty' },
+          {
+            activeBranch: (_values, conditions) =>
+              conditions.pitcher === 'L' ? 'vsLefty' : 'vsRighty',
+          },
         ),
       ],
     })

--- a/packages/core/__tests__/play.test.ts
+++ b/packages/core/__tests__/play.test.ts
@@ -19,7 +19,12 @@ describe('play', () => {
         dependent: {},
         other: {},
       },
-      rules: [enabledWhen<TestFields, TestConditions>('dependent', (values) => values.toggle === true)],
+      rules: [
+        enabledWhen<TestFields, TestConditions>(
+          'dependent',
+          (values) => values.toggle === true,
+        ),
+      ],
     })
 
     const recommendations = ump.play(
@@ -43,7 +48,12 @@ describe('play', () => {
         dependent: {},
         other: {},
       },
-      rules: [enabledWhen<TestFields, TestConditions>('dependent', (values) => values.toggle === true)],
+      rules: [
+        enabledWhen<TestFields, TestConditions>(
+          'dependent',
+          (values) => values.toggle === true,
+        ),
+      ],
     })
 
     const recommendations = ump.play(
@@ -61,7 +71,12 @@ describe('play', () => {
         dependent: { isEmpty: (value) => value === '' || value == null },
         other: {},
       },
-      rules: [enabledWhen<TestFields, TestConditions>('dependent', (values) => values.toggle === true)],
+      rules: [
+        enabledWhen<TestFields, TestConditions>(
+          'dependent',
+          (values) => values.toggle === true,
+        ),
+      ],
     })
 
     const recommendations = ump.play(
@@ -79,7 +94,12 @@ describe('play', () => {
         dependent: { default: '09:00' },
         other: {},
       },
-      rules: [enabledWhen<TestFields, TestConditions>('dependent', (values) => values.toggle === true)],
+      rules: [
+        enabledWhen<TestFields, TestConditions>(
+          'dependent',
+          (values) => values.toggle === true,
+        ),
+      ],
     })
 
     const recommendations = ump.play(
@@ -98,8 +118,14 @@ describe('play', () => {
         other: {},
       },
       rules: [
-        enabledWhen<TestFields, TestConditions>('dependent', (values) => values.toggle === true),
-        enabledWhen<TestFields, TestConditions>('other', (values) => values.toggle === true),
+        enabledWhen<TestFields, TestConditions>(
+          'dependent',
+          (values) => values.toggle === true,
+        ),
+        enabledWhen<TestFields, TestConditions>(
+          'other',
+          (values) => values.toggle === true,
+        ),
       ],
     })
 
@@ -109,8 +135,16 @@ describe('play', () => {
     )
 
     expect(recommendations).toEqual([
-      { field: 'dependent', reason: 'condition not met', suggestedValue: '09:00' },
-      { field: 'other', reason: 'condition not met', suggestedValue: undefined },
+      {
+        field: 'dependent',
+        reason: 'condition not met',
+        suggestedValue: '09:00',
+      },
+      {
+        field: 'other',
+        reason: 'condition not met',
+        suggestedValue: undefined,
+      },
     ])
   })
 
@@ -152,13 +186,23 @@ describe('play', () => {
         other: { default: '09:00' },
       },
       rules: [
-        enabledWhen<TestFields, TestConditions>('dependent', (values) => values.toggle === true),
-        enabledWhen<TestFields, TestConditions>('other', (values) => values.toggle === true),
+        enabledWhen<TestFields, TestConditions>(
+          'dependent',
+          (values) => values.toggle === true,
+        ),
+        enabledWhen<TestFields, TestConditions>(
+          'other',
+          (values) => values.toggle === true,
+        ),
       ],
     })
 
-    const before = { values: { toggle: true, dependent: 'stale', other: '12:00' } }
-    const after = { values: { toggle: false, dependent: 'stale', other: '12:00' } }
+    const before = {
+      values: { toggle: true, dependent: 'stale', other: '12:00' },
+    }
+    const after = {
+      values: { toggle: false, dependent: 'stale', other: '12:00' },
+    }
     const recommendations = ump.play(before, after)
 
     const resetValues = { ...after.values }

--- a/packages/core/__tests__/rules.test.ts
+++ b/packages/core/__tests__/rules.test.ts
@@ -67,27 +67,41 @@ describe('enabledWhen', () => {
     const dynamicReasonRule = enabledWhen<TestFields, TestConditions>(
       'alpha',
       () => false,
-      { reason: (_values, conditions) => (conditions.allow ? 'allowed' : 'denied') },
+      {
+        reason: (_values, conditions) =>
+          conditions.allow ? 'allowed' : 'denied',
+      },
     )
 
-    expect(staticReasonRule.evaluate({}, { allow: false }).get('alpha')?.reason).toBe('blocked')
-    expect(dynamicReasonRule.evaluate({}, { allow: false }).get('alpha')?.reason).toBe('denied')
+    expect(
+      staticReasonRule.evaluate({}, { allow: false }).get('alpha')?.reason,
+    ).toBe('blocked')
+    expect(
+      dynamicReasonRule.evaluate({}, { allow: false }).get('alpha')?.reason,
+    ).toBe('denied')
   })
 })
 
 describe('disables', () => {
   test('with field name source uses source metadata and satisfaction semantics', () => {
-    const rule = disables<TestFields, TestConditions>('beta', ['alpha', 'gamma'])
+    const rule = disables<TestFields, TestConditions>('beta', [
+      'alpha',
+      'gamma',
+    ])
 
     expect(rule.type).toBe('disables')
     expect(rule.sources).toEqual(['beta'])
     expect(rule.targets).toEqual(['alpha', 'gamma'])
 
-    expect(rule.evaluate({ beta: 'present' }, { allow: true }).get('alpha')).toEqual({
+    expect(
+      rule.evaluate({ beta: 'present' }, { allow: true }).get('alpha'),
+    ).toEqual({
       enabled: false,
       reason: 'overridden by beta',
     })
-    expect(rule.evaluate({ beta: undefined }, { allow: true }).get('alpha')).toEqual({
+    expect(
+      rule.evaluate({ beta: undefined }, { allow: true }).get('alpha'),
+    ).toEqual({
       enabled: true,
       reason: null,
     })
@@ -101,7 +115,9 @@ describe('disables', () => {
 
     expect(rule.sources).toEqual(['beta'])
     expect(rule.targets).toEqual(['alpha', 'gamma'])
-    expect(rule.evaluate({ beta: 'present' }, { allow: true }).get('alpha')).toEqual({
+    expect(
+      rule.evaluate({ beta: 'present' }, { allow: true }).get('alpha'),
+    ).toEqual({
       enabled: false,
       reason: 'overridden by beta',
     })
@@ -118,24 +134,25 @@ describe('disables', () => {
   })
 
   test('with check() source extracts the source field', () => {
-    const rule = disables<TestFields, TestConditions>(check('beta', (value) => value === 'ok'), [
-      'alpha',
-    ])
+    const rule = disables<TestFields, TestConditions>(
+      check('beta', (value) => value === 'ok'),
+      ['alpha'],
+    )
 
     expect(rule.sources).toEqual(['beta'])
-    expect(rule.evaluate({ beta: 'ok' }, { allow: true }).get('alpha')?.reason).toBe(
-      'overridden by beta',
-    )
+    expect(
+      rule.evaluate({ beta: 'ok' }, { allow: true }).get('alpha')?.reason,
+    ).toBe('overridden by beta')
   })
 
   test('requires named builders when passing builders to source or targets', () => {
-    expect(() =>
-      disables(field<string>(), ['alpha']),
-    ).toThrow('Named field builder required when passing a field() value to a rule')
+    expect(() => disables(field<string>(), ['alpha'])).toThrow(
+      'Named field builder required when passing a field() value to a rule',
+    )
 
-    expect(() =>
-      disables('beta', [field<string>()]),
-    ).toThrow('Named field builder required when passing a field() value to a rule')
+    expect(() => disables('beta', [field<string>()])).toThrow(
+      'Named field builder required when passing a field() value to a rule',
+    )
   })
 })
 
@@ -146,7 +163,9 @@ describe('requires', () => {
     expect(rule.type).toBe('requires')
     expect(rule.targets).toEqual(['alpha'])
     expect(rule.sources).toEqual(['beta'])
-    expect(rule.evaluate({ beta: undefined }, { allow: true }).get('alpha')).toMatchObject({
+    expect(
+      rule.evaluate({ beta: undefined }, { allow: true }).get('alpha'),
+    ).toMatchObject({
       enabled: false,
       reason: 'requires beta',
     })
@@ -163,16 +182,22 @@ describe('requires', () => {
 
     expect(rule.targets).toEqual(['alpha'])
     expect(rule.sources).toEqual(['beta'])
-    expect(rule.evaluate({ beta: undefined }, { allow: true }).get('alpha')).toMatchObject({
+    expect(
+      rule.evaluate({ beta: undefined }, { allow: true }).get('alpha'),
+    ).toMatchObject({
       enabled: false,
       reason: 'requires beta',
     })
   })
 
   test('detects options when the last arg has a reason property', () => {
-    const rule = requires<TestFields, TestConditions>('alpha', 'beta', { reason: 'custom reason' })
+    const rule = requires<TestFields, TestConditions>('alpha', 'beta', {
+      reason: 'custom reason',
+    })
 
-    expect(rule.evaluate({ beta: undefined }, { allow: true }).get('alpha')).toMatchObject({
+    expect(
+      rule.evaluate({ beta: undefined }, { allow: true }).get('alpha'),
+    ).toMatchObject({
       enabled: false,
       reason: 'custom reason',
     })
@@ -193,14 +218,16 @@ describe('requires', () => {
 
   test('throws when no dependencies are provided', () => {
     expect(() =>
-      requires<TestFields, TestConditions>('alpha', { reason: 'custom reason' }),
+      requires<TestFields, TestConditions>('alpha', {
+        reason: 'custom reason',
+      }),
     ).toThrow('requires("alpha") requires at least one dependency')
   })
 
   test('requires named builders when passing builders as dependencies', () => {
-    expect(() =>
-      requires('alpha', field<string>()),
-    ).toThrow('Named field builder required when passing a field() value to a rule')
+    expect(() => requires('alpha', field<string>())).toThrow(
+      'Named field builder required when passing a field() value to a rule',
+    )
   })
 })
 
@@ -235,7 +262,9 @@ describe('oneOf', () => {
         first: [field<string>()],
         second: ['beta'],
       }),
-    ).toThrow('Named field builder required when passing a field() value to a rule')
+    ).toThrow(
+      'Named field builder required when passing a field() value to a rule',
+    )
   })
 
   test('returns all fields as targets', () => {
@@ -259,7 +288,9 @@ describe('oneOf', () => {
 
     expect(rule.targets).toEqual(['alpha', 'beta', 'gamma'])
     expect(rule.sources).toEqual(['alpha', 'beta', 'gamma'])
-    expect(rule.evaluate({ beta: 'active' }, { allow: true }).get('alpha')).toEqual({
+    expect(
+      rule.evaluate({ beta: 'active' }, { allow: true }).get('alpha'),
+    ).toEqual({
       enabled: false,
       reason: 'conflicts with second strategy',
     })
@@ -332,10 +363,15 @@ describe('oneOf', () => {
         first: ['alpha'],
         second: ['beta'],
       },
-      { activeBranch: (values) => (values.delta === 'pick-second' ? 'second' : 'first') },
+      {
+        activeBranch: (values) =>
+          values.delta === 'pick-second' ? 'second' : 'first',
+      },
     )
 
-    expect(rule.evaluate({ delta: 'pick-second' }, { allow: true }).get('alpha')).toEqual({
+    expect(
+      rule.evaluate({ delta: 'pick-second' }, { allow: true }).get('alpha'),
+    ).toEqual({
       enabled: false,
       reason: 'conflicts with second strategy',
     })
@@ -411,7 +447,11 @@ describe('oneOf', () => {
         second: ['beta'],
       })
 
-      expect(rule.evaluate({ alpha: 'set', beta: 'set' }, { allow: true }).get('beta')).toEqual({
+      expect(
+        rule
+          .evaluate({ alpha: 'set', beta: 'set' }, { allow: true })
+          .get('beta'),
+      ).toEqual({
         enabled: false,
         reason: 'conflicts with first strategy',
       })
@@ -483,18 +523,19 @@ describe('anyOf', () => {
     )
 
     expect(
-      rule.evaluate(
-        { beta: 'stale' },
-        { allow: true },
-        undefined,
-        fields,
-        {
+      rule
+        .evaluate({ beta: 'stale' }, { allow: true }, undefined, fields, {
           alpha: { enabled: true, required: false, reason: null, reasons: [] },
-          beta: { enabled: false, required: false, reason: 'disabled', reasons: ['disabled'] },
+          beta: {
+            enabled: false,
+            required: false,
+            reason: 'disabled',
+            reasons: ['disabled'],
+          },
           gamma: { enabled: true, required: false, reason: null, reasons: [] },
           delta: { enabled: true, required: false, reason: null, reasons: [] },
-        },
-      ).get('gamma'),
+        })
+        .get('gamma'),
     ).toEqual({
       enabled: false,
       reason: 'need beta',
@@ -531,24 +572,18 @@ describe('eitherOf', () => {
   test('validates that all inner rules share the same constraint', () => {
     expect(() =>
       eitherOf<TestFields, TestConditions>('auth', {
-        sso: [
-          enabledWhen('alpha', () => true),
-        ],
-        password: [
-          fairWhen('alpha', () => true),
-        ],
+        sso: [enabledWhen('alpha', () => true)],
+        password: [fairWhen('alpha', () => true)],
       }),
-    ).toThrow('eitherOf("auth") cannot mix fairWhen rules with availability rules')
+    ).toThrow(
+      'eitherOf("auth") cannot mix fairWhen rules with availability rules',
+    )
   })
 
   test('passes if one branch passes', () => {
     const rule = eitherOf<TestFields, TestConditions>('auth', {
-      sso: [
-        enabledWhen('alpha', () => false, { reason: 'sso unavailable' }),
-      ],
-      password: [
-        enabledWhen('alpha', () => true, { reason: 'need password' }),
-      ],
+      sso: [enabledWhen('alpha', () => false, { reason: 'sso unavailable' })],
+      password: [enabledWhen('alpha', () => true, { reason: 'need password' })],
     })
 
     expect(rule.evaluate({}, { allow: false }).get('alpha')).toEqual({
@@ -559,12 +594,8 @@ describe('eitherOf', () => {
 
   test('passes if multiple branches pass', () => {
     const rule = eitherOf<TestFields, TestConditions>('auth', {
-      sso: [
-        enabledWhen('alpha', () => true, { reason: 'sso unavailable' }),
-      ],
-      password: [
-        enabledWhen('alpha', () => true, { reason: 'need password' }),
-      ],
+      sso: [enabledWhen('alpha', () => true, { reason: 'sso unavailable' })],
+      password: [enabledWhen('alpha', () => true, { reason: 'need password' })],
       magicLink: [
         enabledWhen('alpha', () => false, { reason: 'magic link unavailable' }),
       ],
@@ -578,9 +609,7 @@ describe('eitherOf', () => {
 
   test('collects flattened failure reasons in branch order when every branch fails', () => {
     const rule = eitherOf<TestFields, TestConditions>('auth', {
-      sso: [
-        enabledWhen('alpha', () => false, { reason: 'sso unavailable' }),
-      ],
+      sso: [enabledWhen('alpha', () => false, { reason: 'sso unavailable' })],
       password: [
         enabledWhen('alpha', () => false, { reason: 'enter a password' }),
         enabledWhen('alpha', () => false, { reason: 'password too short' }),
@@ -608,13 +637,22 @@ describe('eitherOf', () => {
       ],
     })
 
-    expect(rule.evaluate({ alpha: 'am5', beta: 'am5' }, { allow: false }).get('alpha')).toEqual({
+    expect(
+      rule
+        .evaluate({ alpha: 'am5', beta: 'am5' }, { allow: false })
+        .get('alpha'),
+    ).toEqual({
       enabled: true,
       fair: true,
       reason: null,
     })
     expect(
-      rule.evaluate({ alpha: 'am5', beta: 'lga1700', delta: 'missing' }, { allow: false }).get('alpha'),
+      rule
+        .evaluate(
+          { alpha: 'am5', beta: 'lga1700', delta: 'missing' },
+          { allow: false },
+        )
+        .get('alpha'),
     ).toEqual({
       enabled: true,
       fair: false,
@@ -630,12 +668,16 @@ describe('defineRule', () => {
       type: 'customEnabled',
       targets: ['alpha', 'alpha'],
       sources: ['beta', 'beta'],
-      evaluate: () => new Map([
-        ['alpha', {
-          enabled: false,
-          reason: 'custom blocked',
-        }],
-      ]),
+      evaluate: () =>
+        new Map([
+          [
+            'alpha',
+            {
+              enabled: false,
+              reason: 'custom blocked',
+            },
+          ],
+        ]),
     })
 
     expect(rule.type).toBe('customEnabled')
@@ -657,11 +699,14 @@ describe('defineRule', () => {
         const matches = values.alpha === values.beta
 
         return new Map([
-          ['alpha', {
-            enabled: true,
-            fair: matches,
-            reason: matches ? null : 'socket mismatch',
-          }],
+          [
+            'alpha',
+            {
+              enabled: true,
+              fair: matches,
+              reason: matches ? null : 'socket mismatch',
+            },
+          ],
         ])
       },
     })
@@ -674,23 +719,35 @@ describe('defineRule', () => {
         const allowed = values.delta === 'override'
 
         return new Map([
-          ['alpha', {
-            enabled: true,
-            fair: allowed,
-            reason: allowed ? null : 'delta override missing',
-          }],
+          [
+            'alpha',
+            {
+              enabled: true,
+              fair: allowed,
+              reason: allowed ? null : 'delta override missing',
+            },
+          ],
         ])
       },
     })
     const rule = anyOf(socketRule, allowDeltaRule)
 
-    expect(rule.evaluate({ alpha: 'am5', beta: 'am5' }, { allow: false }).get('alpha')).toEqual({
+    expect(
+      rule
+        .evaluate({ alpha: 'am5', beta: 'am5' }, { allow: false })
+        .get('alpha'),
+    ).toEqual({
       enabled: true,
       fair: true,
       reason: null,
     })
     expect(
-      rule.evaluate({ alpha: 'am5', beta: 'lga1700', delta: 'missing' }, { allow: false }).get('alpha'),
+      rule
+        .evaluate(
+          { alpha: 'am5', beta: 'lga1700', delta: 'missing' },
+          { allow: false },
+        )
+        .get('alpha'),
     ).toEqual({
       enabled: true,
       fair: false,
@@ -723,7 +780,10 @@ describe('check', () => {
   })
 
   test('supports function validators', () => {
-    const predicate = check<TestFields, TestConditions>('alpha', (value) => value === 'ok')
+    const predicate = check<TestFields, TestConditions>(
+      'alpha',
+      (value) => value === 'ok',
+    )
 
     expect(predicate({ alpha: 'ok' }, { allow: true })).toBe(true)
     expect(predicate({ alpha: 'nope' }, { allow: true })).toBe(false)
@@ -778,7 +838,10 @@ describe('check', () => {
       params: { value: 3 },
       validate: (value: string) => value.length >= 3,
     })
-    const plainPredicate = check<TestFields, TestConditions>('beta', (value) => value === 'ok')
+    const plainPredicate = check<TestFields, TestConditions>(
+      'beta',
+      (value) => value === 'ok',
+    )
 
     expect(inspectPredicate(namedPredicate)).toEqual({
       field: 'alpha',
@@ -806,14 +869,21 @@ describe('inspectRule', () => {
       __check: 'email',
       validate: (value: string) => value.includes('@'),
     })
-    const enabledRule = enabledWhen<TestFields, TestConditions>('alpha', namedPredicate, {
-      reason: 'need a valid email',
-    })
+    const enabledRule = enabledWhen<TestFields, TestConditions>(
+      'alpha',
+      namedPredicate,
+      {
+        reason: 'need a valid email',
+      },
+    )
     const fairRule = requires<TestFields, TestConditions>(
       'gamma',
       'beta',
       check('delta', (value) => value === 'ok'),
-      { reason: (_values, conditions) => (conditions.allow ? 'allowed' : 'blocked') },
+      {
+        reason: (_values, conditions) =>
+          conditions.allow ? 'allowed' : 'blocked',
+      },
     )
     const choiceRule = oneOf<TestFields, TestConditions>(
       'mode',
@@ -822,7 +892,8 @@ describe('inspectRule', () => {
         second: ['beta'],
       },
       {
-        activeBranch: (values) => (values.delta === 'pick-second' ? 'second' : 'first'),
+        activeBranch: (values) =>
+          values.delta === 'pick-second' ? 'second' : 'first',
       },
     )
 
@@ -865,9 +936,7 @@ describe('inspectRule', () => {
       type: 'customEnabled',
       targets: ['alpha'],
       sources: ['beta'],
-      evaluate: () => new Map([
-        ['alpha', { enabled: true, reason: null }],
-      ]),
+      evaluate: () => new Map([['alpha', { enabled: true, reason: null }]]),
     })
     const rule = anyOf<TestFields, TestConditions>(
       enabledWhen('alpha', () => false, { reason: 'nope' }),
@@ -902,12 +971,8 @@ describe('inspectRule', () => {
 
   test('describes eitherOf branches', () => {
     const rule = eitherOf<TestFields, TestConditions>('auth', {
-      sso: [
-        enabledWhen('alpha', () => false, { reason: 'sso unavailable' }),
-      ],
-      password: [
-        enabledWhen('alpha', () => true),
-      ],
+      sso: [enabledWhen('alpha', () => false, { reason: 'sso unavailable' })],
+      password: [enabledWhen('alpha', () => true)],
     })
 
     expect(inspectRule(rule)).toEqual({
@@ -939,15 +1004,11 @@ describe('inspectRule', () => {
       type: 'opaque',
       targets: ['alpha'],
       sources: ['beta'],
-      evaluate: () => new Map([
-        ['alpha', { enabled: true, reason: null }],
-      ]),
+      evaluate: () => new Map([['alpha', { enabled: true, reason: null }]]),
     }
 
     const rule = eitherOf<TestFields, TestConditions>('auth', {
-      password: [
-        enabledWhen('alpha', () => true),
-      ],
+      password: [enabledWhen('alpha', () => true)],
       opaque: [opaqueRule],
     })
 

--- a/packages/core/__tests__/scorecard.test.ts
+++ b/packages/core/__tests__/scorecard.test.ts
@@ -7,9 +7,15 @@ describe('scorecard', () => {
     const sharedRam = ['ddr5-kit']
     const ump = umpire({
       fields: {
-        cpu: field<string>().required().isEmpty((value) => !value),
-        motherboard: field<string>().required().isEmpty((value) => !value),
-        ram: field<string[]>().required().isEmpty((value) => !value || value.length === 0),
+        cpu: field<string>()
+          .required()
+          .isEmpty((value) => !value),
+        motherboard: field<string>()
+          .required()
+          .isEmpty((value) => !value),
+        ram: field<string[]>()
+          .required()
+          .isEmpty((value) => !value || value.length === 0),
       },
       rules: [
         fairWhen('motherboard', (value, values) => value === values.cpu, {
@@ -80,7 +86,9 @@ describe('scorecard', () => {
   test('uses compiled field definitions to compute satisfied without extra options', () => {
     const ump = umpire({
       fields: {
-        tags: field<string[]>().isEmpty((value) => !value || value.length === 0),
+        tags: field<string[]>().isEmpty(
+          (value) => !value || value.length === 0,
+        ),
       },
       rules: [],
     })
@@ -116,7 +124,10 @@ describe('scorecard', () => {
     }
 
     expect(ump.scorecard(snapshot).fields.motherboard.trace).toBeUndefined()
-    expect(ump.scorecard(snapshot, { includeChallenge: true }).fields.motherboard.trace).toEqual(
+    expect(
+      ump.scorecard(snapshot, { includeChallenge: true }).fields.motherboard
+        .trace,
+    ).toEqual(
       expect.objectContaining({
         field: 'motherboard',
         fair: false,

--- a/packages/core/__tests__/strike.test.ts
+++ b/packages/core/__tests__/strike.test.ts
@@ -17,8 +17,16 @@ describe('strike', () => {
     }
 
     const next = strike(values, [
-      { field: 'companyName', reason: 'business plan required', suggestedValue: undefined },
-      { field: 'companySize', reason: 'business plan required', suggestedValue: '' },
+      {
+        field: 'companyName',
+        reason: 'business plan required',
+        suggestedValue: undefined,
+      },
+      {
+        field: 'companySize',
+        reason: 'business plan required',
+        suggestedValue: '',
+      },
     ])
 
     expect(next).toEqual({
@@ -41,7 +49,11 @@ describe('strike', () => {
     }
 
     const next = strike(values, [
-      { field: 'companyName', reason: 'business plan required', suggestedValue: undefined },
+      {
+        field: 'companyName',
+        reason: 'business plan required',
+        suggestedValue: undefined,
+      },
     ])
 
     expect(next).toBe(values)

--- a/packages/core/__tests__/validation.test.ts
+++ b/packages/core/__tests__/validation.test.ts
@@ -4,10 +4,7 @@ import { umpire } from '../src/umpire.js'
 
 describe('surface validation metadata', () => {
   test.each([
-    [
-      'function',
-      (value: string) => value === 'ok',
-    ],
+    ['function', (value: string) => value === 'ok'],
     [
       'named check',
       {
@@ -27,32 +24,35 @@ describe('surface validation metadata', () => {
         test: (value: string) => value === 'ok',
       },
     ],
-  ])('supports %s validator shapes in validators config', (_label, validator) => {
-    const ump = umpire({
-      fields: {
-        alpha: { required: true, isEmpty: (value: unknown) => !value },
-      },
-      rules: [],
-      validators: {
-        alpha: validator,
-      },
-    })
+  ])(
+    'supports %s validator shapes in validators config',
+    (_label, validator) => {
+      const ump = umpire({
+        fields: {
+          alpha: { required: true, isEmpty: (value: unknown) => !value },
+        },
+        rules: [],
+        validators: {
+          alpha: validator,
+        },
+      })
 
-    expect(ump.check({ alpha: 'ok' }).alpha).toMatchObject({
-      enabled: true,
-      fair: true,
-      required: true,
-      valid: true,
-    })
+      expect(ump.check({ alpha: 'ok' }).alpha).toMatchObject({
+        enabled: true,
+        fair: true,
+        required: true,
+        valid: true,
+      })
 
-    expect(ump.check({ alpha: 'nope' }).alpha).toMatchObject({
-      enabled: true,
-      fair: true,
-      required: true,
-      valid: false,
-    })
-    expect(ump.check({ alpha: 'nope' }).alpha.error).toBeUndefined()
-  })
+      expect(ump.check({ alpha: 'nope' }).alpha).toMatchObject({
+        enabled: true,
+        fair: true,
+        required: true,
+        valid: false,
+      })
+      expect(ump.check({ alpha: 'nope' }).alpha.error).toBeUndefined()
+    },
+  )
 
   test('surfaces configured validation errors for failing validators', () => {
     const ump = umpire({
@@ -63,7 +63,9 @@ describe('surface validation metadata', () => {
       validators: {
         email: {
           validator: {
-            safeParse: (value: unknown) => ({ success: value === 'ok@example.com' }),
+            safeParse: (value: unknown) => ({
+              success: value === 'ok@example.com',
+            }),
           },
           error: 'Must be a valid email address',
         },
@@ -90,9 +92,10 @@ describe('surface validation metadata', () => {
       },
       rules: [],
       validators: {
-        username: (value: string) => value === 'doug'
-          ? { valid: true }
-          : { valid: false, error: 'Username is taken' },
+        username: (value: string) =>
+          value === 'doug'
+            ? { valid: true }
+            : { valid: false, error: 'Username is taken' },
       },
     })
 
@@ -154,9 +157,14 @@ describe('surface validation metadata', () => {
         companyName: { required: true, isEmpty: (value: unknown) => !value },
       },
       rules: [
-        enabledWhen('companyName', (_values, conditions: { plan?: string }) => conditions.plan === 'business', {
-          reason: 'business plan required',
-        }),
+        enabledWhen(
+          'companyName',
+          (_values, conditions: { plan?: string }) =>
+            conditions.plan === 'business',
+          {
+            reason: 'business plan required',
+          },
+        ),
       ],
       validators: {
         companyName: {
@@ -234,7 +242,9 @@ describe('surface validation metadata', () => {
       validators: {
         email: {
           validator: {
-            safeParse: (value: unknown) => ({ success: value === 'ok@example.com' }),
+            safeParse: (value: unknown) => ({
+              success: value === 'ok@example.com',
+            }),
           },
           error: 'Must be a valid email address',
         },
@@ -258,28 +268,32 @@ describe('surface validation metadata', () => {
   })
 
   test('throws for validator config that references an unknown field', () => {
-    expect(() => umpire({
-      fields: {
-        alpha: {},
-      },
-      rules: [],
-      validators: {
-        beta: (value: unknown) => value === 'ok',
-      } as never,
-    })).toThrow('Unknown field "beta" referenced by validators')
+    expect(() =>
+      umpire({
+        fields: {
+          alpha: {},
+        },
+        rules: [],
+        validators: {
+          beta: (value: unknown) => value === 'ok',
+        } as never,
+      }),
+    ).toThrow('Unknown field "beta" referenced by validators')
   })
 
   test('throws for invalid validator config shapes', () => {
-    expect(() => umpire({
-      fields: {
-        alpha: {},
-      },
-      rules: [],
-      validators: {
-        alpha: {
-          validator: { nope: true },
+    expect(() =>
+      umpire({
+        fields: {
+          alpha: {},
         },
-      } as never,
-    })).toThrow('Invalid validator configured for field "alpha"')
+        rules: [],
+        validators: {
+          alpha: {
+            validator: { nope: true },
+          },
+        } as never,
+      }),
+    ).toThrow('Invalid validator configured for field "alpha"')
   })
 })

--- a/packages/core/scripts/benchmark.mjs
+++ b/packages/core/scripts/benchmark.mjs
@@ -47,10 +47,12 @@ function variance(values, mean) {
     return 0
   }
 
-  return values.reduce((sum, value) => {
-    const delta = value - mean
-    return sum + delta * delta
-  }, 0) / values.length
+  return (
+    values.reduce((sum, value) => {
+      const delta = value - mean
+      return sum + delta * delta
+    }, 0) / values.length
+  )
 }
 
 function summarizeScenarioRuns(scenario, runCount) {
@@ -146,7 +148,6 @@ function sumAvailability(availability) {
   return enabled + required + reasons
 }
 
-
 function makeSchedulerScenario(sectionCount) {
   const fields = {}
   const rules = []
@@ -169,14 +170,16 @@ function makeSchedulerScenario(sectionCount) {
     fields[contact] = { default: undefined }
     fields[dates] = {
       default: undefined,
-      isEmpty: (value) => value == null || (Array.isArray(value) && value.length === 0),
+      isEmpty: (value) =>
+        value == null || (Array.isArray(value) && value.length === 0),
     }
     fields[startTime] = { default: undefined }
     fields[endTime] = { default: undefined }
     fields[repeatEvery] = { default: 30 }
     fields[everyHour] = {
       default: undefined,
-      isEmpty: (value) => value == null || (Array.isArray(value) && value.length === 0),
+      isEmpty: (value) =>
+        value == null || (Array.isArray(value) && value.length === 0),
     }
     fields[notes] = {
       default: '',
@@ -197,11 +200,17 @@ function makeSchedulerScenario(sectionCount) {
           activeBranch: (values) => values[mode] ?? null,
         },
       ),
-      disables(lock, [dates, startTime, endTime, repeatEvery, everyHour, notes], {
-        reason: 'section locked',
-      }),
+      disables(
+        lock,
+        [dates, startTime, endTime, repeatEvery, everyHour, notes],
+        {
+          reason: 'section locked',
+        },
+      ),
       requires(endTime, startTime, { reason: 'start time required' }),
-      requires(repeatEvery, startTime, endTime, { reason: 'complete interval required' }),
+      requires(repeatEvery, startTime, endTime, {
+        reason: 'complete interval required',
+      }),
       anyOf(
         requires(submit, dates, { reason: 'schedule incomplete' }),
         requires(submit, startTime, endTime, { reason: 'schedule incomplete' }),
@@ -210,9 +219,13 @@ function makeSchedulerScenario(sectionCount) {
       enabledWhen(submit, check(contact, /@/), {
         reason: 'valid contact required',
       }),
-      enabledWhen(submit, (_values, conditions) => conditions.readonly !== true, {
-        reason: 'read only',
-      }),
+      enabledWhen(
+        submit,
+        (_values, conditions) => conditions.readonly !== true,
+        {
+          reason: 'read only',
+        },
+      ),
       enabledWhen(notes, (_values, conditions) => conditions.plan === 'pro', {
         reason: 'pro plan required',
       }),
@@ -307,9 +320,14 @@ function buildBoard(width, height, minePositions) {
   const mines = new Set(minePositions.map(([x, y]) => cellKey(x, y)))
   const board = {}
   const offsets = [
-    [-1, -1], [0, -1], [1, -1],
-    [-1, 0], [1, 0],
-    [-1, 1], [0, 1], [1, 1],
+    [-1, -1],
+    [0, -1],
+    [1, -1],
+    [-1, 0],
+    [1, 0],
+    [-1, 1],
+    [0, 1],
+    [1, 1],
   ]
 
   for (let y = 0; y < height; y += 1) {
@@ -354,21 +372,29 @@ function createExpertMinesweeperScenario() {
   for (const key of Object.keys(board)) {
     fields[key] = { default: undefined }
     rules.push(
-      enabledWhen(key, (_values, conditions) => conditions.gameStatus === 'playing', {
-        reason: 'GAME_OVER',
-      }),
+      enabledWhen(
+        key,
+        (_values, conditions) => conditions.gameStatus === 'playing',
+        {
+          reason: 'GAME_OVER',
+        },
+      ),
       enabledWhen(key, (values) => values[key] !== 'revealed', {
         reason: 'ALREADY_REVEALED',
       }),
-      enabledWhen(key, (values, conditions) => {
-        if (conditions.flagMode) {
-          return true
-        }
+      enabledWhen(
+        key,
+        (values, conditions) => {
+          if (conditions.flagMode) {
+            return true
+          }
 
-        return values[key] !== 'flagged'
-      }, {
-        reason: 'FLAGGED',
-      }),
+          return values[key] !== 'flagged'
+        },
+        {
+          reason: 'FLAGGED',
+        },
+      ),
     )
   }
 
@@ -446,15 +472,17 @@ const scenarios = [
       const trace = schedulerRuntime.engine.challenge(
         challengeField,
         schedulerRuntime.afterValues,
-      schedulerRuntime.afterConditions,
-      schedulerRuntime.beforeValues,
-    )
+        schedulerRuntime.afterConditions,
+        schedulerRuntime.beforeValues,
+      )
 
       return (
         (trace.enabled ? 1 : 0) +
         trace.directReasons.length +
         trace.transitiveDeps.length +
-        (trace.oneOfResolution ? Object.keys(trace.oneOfResolution.branches).length : 0)
+        (trace.oneOfResolution
+          ? Object.keys(trace.oneOfResolution.branches).length
+          : 0)
       )
     },
   },
@@ -466,15 +494,17 @@ const scenarios = [
       const fouls = schedulerRuntime.engine.play(
         {
           values: schedulerRuntime.beforeValues,
-        conditions: schedulerRuntime.beforeConditions,
-      },
-      {
-        values: schedulerRuntime.afterValues,
-        conditions: schedulerRuntime.afterConditions,
-      },
+          conditions: schedulerRuntime.beforeConditions,
+        },
+        {
+          values: schedulerRuntime.afterValues,
+          conditions: schedulerRuntime.afterConditions,
+        },
       )
 
-      return fouls.length + fouls.reduce((sum, foul) => sum + foul.field.length, 0)
+      return (
+        fouls.length + fouls.reduce((sum, foul) => sum + foul.field.length, 0)
+      )
     },
   },
   {
@@ -491,13 +521,18 @@ const scenarios = [
     category: 'runtime-heavy',
     iterations: 100,
     run: () => {
-      const availability = minesweeper.engine.check(minesweeper.values, minesweeper.conditions)
+      const availability = minesweeper.engine.check(
+        minesweeper.values,
+        minesweeper.conditions,
+      )
       return sumAvailability(availability)
     },
   },
 ]
 
-const results = scenarios.map((scenario) => summarizeScenarioRuns(scenario, runCount))
+const results = scenarios.map((scenario) =>
+  summarizeScenarioRuns(scenario, runCount),
+)
 
 printScenarioResults(results, runCount)
 printCategoryTotals(results, runCount)

--- a/packages/core/src/composite.ts
+++ b/packages/core/src/composite.ts
@@ -3,7 +3,10 @@ import type { RuleEvaluation } from './types.js'
 export type CompositeConstraint = 'enabled' | 'fair'
 export type CompositeMode = 'and' | 'or'
 
-export function appendCompositeFailureReasons(result: RuleEvaluation, reasons: string[]): void {
+export function appendCompositeFailureReasons(
+  result: RuleEvaluation,
+  reasons: string[],
+): void {
   if (result.reasons && result.reasons.length > 0) {
     for (const reason of result.reasons) {
       reasons.push(reason)
@@ -31,7 +34,8 @@ export function combineCompositeResults(
   let passed = mode === 'and'
 
   for (const result of results) {
-    const currentPassed = constraint === 'fair' ? result.fair !== false : result.enabled
+    const currentPassed =
+      constraint === 'fair' ? result.fair !== false : result.enabled
 
     if (mode === 'and') {
       if (!currentPassed) {

--- a/packages/core/src/dev.ts
+++ b/packages/core/src/dev.ts
@@ -1,4 +1,6 @@
 export function shouldWarnInDev(): boolean {
-  const processLike = globalThis as { process?: { env?: Record<string, string | undefined> } }
+  const processLike = globalThis as {
+    process?: { env?: Record<string, string | undefined> }
+  }
   return processLike.process?.env?.NODE_ENV !== 'production'
 }

--- a/packages/core/src/emptiness.ts
+++ b/packages/core/src/emptiness.ts
@@ -2,14 +2,21 @@ import type { FieldDef } from './types.js'
 
 type IsEmptyFn = NonNullable<FieldDef['isEmpty']>
 
-export const isEmptyPresent: IsEmptyFn = (value) => value === null || value === undefined
+export const isEmptyPresent: IsEmptyFn = (value) =>
+  value === null || value === undefined
 
-export const isEmptyString: IsEmptyFn = (value) => typeof value !== 'string' || value.length === 0
+export const isEmptyString: IsEmptyFn = (value) =>
+  typeof value !== 'string' || value.length === 0
 
-export const isEmptyArray: IsEmptyFn = (value) => !Array.isArray(value) || value.length === 0
+export const isEmptyArray: IsEmptyFn = (value) =>
+  !Array.isArray(value) || value.length === 0
 
 export const isEmptyObject: IsEmptyFn = (value) => {
-  if (isEmptyPresent(value) || typeof value !== 'object' || Array.isArray(value)) {
+  if (
+    isEmptyPresent(value) ||
+    typeof value !== 'object' ||
+    Array.isArray(value)
+  ) {
     return true
   }
 

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -2,9 +2,20 @@ import {
   appendCompositeFailureReasons,
   combineCompositeResults,
 } from './composite.js'
-import { getInternalRuleMetadata, isFairRule, isGateRule, resolveReason } from './rules.js'
+import {
+  getInternalRuleMetadata,
+  isFairRule,
+  isGateRule,
+  resolveReason,
+} from './rules.js'
 import { isSatisfied } from './satisfaction.js'
-import type { AvailabilityMap, FieldDef, FieldValues, Rule, RuleEvaluation } from './types.js'
+import type {
+  AvailabilityMap,
+  FieldDef,
+  FieldValues,
+  Rule,
+  RuleEvaluation,
+} from './types.js'
 
 type RulePhaseBuckets<
   F extends Record<string, FieldDef>,
@@ -46,7 +57,9 @@ function partitionRulesByPhase<
 export function indexRulesByTargetPhase<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(rulesByTarget: Map<string, Rule<F, C>[]>): Map<string, RulePhaseBuckets<F, C>> {
+>(
+  rulesByTarget: Map<string, Rule<F, C>[]>,
+): Map<string, RulePhaseBuckets<F, C>> {
   const rulesByTargetPhase = new Map<string, RulePhaseBuckets<F, C>>()
 
   for (const [field, rules] of rulesByTarget) {
@@ -134,7 +147,9 @@ export function evaluateRuleForField<
         )
       }
 
-      branchResults.push(combineCompositeResults(metadata.constraint, 'and', innerResults))
+      branchResults.push(
+        combineCompositeResults(metadata.constraint, 'and', innerResults),
+      )
     }
 
     return combineCompositeResults(metadata.constraint, 'or', branchResults)
@@ -156,7 +171,8 @@ export function evaluateRuleForField<
     enabled: result.enabled,
     fair: result.fair,
     reason: result.reason,
-    reasons: result.reasons && result.reasons.length > 0 ? result.reasons : undefined,
+    reasons:
+      result.reasons && result.reasons.length > 0 ? result.reasons : undefined,
   }
 }
 
@@ -176,7 +192,8 @@ export function evaluate<
   const availability = {} as AvailabilityMap<F>
   const baseRuleCache = new Map<Rule<F, C>, Map<string, RuleEvaluation>>()
   const resolvedRulesByTarget = rulesByTarget ?? indexRulesByTarget(rules)
-  const resolvedRulesByTargetPhase = rulesByTargetPhase ?? indexRulesByTargetPhase(resolvedRulesByTarget)
+  const resolvedRulesByTargetPhase =
+    rulesByTargetPhase ?? indexRulesByTargetPhase(resolvedRulesByTarget)
 
   for (const field of topoOrder) {
     const { gateRules, fairRules } =
@@ -242,7 +259,7 @@ export function evaluate<
       enabled,
       satisfied: isSatisfied(values[field], fields[field]),
       fair,
-      required: enabled ? fields[field].required ?? false : false,
+      required: enabled ? (fields[field].required ?? false) : false,
       reason,
       reasons,
     }

--- a/packages/core/src/field.ts
+++ b/packages/core/src/field.ts
@@ -13,7 +13,9 @@ type RuleOptions<
   C extends Record<string, unknown>,
 > = {
   reason?: ReasonOption<F, C>
-  trace?: RuleTraceAttachment<FieldValues<F>, C> | RuleTraceAttachment<FieldValues<F>, C>[]
+  trace?:
+    | RuleTraceAttachment<FieldValues<F>, C>
+    | RuleTraceAttachment<FieldValues<F>, C>[]
 }
 
 type Predicate<
@@ -27,10 +29,10 @@ type FairPredicate<
   C extends Record<string, unknown>,
 > = (value: NonNullable<V>, values: FieldValues<F>, conditions: C) => boolean
 
-type FieldSelector<
-  F extends Record<string, FieldDef>,
-  V = unknown,
-> = (keyof F & string) | { readonly __umpfield: keyof F & string } | { readonly __umpfield: string }
+type FieldSelector<F extends Record<string, FieldDef>, V = unknown> =
+  | (keyof F & string)
+  | { readonly __umpfield: keyof F & string }
+  | { readonly __umpfield: string }
 
 export type AttachedFieldRule =
   | {
@@ -40,7 +42,11 @@ export type AttachedFieldRule =
     }
   | {
       kind: 'fairWhen'
-      predicate: FairPredicate<unknown, Record<string, FieldDef>, Record<string, unknown>>
+      predicate: FairPredicate<
+        unknown,
+        Record<string, FieldDef>,
+        Record<string, unknown>
+      >
       options?: RuleOptions<Record<string, FieldDef>, Record<string, unknown>>
     }
   | {
@@ -91,22 +97,30 @@ export type FieldBuilder<V = unknown> = BaseFieldBuilder<V> & {
   readonly [FIELD_STATE]: FieldBuilderState<V>
 }
 
-export type FieldRef<V = unknown, Name extends string = string> = FieldBuilder<V> & {
+export type FieldRef<
+  V = unknown,
+  Name extends string = string,
+> = FieldBuilder<V> & {
   readonly __umpfield: Name
 }
 
 export type FieldInput<V = unknown> = FieldDef<V> | FieldBuilder<V>
 
 export type NormalizeField<T> =
-  T extends FieldBuilder<infer V> ? FieldDef<V>
-  : T extends FieldDef<infer V> ? FieldDef<V>
-  : FieldDef
+  T extends FieldBuilder<infer V>
+    ? FieldDef<V>
+    : T extends FieldDef<infer V>
+      ? FieldDef<V>
+      : FieldDef
 
 export type NormalizeFields<F extends Record<string, FieldInput>> = {
   [K in keyof F]: NormalizeField<F[K]>
 }
 
-function pushRule<V>(builder: FieldBuilder<V>, rule: AttachedFieldRule): FieldBuilder<V> {
+function pushRule<V>(
+  builder: FieldBuilder<V>,
+  rule: AttachedFieldRule,
+): FieldBuilder<V> {
   builder[FIELD_STATE].rules.push(rule)
   return builder
 }
@@ -134,10 +148,7 @@ function createFieldBuilder<V>(name?: string): FieldBuilder<V> {
     fairWhen<
       F extends Record<string, FieldDef>,
       C extends Record<string, unknown> = Record<string, unknown>,
-    >(
-      predicate: FairPredicate<V, F, C>,
-      options?: RuleOptions<F, C>,
-    ) {
+    >(predicate: FairPredicate<V, F, C>, options?: RuleOptions<F, C>) {
       return pushRule(this, {
         kind: 'fairWhen',
         predicate: predicate as AttachedFairWhen['predicate'],
@@ -147,10 +158,7 @@ function createFieldBuilder<V>(name?: string): FieldBuilder<V> {
     enabledWhen<
       F extends Record<string, FieldDef>,
       C extends Record<string, unknown> = Record<string, unknown>,
-    >(
-      predicate: Predicate<F, C>,
-      options?: RuleOptions<F, C>,
-    ) {
+    >(predicate: Predicate<F, C>, options?: RuleOptions<F, C>) {
       return pushRule(this, {
         kind: 'enabledWhen',
         predicate: predicate as AttachedEnabledWhen['predicate'],
@@ -160,10 +168,7 @@ function createFieldBuilder<V>(name?: string): FieldBuilder<V> {
     requires<
       F extends Record<string, FieldDef>,
       C extends Record<string, unknown> = Record<string, unknown>,
-    >(
-      dependency: FieldSelector<F>,
-      options?: RuleOptions<F, C>,
-    ) {
+    >(dependency: FieldSelector<F>, options?: RuleOptions<F, C>) {
       return pushRule(this, {
         kind: 'requires',
         dependency: getFieldNameOrThrow(dependency),
@@ -199,10 +204,7 @@ export function getFieldBuilderName(value: unknown): string | undefined {
   return typeof name === 'string' ? name : undefined
 }
 
-export function getFieldNameOrThrow<
-  F extends Record<string, FieldDef>,
-  V,
->(
+export function getFieldNameOrThrow<F extends Record<string, FieldDef>, V>(
   field: FieldSelector<F, V>,
 ): keyof F & string {
   if (typeof field === 'string') {
@@ -211,7 +213,9 @@ export function getFieldNameOrThrow<
 
   const name = getFieldBuilderName(field)
   if (!name) {
-    throw new Error('[@umpire/core] Named field builder required when passing a field() value to a rule')
+    throw new Error(
+      '[@umpire/core] Named field builder required when passing a field() value to a rule',
+    )
   }
 
   return name as keyof F & string
@@ -221,12 +225,16 @@ export function getFieldBuilderDef<V>(builder: FieldBuilder<V>): FieldDef<V> {
   return { ...builder[FIELD_STATE].definition }
 }
 
-export function getFieldBuilderRules(builder: FieldBuilder): AttachedFieldRule[] {
+export function getFieldBuilderRules(
+  builder: FieldBuilder,
+): AttachedFieldRule[] {
   return [...builder[FIELD_STATE].rules]
 }
 
 export function field<V = unknown>(): FieldBuilder<V>
-export function field<V = unknown, Name extends string = string>(name: Name): FieldRef<V, Name>
+export function field<V = unknown, Name extends string = string>(
+  name: Name,
+): FieldRef<V, Name>
 export function field<V = unknown>(name?: string): FieldBuilder<V> {
   return createFieldBuilder(name)
 }

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -36,7 +36,12 @@ export function buildGraph<
   const deferredEdgeGroups: DeferredGraphEdgeGroup[] = []
   const seenEdges = new Set<string>()
 
-  function addEdge(from: string, to: string, type: string, ordering: boolean): void {
+  function addEdge(
+    from: string,
+    to: string,
+    type: string,
+    ordering: boolean,
+  ): void {
     const edgeKey = `${from}:${to}:${type}:${ordering ? 'ordering' : 'informational'}`
     if (seenEdges.has(edgeKey)) {
       return
@@ -77,7 +82,9 @@ export function buildGraph<
     if (metadata?.kind === 'oneOf') {
       deferredEdgeGroups.push({
         type: rule.type,
-        branches: Object.keys(metadata.branches).map((branchName) => [...metadata.branches[branchName]]),
+        branches: Object.keys(metadata.branches).map((branchName) => [
+          ...metadata.branches[branchName],
+        ]),
       })
 
       continue
@@ -159,7 +166,10 @@ export function detectCycles(graph: DependencyGraph): void {
   }
 }
 
-export function topologicalSort(graph: DependencyGraph, fieldNames: string[]): string[] {
+export function topologicalSort(
+  graph: DependencyGraph,
+  fieldNames: string[],
+): string[] {
   const orderedFields = uniqueNodes(fieldNames)
   const incomingCounts = new Map<string, number>()
 
@@ -167,7 +177,9 @@ export function topologicalSort(graph: DependencyGraph, fieldNames: string[]): s
     incomingCounts.set(field, graph.incomingCounts.get(field) ?? 0)
   }
 
-  const queue = orderedFields.filter((field) => (incomingCounts.get(field) ?? 0) === 0)
+  const queue = orderedFields.filter(
+    (field) => (incomingCounts.get(field) ?? 0) === 0,
+  )
   const result: string[] = []
 
   for (let index = 0; index < queue.length; index += 1) {
@@ -213,10 +225,18 @@ export function exportGraph(graph: DependencyGraph): {
   }
 
   for (const group of graph.deferredEdgeGroups) {
-    for (let sourceIndex = 0; sourceIndex < group.branches.length; sourceIndex += 1) {
+    for (
+      let sourceIndex = 0;
+      sourceIndex < group.branches.length;
+      sourceIndex += 1
+    ) {
       const sourceBranch = group.branches[sourceIndex]
 
-      for (let targetIndex = 0; targetIndex < group.branches.length; targetIndex += 1) {
+      for (
+        let targetIndex = 0;
+        targetIndex < group.branches.length;
+        targetIndex += 1
+      ) {
         if (sourceIndex === targetIndex) {
           continue
         }

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -2,6 +2,8 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
 
-export function isPlainRecord(value: unknown): value is Record<string, unknown> {
+export function isPlainRecord(
+  value: unknown,
+): value is Record<string, unknown> {
   return isRecord(value) && !Array.isArray(value)
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,7 +34,13 @@ export type {
   ValidationMap,
   FieldsOf,
 } from './types.js'
-export type { FieldBuilder, FieldInput, FieldRef, NormalizeField, NormalizeFields } from './field.js'
+export type {
+  FieldBuilder,
+  FieldInput,
+  FieldRef,
+  NormalizeField,
+  NormalizeFields,
+} from './field.js'
 export type {
   DefineRuleConfig,
   PredicateInspection,
@@ -42,7 +48,12 @@ export type {
   RuleInspection,
   RuleOperandInspection,
 } from './rules.js'
-export { isEmptyArray, isEmptyObject, isEmptyPresent, isEmptyString } from './emptiness.js'
+export {
+  isEmptyArray,
+  isEmptyObject,
+  isEmptyPresent,
+  isEmptyString,
+} from './emptiness.js'
 export { field } from './field.js'
 export { foulMap } from './foul-map.js'
 export { isSatisfied } from './satisfaction.js'

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -5,7 +5,10 @@ import {
 import { shouldWarnInDev } from './dev.js'
 import { getFieldBuilderName, getFieldNameOrThrow } from './field.js'
 import { isSatisfied } from './satisfaction.js'
-import { isNamedCheck as isNamedCheckValidator, runFieldValidator } from './validation.js'
+import {
+  isNamedCheck as isNamedCheckValidator,
+  runFieldValidator,
+} from './validation.js'
 import type {
   FieldValidator,
   FieldDef,
@@ -124,13 +127,15 @@ type RuleOptions<
   C extends Record<string, unknown>,
 > = {
   reason?: ReasonOption<F, C>
-  trace?: RuleTraceAttachment<FieldValues<F>, C> | RuleTraceAttachment<FieldValues<F>, C>[]
+  trace?:
+    | RuleTraceAttachment<FieldValues<F>, C>
+    | RuleTraceAttachment<FieldValues<F>, C>[]
 }
 
-type FieldSelector<
-  F extends Record<string, FieldDef>,
-  V = unknown,
-> = (keyof F & string) | { readonly __umpfield: keyof F & string } | { readonly __umpfield: string }
+type FieldSelector<F extends Record<string, FieldDef>, V = unknown> =
+  | (keyof F & string)
+  | { readonly __umpfield: keyof F & string }
+  | { readonly __umpfield: string }
 
 type Source<
   F extends Record<string, FieldDef>,
@@ -147,7 +152,11 @@ type FairPredicate<
   V,
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-> = ((value: NonNullable<V>, values: FieldValues<F>, conditions: C) => boolean) & {
+> = ((
+  value: NonNullable<V>,
+  values: FieldValues<F>,
+  conditions: C,
+) => boolean) & {
   _checkField?: keyof F & string
 }
 
@@ -171,10 +180,9 @@ type OneOfOptions<
   C extends Record<string, unknown>,
   BranchName extends string = string,
 > = RuleOptions<F, C> & {
-  activeBranch?: BranchName | ((
-    values: FieldValues<F>,
-    conditions: C,
-  ) => BranchName | null | undefined)
+  activeBranch?:
+    | BranchName
+    | ((values: FieldValues<F>, conditions: C) => BranchName | null | undefined)
 }
 
 export type InternalPredicate<
@@ -187,7 +195,8 @@ export type InternalSource<
   C extends Record<string, unknown>,
 > = Source<F, C>
 
-export type InternalOneOfBranches<F extends Record<string, FieldDef>> = OneOfBranches<F>
+export type InternalOneOfBranches<F extends Record<string, FieldDef>> =
+  OneOfBranches<F>
 
 export type InternalFairPredicate<
   V,
@@ -315,10 +324,7 @@ function createResultMap<F extends Record<string, FieldDef>>(
   const results = new Map<string, RuleEvaluation>()
 
   for (const target of targets) {
-    results.set(
-      target,
-      resultForTarget(target),
-    )
+    results.set(target, resultForTarget(target))
   }
 
   return results
@@ -340,9 +346,10 @@ export function resolveReason<
   return reason ?? fallback
 }
 
-function getCheckField<F extends Record<string, FieldDef>, C extends Record<string, unknown>>(
-  source: Predicate<F, C>,
-): (keyof F & string) | undefined {
+function getCheckField<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(source: Predicate<F, C>): (keyof F & string) | undefined {
   return source._checkField
 }
 
@@ -350,18 +357,14 @@ function getFairCheckField<
   V,
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  predicate: FairPredicate<V, F, C>,
-): (keyof F & string) | undefined {
+>(predicate: FairPredicate<V, F, C>): (keyof F & string) | undefined {
   return predicate._checkField
 }
 
 export function getSourceField<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  source: InternalSource<F, C>,
-): (keyof F & string) | undefined {
+>(source: InternalSource<F, C>): (keyof F & string) | undefined {
   if (typeof source === 'string') {
     return source
   }
@@ -373,9 +376,7 @@ function normalizeSource<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
   V = unknown,
->(
-  source: SourceInput<F, C, V>,
-): Source<F, C> {
+>(source: SourceInput<F, C, V>): Source<F, C> {
   if (typeof source === 'function') {
     return source
   }
@@ -401,8 +402,12 @@ export function getInternalRuleMetadata<
   return (rule as InternalRuleCarrier<F, C>)._umpire
 }
 
-function cloneNamedCheckMetadata(metadata: NamedCheckMetadata): NamedCheckMetadata {
-  const params = metadata.params ? Object.freeze({ ...metadata.params }) : undefined
+function cloneNamedCheckMetadata(
+  metadata: NamedCheckMetadata,
+): NamedCheckMetadata {
+  const params = metadata.params
+    ? Object.freeze({ ...metadata.params })
+    : undefined
 
   if (!params) {
     return Object.freeze({ __check: metadata.__check })
@@ -414,8 +419,12 @@ function cloneNamedCheckMetadata(metadata: NamedCheckMetadata): NamedCheckMetada
   })
 }
 
-function isNamedCheckMetadataCarrier(value: unknown): value is NamedCheckMetadataCarrier {
-  return (typeof value === 'function' || typeof value === 'object') && value !== null
+function isNamedCheckMetadataCarrier(
+  value: unknown,
+): value is NamedCheckMetadataCarrier {
+  return (
+    (typeof value === 'function' || typeof value === 'object') && value !== null
+  )
 }
 
 function hasNamedCheckMetadata(
@@ -424,7 +433,9 @@ function hasNamedCheckMetadata(
   return isNamedCheckMetadataCarrier(value) && value._namedCheck !== undefined
 }
 
-export function getNamedCheckMetadata(value: unknown): NamedCheckMetadata | undefined {
+export function getNamedCheckMetadata(
+  value: unknown,
+): NamedCheckMetadata | undefined {
   if (isNamedCheckValidator(value)) {
     return cloneNamedCheckMetadata(value)
   }
@@ -437,7 +448,10 @@ export function getNamedCheckMetadata(value: unknown): NamedCheckMetadata | unde
 }
 
 function getPredicateField(value: unknown): string | undefined {
-  if ((typeof value !== 'function' && typeof value !== 'object') || value === null) {
+  if (
+    (typeof value !== 'function' && typeof value !== 'object') ||
+    value === null
+  ) {
     return undefined
   }
 
@@ -489,7 +503,9 @@ function inspectReasonOption<
   return { hasDynamicReason: false }
 }
 
-function inspectOperand<Field extends string = string>(value: unknown): RuleOperandInspection<Field> {
+function inspectOperand<Field extends string = string>(
+  value: unknown,
+): RuleOperandInspection<Field> {
   if (typeof value === 'string') {
     return {
       kind: 'field',
@@ -521,7 +537,10 @@ function getBranchRules<
 function resolveCompositeRuleShape<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(label: string, rules: Rule<F, C>[]): {
+>(
+  label: string,
+  rules: Rule<F, C>[],
+): {
   targets: Array<keyof F & string>
   sources: Array<keyof F & string>
   constraint: RuleConstraint
@@ -535,7 +554,9 @@ function resolveCompositeRuleShape<
       currentTargets.length !== expectedTargets.length ||
       currentTargets.some((target, index) => target !== expectedTargets[index])
     ) {
-      throw new Error(`[@umpire/core] ${label} rules must target the same fields`)
+      throw new Error(
+        `[@umpire/core] ${label} rules must target the same fields`,
+      )
     }
   }
 
@@ -543,7 +564,9 @@ function resolveCompositeRuleShape<
 
   for (const innerRule of rules.slice(1)) {
     if (getRuleConstraint(innerRule) !== constraint) {
-      throw new Error(`[@umpire/core] ${label} cannot mix fairWhen rules with availability rules`)
+      throw new Error(
+        `[@umpire/core] ${label} cannot mix fairWhen rules with availability rules`,
+      )
     }
   }
 
@@ -596,7 +619,8 @@ export function inspectRule<
       kind: 'requires',
       target: rule.targets[0],
       dependencies: metadata.dependencies.map((dependency) =>
-        inspectOperand<keyof F & string>(dependency)),
+        inspectOperand<keyof F & string>(dependency),
+      ),
       ...inspectReasonOption(metadata.options),
     }
   }
@@ -610,13 +634,16 @@ export function inspectRule<
         typeof metadata.options?.activeBranch === 'string'
           ? metadata.options.activeBranch
           : undefined,
-      hasDynamicActiveBranch: typeof metadata.options?.activeBranch === 'function',
+      hasDynamicActiveBranch:
+        typeof metadata.options?.activeBranch === 'function',
       ...inspectReasonOption(metadata.options),
     }
   }
 
   if (metadata.kind === 'anyOf') {
-    const inspectedRules = metadata.rules.map((innerRule) => inspectRule(innerRule))
+    const inspectedRules = metadata.rules.map((innerRule) =>
+      inspectRule(innerRule),
+    )
 
     if (inspectedRules.some((entry) => entry === undefined)) {
       return undefined
@@ -639,7 +666,8 @@ export function inspectRule<
 
     if (
       Object.values(inspectedBranches).some((branchRules) =>
-        branchRules.some((entry) => entry === undefined))
+        branchRules.some((entry) => entry === undefined),
+      )
     ) {
       return undefined
     }
@@ -648,7 +676,10 @@ export function inspectRule<
       kind: 'eitherOf',
       groupName: metadata.groupName,
       constraint: metadata.constraint,
-      branches: inspectedBranches as Record<string, Array<RuleInspection<F, C>>>,
+      branches: inspectedBranches as Record<
+        string,
+        Array<RuleInspection<F, C>>
+      >,
     }
   }
 
@@ -702,7 +733,9 @@ export function getGraphSourceInfo<
 
   if (metadata?.kind === 'anyOf') {
     const ordering = uniqueFields(
-      metadata.rules.flatMap((innerRule) => getGraphSourceInfo(innerRule).ordering),
+      metadata.rules.flatMap(
+        (innerRule) => getGraphSourceInfo(innerRule).ordering,
+      ),
     )
     const orderingSet = new Set(ordering)
     const informational = uniqueFields(
@@ -720,7 +753,9 @@ export function getGraphSourceInfo<
   if (metadata?.kind === 'eitherOf') {
     const branchRules = getBranchRules(metadata.branches)
     const ordering = uniqueFields(
-      branchRules.flatMap((innerRule) => getGraphSourceInfo(innerRule).ordering),
+      branchRules.flatMap(
+        (innerRule) => getGraphSourceInfo(innerRule).ordering,
+      ),
     )
     const orderingSet = new Set(ordering)
     const informational = uniqueFields(
@@ -748,9 +783,10 @@ export function getGraphSourceInfo<
   }
 }
 
-function getSourceFields<F extends Record<string, FieldDef>, C extends Record<string, unknown>>(
-  source: InternalSource<F, C>,
-): Array<keyof F & string> {
+function getSourceFields<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(source: InternalSource<F, C>): Array<keyof F & string> {
   const checkField = getSourceField(source)
   return checkField ? [checkField] : []
 }
@@ -759,16 +795,15 @@ function getFairSourceFields<
   V,
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  predicate: FairPredicate<V, F, C>,
-): Array<keyof F & string> {
+>(predicate: FairPredicate<V, F, C>): Array<keyof F & string> {
   const checkField = getFairCheckField(predicate)
   return checkField ? [checkField] : []
 }
 
-function getSourceLabel<F extends Record<string, FieldDef>, C extends Record<string, unknown>>(
-  source: Source<F, C>,
-): string {
+function getSourceLabel<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(source: Source<F, C>): string {
   if (typeof source === 'string') {
     return source
   }
@@ -776,7 +811,10 @@ function getSourceLabel<F extends Record<string, FieldDef>, C extends Record<str
   return getCheckField(source) ?? 'condition'
 }
 
-function isSourceActive<F extends Record<string, FieldDef>, C extends Record<string, unknown>>(
+function isSourceActive<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
   source: Source<F, C>,
   values: FieldValues<F>,
   conditions: C,
@@ -793,7 +831,11 @@ function isRuleOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 >(value: unknown): value is RuleOptions<F, C> {
-  return typeof value === 'object' && value !== null && ('reason' in value || 'trace' in value)
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    ('reason' in value || 'trace' in value)
+  )
 }
 
 function uniqueFields<F extends Record<string, FieldDef>>(
@@ -878,9 +920,7 @@ export function isGateRule<
 export function defineRule<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
->(
-  config: DefineRuleConfig<F, C>,
-): Rule<F, C> {
+>(config: DefineRuleConfig<F, C>): Rule<F, C> {
   const rule: InternalRuleCarrier<F, C> = {
     type: config.type,
     targets: uniqueFields([...config.targets]),
@@ -905,7 +945,9 @@ function branchHasSatisfiedField<F extends Record<string, FieldDef>>(
     return false
   }
 
-  return branchFields.some((field) => isSatisfied(values[field], fields?.[field]))
+  return branchFields.some((field) =>
+    isSatisfied(values[field], fields?.[field]),
+  )
 }
 
 function warnAmbiguousOneOf(groupName: string, branchNames: string[]): void {
@@ -937,7 +979,11 @@ export function resolveOneOfState<
       branchName,
       {
         fields: [...branches[branchName]],
-        anySatisfied: branchHasSatisfiedField(branches[branchName], values, fields),
+        anySatisfied: branchHasSatisfiedField(
+          branches[branchName],
+          values,
+          fields,
+        ),
       },
     ]),
   ) as Record<string, { fields: string[]; anySatisfied: boolean }>
@@ -960,7 +1006,9 @@ export function resolveOneOfState<
       }
     }
     if (!(resolvedBranch in branches)) {
-      throw new Error(`[@umpire/core] Unknown active branch "${resolvedBranch}" for oneOf("${groupName}")`)
+      throw new Error(
+        `[@umpire/core] Unknown active branch "${resolvedBranch}" for oneOf("${groupName}")`,
+      )
     }
     return {
       activeBranch: resolvedBranch,
@@ -1047,7 +1095,12 @@ export function enabledWhen<
         enabled: passed,
         reason: passed
           ? null
-          : resolveReason(options?.reason, values, conditions, 'condition not met'),
+          : resolveReason(
+              options?.reason,
+              values,
+              conditions,
+              'condition not met',
+            ),
       }))
     },
   }
@@ -1138,7 +1191,9 @@ export function disables<
 
       return createResultMap(resolvedTargets, () => ({
         enabled: !active,
-        reason: active ? resolveReason(options?.reason, values, conditions, defaultReason) : null,
+        reason: active
+          ? resolveReason(options?.reason, values, conditions, defaultReason)
+          : null,
       }))
     },
   }
@@ -1163,11 +1218,14 @@ export function requires<
   const target = getFieldNameOrThrow(field)
   const maybeOptions = deps[deps.length - 1]
   const options = isRuleOptions<F, C>(maybeOptions) ? maybeOptions : undefined
-  const dependencies: Array<Source<F, C>> = (options ? deps.slice(0, -1) : deps)
-    .map((dependency) => normalizeSource(dependency as SourceInput<F, C>))
+  const dependencies: Array<Source<F, C>> = (
+    options ? deps.slice(0, -1) : deps
+  ).map((dependency) => normalizeSource(dependency as SourceInput<F, C>))
 
   if (dependencies.length === 0) {
-    throw new Error(`[@umpire/core] requires("${target}") requires at least one dependency`)
+    throw new Error(
+      `[@umpire/core] requires("${target}") requires at least one dependency`,
+    )
   }
 
   const rule: InternalRuleCarrier<F, C> = {
@@ -1197,7 +1255,12 @@ export function requires<
             ? `requires ${dependency}`
             : `required condition not met`
 
-        const resolvedReason = resolveReason(options?.reason, values, conditions, fallback)
+        const resolvedReason = resolveReason(
+          options?.reason,
+          values,
+          conditions,
+          fallback,
+        )
 
         if (reason === null) {
           reason = resolvedReason
@@ -1237,32 +1300,43 @@ export function oneOf<
   const branchNames = Object.keys(resolvedBranches)
 
   if (branchNames.length === 0) {
-    throw new Error(`[@umpire/core] oneOf("${groupName}") must include at least one branch`)
+    throw new Error(
+      `[@umpire/core] oneOf("${groupName}") must include at least one branch`,
+    )
   }
 
   for (const branchName of branchNames) {
     const fields = resolvedBranches[branchName]
 
     if (fields.length === 0) {
-      throw new Error(`[@umpire/core] oneOf("${groupName}") branch "${branchName}" must not be empty`)
+      throw new Error(
+        `[@umpire/core] oneOf("${groupName}") branch "${branchName}" must not be empty`,
+      )
     }
 
     for (const field of fields) {
       if (seenFields.has(field)) {
-        throw new Error(`[@umpire/core] oneOf("${groupName}") field "${field}" appears in multiple branches`)
+        throw new Error(
+          `[@umpire/core] oneOf("${groupName}") field "${field}" appears in multiple branches`,
+        )
       }
 
       seenFields.add(field)
     }
   }
 
-  if (typeof options?.activeBranch === 'string' && !(options.activeBranch in resolvedBranches)) {
+  if (
+    typeof options?.activeBranch === 'string' &&
+    !(options.activeBranch in resolvedBranches)
+  ) {
     throw new Error(
       `[@umpire/core] Unknown active branch "${options.activeBranch}" for oneOf("${groupName}")`,
     )
   }
 
-  const targets = branchNames.flatMap((branchName) => resolvedBranches[branchName])
+  const targets = branchNames.flatMap(
+    (branchName) => resolvedBranches[branchName],
+  )
 
   const rule: InternalRuleCarrier<F, C> = {
     type: 'oneOf',
@@ -1284,7 +1358,8 @@ export function oneOf<
       }
 
       return createResultMap(targets, (target) => {
-        const inActiveBranch = resolvedBranches[resolution.activeBranch as string].includes(target)
+        const inActiveBranch =
+          resolvedBranches[resolution.activeBranch as string].includes(target)
         return {
           enabled: inActiveBranch,
           reason: inActiveBranch
@@ -1318,7 +1393,10 @@ export function anyOf<
     throw new Error('[@umpire/core] anyOf() requires at least one rule')
   }
 
-  const { targets, sources, constraint } = resolveCompositeRuleShape('anyOf()', rules)
+  const { targets, sources, constraint } = resolveCompositeRuleShape(
+    'anyOf()',
+    rules,
+  )
 
   const rule: InternalRuleCarrier<F, C> = {
     type: 'anyOf',
@@ -1330,8 +1408,9 @@ export function anyOf<
       )
 
       return createResultMap(targets, (target) => {
-        const targetResults = evaluations
-          .map((evaluation) => getCompositeTargetEvaluation(evaluation, target))
+        const targetResults = evaluations.map((evaluation) =>
+          getCompositeTargetEvaluation(evaluation, target),
+        )
 
         return combineCompositeResults(constraint, 'or', targetResults)
       })
@@ -1350,25 +1429,29 @@ export function anyOf<
 export function eitherOf<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
->(
-  groupName: string,
-  branches: EitherOfBranches<F, C>,
-): Rule<F, C> {
+>(groupName: string, branches: EitherOfBranches<F, C>): Rule<F, C> {
   const branchNames = Object.keys(branches)
 
   if (branchNames.length === 0) {
-    throw new Error(`[@umpire/core] eitherOf("${groupName}") must include at least one branch`)
+    throw new Error(
+      `[@umpire/core] eitherOf("${groupName}") must include at least one branch`,
+    )
   }
 
   for (const branchName of branchNames) {
     if (branches[branchName].length === 0) {
-      throw new Error(`[@umpire/core] eitherOf("${groupName}") branch "${branchName}" must not be empty`)
+      throw new Error(
+        `[@umpire/core] eitherOf("${groupName}") branch "${branchName}" must not be empty`,
+      )
     }
   }
 
   const rules = getBranchRules(branches)
   const label = `eitherOf("${groupName}")`
-  const { targets, sources, constraint } = resolveCompositeRuleShape(label, rules)
+  const { targets, sources, constraint } = resolveCompositeRuleShape(
+    label,
+    rules,
+  )
 
   const rule: InternalRuleCarrier<F, C> = {
     type: 'eitherOf',
@@ -1379,14 +1462,16 @@ export function eitherOf<
         branchNames.map((branchName) => [
           branchName,
           branches[branchName].map((branchRule) =>
-            branchRule.evaluate(values, conditions, prev, fields, availability)),
+            branchRule.evaluate(values, conditions, prev, fields, availability),
+          ),
         ]),
       ) as Record<string, Array<Map<string, RuleEvaluation>>>
 
       return createResultMap(targets, (target) => {
         const branchResults = branchNames.map((branchName) => {
-          const targetResults = branchEvaluations[branchName].map((evaluation) =>
-            getCompositeTargetEvaluation(evaluation, target))
+          const targetResults = branchEvaluations[branchName].map(
+            (evaluation) => getCompositeTargetEvaluation(evaluation, target),
+          )
 
           return combineCompositeResults(constraint, 'and', targetResults)
         })

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -1,7 +1,4 @@
-function cloneSnapshotValue<T>(
-  value: T,
-  seen: WeakMap<object, unknown>,
-): T {
+function cloneSnapshotValue<T>(value: T, seen: WeakMap<object, unknown>): T {
   if (value === null || typeof value !== 'object') {
     return value
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,7 +15,8 @@ export interface NamedCheck<T = unknown> extends NamedCheckMetadata {
   readonly validate: (value: NonNullable<T>) => boolean
 }
 
-export type FieldValue<T extends FieldDef> = T extends FieldDef<infer V> ? V : unknown
+export type FieldValue<T extends FieldDef> =
+  T extends FieldDef<infer V> ? V : unknown
 
 export type FunctionValidator<T = unknown> = (value: NonNullable<T>) => boolean
 
@@ -40,7 +41,9 @@ export type ValidationResult = {
 
 export type ValidationOutcome = boolean | ValidationResult
 
-export type ValidationFunction<T = unknown> = (value: NonNullable<T>) => ValidationOutcome
+export type ValidationFunction<T = unknown> = (
+  value: NonNullable<T>,
+) => ValidationOutcome
 
 export type ValidationValidator<T = unknown> =
   | ValidationFunction<T>
@@ -79,7 +82,6 @@ export type FieldValues<F extends Record<string, FieldDef>> = {
 }
 
 export type InputValues = Record<string, unknown>
-
 
 export type Snapshot<C extends Record<string, unknown>> = {
   values: InputValues
@@ -247,7 +249,11 @@ export interface Umpire<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
 > {
-  check(values: InputValues, conditions?: C, prev?: InputValues): AvailabilityMap<F>
+  check(
+    values: InputValues,
+    conditions?: C,
+    prev?: InputValues,
+  ): AvailabilityMap<F>
   play(before: Snapshot<C>, after: Snapshot<C>): Foul<F>[]
   init(overrides?: InputValues): FieldValues<F>
   scorecard(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -263,4 +263,4 @@ export interface Umpire<
   graph(): UmpireGraph
 }
 
-export type FieldsOf<U> = U extends Umpire<infer F, any> ? F : never
+export type FieldsOf<U> = U extends Umpire<infer F> ? F : never

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -13,7 +13,12 @@ import {
 } from './field.js'
 import type { FieldInput, NormalizeFields } from './field.js'
 import { foulMap } from './foul-map.js'
-import { buildGraph, detectCycles, exportGraph, topologicalSort } from './graph.js'
+import {
+  buildGraph,
+  detectCycles,
+  exportGraph,
+  topologicalSort,
+} from './graph.js'
 import {
   enabledWhen,
   fairWhen,
@@ -53,7 +58,9 @@ import type {
 
 const EMPTY_CONDITIONS = Object.freeze({}) as Record<string, unknown>
 
-function createEmptyConditions<C extends Record<string, unknown>>(conditions: C | undefined): C {
+function createEmptyConditions<C extends Record<string, unknown>>(
+  conditions: C | undefined,
+): C {
   return (conditions ?? EMPTY_CONDITIONS) as C
 }
 
@@ -73,7 +80,9 @@ function getChangedFields<
     return []
   }
 
-  return fieldNames.filter((field) => !Object.is(before.values[field], after.values[field]))
+  return fieldNames.filter(
+    (field) => !Object.is(before.values[field], after.values[field]),
+  )
 }
 
 function normalizeValidators<F extends Record<string, FieldDef>>(
@@ -88,19 +97,25 @@ function normalizeValidators<F extends Record<string, FieldDef>>(
 
   const fieldNames = new Set(Object.keys(fields))
 
-  for (const [field, entry] of Object.entries(validators) as Array<[keyof F & string, unknown]>) {
+  for (const [field, entry] of Object.entries(validators) as Array<
+    [keyof F & string, unknown]
+  >) {
     if (entry === undefined) {
       continue
     }
 
     if (!fieldNames.has(field)) {
-      throw new Error(`[@umpire/core] Unknown field "${field}" referenced by validators`)
+      throw new Error(
+        `[@umpire/core] Unknown field "${field}" referenced by validators`,
+      )
     }
 
     const normalizedEntry = normalizeValidationEntry(entry)
 
     if (!normalizedEntry) {
-      throw new Error(`[@umpire/core] Invalid validator configured for field "${field}"`)
+      throw new Error(
+        `[@umpire/core] Invalid validator configured for field "${field}"`,
+      )
     }
 
     normalized[field] = normalizedEntry
@@ -113,8 +128,14 @@ function buildFieldEdgeLookup<F extends Record<string, FieldDef>>(
   graph: UmpireGraph,
   fieldNames: Array<keyof F & string>,
 ) {
-  const incomingByField = {} as Record<keyof F & string, Array<{ field: string; type: string }>>
-  const outgoingByField = {} as Record<keyof F & string, Array<{ field: string; type: string }>>
+  const incomingByField = {} as Record<
+    keyof F & string,
+    Array<{ field: string; type: string }>
+  >
+  const outgoingByField = {} as Record<
+    keyof F & string,
+    Array<{ field: string; type: string }>
+  >
 
   for (const field of fieldNames) {
     incomingByField[field] = []
@@ -122,8 +143,14 @@ function buildFieldEdgeLookup<F extends Record<string, FieldDef>>(
   }
 
   for (const edge of graph.edges) {
-    incomingByField[edge.to as keyof F & string].push({ field: edge.from, type: edge.type })
-    outgoingByField[edge.from as keyof F & string].push({ field: edge.to, type: edge.type })
+    incomingByField[edge.to as keyof F & string].push({
+      field: edge.from,
+      type: edge.type,
+    })
+    outgoingByField[edge.from as keyof F & string].push({
+      field: edge.to,
+      type: edge.type,
+    })
   }
 
   return {
@@ -163,11 +190,13 @@ function inspectRuleTraceAttachments<
       return []
     }
 
-    return [{
-      kind: attachment.kind,
-      id: attachment.id,
-      ...result,
-    }]
+    return [
+      {
+        kind: attachment.kind,
+        id: attachment.id,
+        ...result,
+      },
+    ]
   })
 
   return trace.length > 0 ? trace : undefined
@@ -196,10 +225,7 @@ function withRuleTrace<
 function didRulePass<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  rule: Rule<F, C>,
-  evaluation: RuleEvaluation,
-): boolean {
+>(rule: Rule<F, C>, evaluation: RuleEvaluation): boolean {
   return isFairRule(rule) ? evaluation.fair !== false : evaluation.enabled
 }
 
@@ -216,9 +242,12 @@ function normalizeConfig<
   const normalizedFields = {} as NormalizeFields<F>
   const attachedRules: Rule<NormalizeFields<F>, C>[] = []
 
-  for (const [fieldKey, rawField] of Object.entries(rawFields) as Array<[keyof F & string, F[keyof F & string]]>) {
+  for (const [fieldKey, rawField] of Object.entries(rawFields) as Array<
+    [keyof F & string, F[keyof F & string]]
+  >) {
     if (!isFieldBuilder(rawField)) {
-      normalizedFields[fieldKey] = rawField as unknown as NormalizeFields<F>[keyof F & string]
+      normalizedFields[fieldKey] =
+        rawField as unknown as NormalizeFields<F>[keyof F & string]
       continue
     }
 
@@ -229,15 +258,21 @@ function normalizeConfig<
       )
     }
 
-    normalizedFields[fieldKey] = getFieldBuilderDef(rawField) as NormalizeFields<F>[keyof F & string]
+    normalizedFields[fieldKey] = getFieldBuilderDef(
+      rawField,
+    ) as NormalizeFields<F>[keyof F & string]
 
     for (const attachedRule of getFieldBuilderRules(rawField)) {
       if (attachedRule.kind === 'enabledWhen') {
         attachedRules.push(
           enabledWhen<NormalizeFields<F>, C>(
             fieldKey,
-            attachedRule.predicate as Parameters<typeof enabledWhen<NormalizeFields<F>, C>>[1],
-            attachedRule.options as Parameters<typeof enabledWhen<NormalizeFields<F>, C>>[2],
+            attachedRule.predicate as Parameters<
+              typeof enabledWhen<NormalizeFields<F>, C>
+            >[1],
+            attachedRule.options as Parameters<
+              typeof enabledWhen<NormalizeFields<F>, C>
+            >[2],
           ),
         )
         continue
@@ -247,8 +282,12 @@ function normalizeConfig<
         attachedRules.push(
           fairWhen<NormalizeFields<F>, C>(
             fieldKey,
-            attachedRule.predicate as Parameters<typeof fairWhen<NormalizeFields<F>, C>>[1],
-            attachedRule.options as Parameters<typeof fairWhen<NormalizeFields<F>, C>>[2],
+            attachedRule.predicate as Parameters<
+              typeof fairWhen<NormalizeFields<F>, C>
+            >[1],
+            attachedRule.options as Parameters<
+              typeof fairWhen<NormalizeFields<F>, C>
+            >[2],
           ),
         )
         continue
@@ -258,7 +297,9 @@ function normalizeConfig<
         requires<NormalizeFields<F>, C>(
           fieldKey,
           attachedRule.dependency as keyof NormalizeFields<F> & string,
-          attachedRule.options as Parameters<typeof requires<NormalizeFields<F>, C>>[2],
+          attachedRule.options as Parameters<
+            typeof requires<NormalizeFields<F>, C>
+          >[2],
         ),
       )
     }
@@ -298,14 +339,20 @@ function describeRuleForField<
   if (metadata?.kind === 'enabledWhen') {
     const source = getSourceField(metadata.predicate)
 
-    return withRuleTrace({
-      rule: 'enabledWhen',
-      passed: evaluation.enabled,
-      reason: evaluation.reason,
-      predicate: metadata.predicate.toString(),
-      source,
-      sourceValue: source ? values[source] : undefined,
-    }, metadata, values, conditions, prev)
+    return withRuleTrace(
+      {
+        rule: 'enabledWhen',
+        passed: evaluation.enabled,
+        reason: evaluation.reason,
+        predicate: metadata.predicate.toString(),
+        source,
+        sourceValue: source ? values[source] : undefined,
+      },
+      metadata,
+      values,
+      conditions,
+      prev,
+    )
   }
 
   if (metadata?.kind === 'disables') {
@@ -316,24 +363,36 @@ function describeRuleForField<
         : metadata.source(values, conditions)
     const source = sourceField ?? metadata.source.toString()
 
-    return withRuleTrace({
-      rule: 'disables',
-      passed: evaluation.enabled,
-      reason: evaluation.reason,
-      source,
-      sourceValue: sourceField ? values[sourceField] : sourceSatisfied,
-      sourceSatisfied,
-    }, metadata, values, conditions, prev)
+    return withRuleTrace(
+      {
+        rule: 'disables',
+        passed: evaluation.enabled,
+        reason: evaluation.reason,
+        source,
+        sourceValue: sourceField ? values[sourceField] : sourceSatisfied,
+        sourceSatisfied,
+      },
+      metadata,
+      values,
+      conditions,
+      prev,
+    )
   }
 
   if (metadata?.kind === 'fairWhen') {
-    return withRuleTrace({
-      rule: 'fair',
-      passed: evaluation.fair !== false,
-      reason: evaluation.reason,
-      predicate: metadata.predicate.toString(),
-      value: values[field],
-    }, metadata, values, conditions, prev)
+    return withRuleTrace(
+      {
+        rule: 'fair',
+        passed: evaluation.fair !== false,
+        reason: evaluation.reason,
+        predicate: metadata.predicate.toString(),
+        value: values[field],
+      },
+      metadata,
+      values,
+      conditions,
+      prev,
+    )
   }
 
   if (metadata?.kind === 'requires') {
@@ -343,7 +402,9 @@ function describeRuleForField<
       if (typeof dependency !== 'string') {
         return {
           dependency: dependencyField ?? dependency.toString(),
-          dependencyValue: dependencyField ? values[dependencyField] : undefined,
+          dependencyValue: dependencyField
+            ? values[dependencyField]
+            : undefined,
           satisfied: dependency(values, conditions),
         }
       }
@@ -356,17 +417,23 @@ function describeRuleForField<
       }
     })
 
-    return withRuleTrace({
-      rule: 'requires',
-      passed: evaluation.enabled,
-      reason: evaluation.reason,
-      dependency: dependencies[0]?.dependency,
-      dependencyValue: dependencies[0]?.dependencyValue,
-      satisfied: dependencies[0]?.satisfied,
-      dependencyEnabled: dependencies[0]?.dependencyEnabled,
-      dependencyFair: dependencies[0]?.dependencyFair,
-      dependencies,
-    }, metadata, values, conditions, prev)
+    return withRuleTrace(
+      {
+        rule: 'requires',
+        passed: evaluation.enabled,
+        reason: evaluation.reason,
+        dependency: dependencies[0]?.dependency,
+        dependencyValue: dependencies[0]?.dependencyValue,
+        satisfied: dependencies[0]?.satisfied,
+        dependencyEnabled: dependencies[0]?.dependencyEnabled,
+        dependencyFair: dependencies[0]?.dependencyFair,
+        dependencies,
+      },
+      metadata,
+      values,
+      conditions,
+      prev,
+    )
   }
 
   if (metadata?.kind === 'oneOf') {
@@ -380,30 +447,39 @@ function describeRuleForField<
       conditions,
     )
     const thisBranch =
-      Object.entries(metadata.branches).find(([, branchFields]) => branchFields.includes(field))?.[0] ?? null
+      Object.entries(metadata.branches).find(([, branchFields]) =>
+        branchFields.includes(field),
+      )?.[0] ?? null
 
-    return withRuleTrace({
-      rule: 'oneOf',
-      passed: evaluation.enabled,
-      reason: evaluation.reason,
-      group: metadata.groupName,
-      activeBranch: resolution.activeBranch,
-      thisBranch,
-    }, metadata, values, conditions, prev)
+    return withRuleTrace(
+      {
+        rule: 'oneOf',
+        passed: evaluation.enabled,
+        reason: evaluation.reason,
+        group: metadata.groupName,
+        activeBranch: resolution.activeBranch,
+        thisBranch,
+      },
+      metadata,
+      values,
+      conditions,
+      prev,
+    )
   }
 
   if (metadata?.kind === 'anyOf') {
-    const inner: ChallengeTrace['directReasons'] = metadata.rules.map((innerRule) =>
-      describeRuleForField(
-        innerRule,
-        field,
-        fields,
-        values,
-        conditions,
-        prev,
-        availability,
-        baseRuleCache,
-      ),
+    const inner: ChallengeTrace['directReasons'] = metadata.rules.map(
+      (innerRule) =>
+        describeRuleForField(
+          innerRule,
+          field,
+          fields,
+          values,
+          conditions,
+          prev,
+          availability,
+          baseRuleCache,
+        ),
     )
 
     return {
@@ -427,14 +503,21 @@ function describeRuleForField<
             prev,
             availability,
             baseRuleCache,
-          ))
+          ),
+        )
 
-        return [branchName, {
-          passed: inner.every((entry) => entry.passed),
-          inner,
-        }]
+        return [
+          branchName,
+          {
+            passed: inner.every((entry) => entry.passed),
+            inner,
+          },
+        ]
       }),
-    ) as Record<string, { passed: boolean; inner: ChallengeTrace['directReasons'] }>
+    ) as Record<
+      string,
+      { passed: boolean; inner: ChallengeTrace['directReasons'] }
+    >
 
     const matchedBranches = Object.entries(branches)
       .filter(([, branch]) => branch.passed)
@@ -451,11 +534,17 @@ function describeRuleForField<
     }
   }
 
-  return withRuleTrace({
-    rule: rule.type,
-    passed: didRulePass(rule, evaluation),
-    reason: evaluation.reason,
-  }, metadata, values, conditions, prev)
+  return withRuleTrace(
+    {
+      rule: rule.type,
+      passed: didRulePass(rule, evaluation),
+      reason: evaluation.reason,
+    },
+    metadata,
+    values,
+    conditions,
+    prev,
+  )
 }
 
 function collectFailedDependenciesForRule<
@@ -485,7 +574,11 @@ function collectFailedDependenciesForRule<
       baseRuleCache,
     )
 
-    if (metadata.constraint === 'fair' ? evaluation.fair !== false : evaluation.enabled) {
+    if (
+      metadata.constraint === 'fair'
+        ? evaluation.fair !== false
+        : evaluation.enabled
+    ) {
       return []
     }
 
@@ -521,7 +614,11 @@ function collectFailedDependenciesForRule<
       baseRuleCache,
     )
 
-    if (metadata.constraint === 'fair' ? evaluation.fair !== false : evaluation.enabled) {
+    if (
+      metadata.constraint === 'fair'
+        ? evaluation.fair !== false
+        : evaluation.enabled
+    ) {
       return []
     }
 
@@ -566,16 +663,25 @@ function collectFailedDependenciesForRule<
     return []
   }
 
-  return metadata.dependencies.filter((dependency): dependency is keyof F & string => {
-    if (typeof dependency !== 'string') {
-      return false
-    }
+  return metadata.dependencies.filter(
+    (dependency): dependency is keyof F & string => {
+      if (typeof dependency !== 'string') {
+        return false
+      }
 
-    const dependencySatisfied = isSatisfied(values[dependency], fields[dependency])
-    const dependencyAvailability = availability[dependency]
+      const dependencySatisfied = isSatisfied(
+        values[dependency],
+        fields[dependency],
+      )
+      const dependencyAvailability = availability[dependency]
 
-    return !(dependencySatisfied && dependencyAvailability.enabled && dependencyAvailability.fair)
-  })
+      return !(
+        dependencySatisfied &&
+        dependencyAvailability.enabled &&
+        dependencyAvailability.fair
+      )
+    },
+  )
 }
 
 function describeCausedBy<
@@ -705,25 +811,27 @@ function getStructuralRequirementsFromRule<
 
   return metadata.dependencies.flatMap((dependency) => {
     const dependencyField =
-      typeof dependency === 'string'
-        ? dependency
-        : getSourceField(dependency)
+      typeof dependency === 'string' ? dependency : getSourceField(dependency)
 
     if (!dependencyField) {
       return []
     }
 
-    return [{
-      target: rule.targets[0],
-      dependency: dependencyField,
-    }]
+    return [
+      {
+        target: rule.targets[0],
+        dependency: dependencyField,
+      },
+    ]
   })
 }
 
 function getFieldSourceDisableTargetsFromRule<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(rule: Rule<F, C>): { source: keyof F & string; targets: Array<keyof F & string> } | null {
+>(
+  rule: Rule<F, C>,
+): { source: keyof F & string; targets: Array<keyof F & string> } | null {
   const metadata = getInternalRuleMetadata(rule)
 
   // Only a plain field-name source proves the hard contradiction we care
@@ -809,7 +917,9 @@ function validateStructuralContradictions<
 
     const disableTargets = getFieldSourceDisableTargetsFromRule(rule)
     if (disableTargets) {
-      const targets = disablesBySource.get(disableTargets.source) ?? new Set<keyof F & string>()
+      const targets =
+        disablesBySource.get(disableTargets.source) ??
+        new Set<keyof F & string>()
 
       for (const target of disableTargets.targets) {
         targets.add(target)
@@ -835,7 +945,11 @@ function validateStructuralContradictions<
       const targetBranch = group.branchByField.get(target)
       const dependencyBranch = group.branchByField.get(dependency)
 
-      if (!targetBranch || !dependencyBranch || targetBranch === dependencyBranch) {
+      if (
+        !targetBranch ||
+        !dependencyBranch ||
+        targetBranch === dependencyBranch
+      ) {
         continue
       }
 
@@ -857,7 +971,9 @@ function validateRules<
     const { ordering, informational } = getGraphSourceInfo(rule)
 
     if (metadata?.kind === 'oneOf') {
-      for (const [branchName, branchFields] of Object.entries(metadata.branches)) {
+      for (const [branchName, branchFields] of Object.entries(
+        metadata.branches,
+      )) {
         for (const field of branchFields) {
           if (!fieldNames.has(field)) {
             throw new Error(
@@ -870,7 +986,9 @@ function validateRules<
 
     for (const field of [...ordering, ...informational, ...rule.targets]) {
       if (!fieldNames.has(field)) {
-        throw new Error(`[@umpire/core] Unknown field "${field}" referenced by ${rule.type} rule`)
+        throw new Error(
+          `[@umpire/core] Unknown field "${field}" referenced by ${rule.type} rule`,
+        )
       }
     }
   }
@@ -887,7 +1005,9 @@ export function umpire<
   validators?: ValidationMap<NormalizeFields<FInput>>
 }): Umpire<NormalizeFields<FInput>, C> {
   const { fields, rules } = normalizeConfig(config.fields, config.rules)
-  const fieldNames = Object.keys(fields) as Array<keyof NormalizeFields<FInput> & string>
+  const fieldNames = Object.keys(fields) as Array<
+    keyof NormalizeFields<FInput> & string
+  >
   const validators = normalizeValidators(fields, config.validators)
   const hasValidators = Object.keys(validators).length > 0
 
@@ -899,7 +1019,10 @@ export function umpire<
   const rulesByTarget = indexRulesByTarget(rules)
   const rulesByTargetPhase = indexRulesByTargetPhase(rulesByTarget)
   const exportedGraph = exportGraph(graph)
-  const { incomingByField, outgoingByField } = buildFieldEdgeLookup(exportedGraph, fieldNames)
+  const { incomingByField, outgoingByField } = buildFieldEdgeLookup(
+    exportedGraph,
+    fieldNames,
+  )
 
   function exportCompiledGraph(): UmpireGraph {
     return {
@@ -948,7 +1071,9 @@ export function umpire<
 
       const result = runValidationEntry(
         validator,
-        values[field] as NonNullable<FieldValues<NormalizeFields<FInput>>[typeof field]>,
+        values[field] as NonNullable<
+          FieldValues<NormalizeFields<FInput>>[typeof field]
+        >,
       )
 
       const nextStatus = { ...status, valid: result.valid }
@@ -982,10 +1107,8 @@ export function umpire<
     for (const field of fieldNames) {
       const beforeStatus = beforeAvailability[field]
       const afterStatus = afterAvailability[field]
-      const disabledTransition =
-        beforeStatus.enabled && !afterStatus.enabled
-      const foulTransition =
-        beforeStatus.fair && afterStatus.fair === false
+      const disabledTransition = beforeStatus.enabled && !afterStatus.enabled
+      const foulTransition = beforeStatus.fair && afterStatus.fair === false
 
       if (!disabledTransition && !foulTransition) {
         continue
@@ -1006,7 +1129,9 @@ export function umpire<
 
       recommendations.push({
         field,
-        reason: afterStatus.reason ?? (disabledTransition ? 'field disabled' : 'field fouled'),
+        reason:
+          afterStatus.reason ??
+          (disabledTransition ? 'field disabled' : 'field fouled'),
         suggestedValue,
       })
     }
@@ -1019,11 +1144,15 @@ export function umpire<
 
     for (const field of fieldNames) {
       if (overrides && field in overrides) {
-        values[field] = overrides[field] as FieldValues<NormalizeFields<FInput>>[typeof field]
+        values[field] = overrides[field] as FieldValues<
+          NormalizeFields<FInput>
+        >[typeof field]
         continue
       }
 
-      values[field] = fields[field].default as FieldValues<NormalizeFields<FInput>>[typeof field]
+      values[field] = fields[field].default as FieldValues<
+        NormalizeFields<FInput>
+      >[typeof field]
     }
 
     return values
@@ -1042,28 +1171,36 @@ export function umpire<
     const resolvedConditions = createEmptyConditions(conditions)
     const typedValues = values as FieldValues<NormalizeFields<FInput>>
     const typedPrev = prev as FieldValues<NormalizeFields<FInput>> | undefined
-    const availability = checkAvailability(typedValues, resolvedConditions, typedPrev)
-    const baseRuleCache = new Map<Rule<NormalizeFields<FInput>, C>, Map<string, RuleEvaluation>>()
+    const availability = checkAvailability(
+      typedValues,
+      resolvedConditions,
+      typedPrev,
+    )
+    const baseRuleCache = new Map<
+      Rule<NormalizeFields<FInput>, C>,
+      Map<string, RuleEvaluation>
+    >()
     const targetRules = rulesByTarget.get(field) ?? []
-    const directReasons = targetRules
-      .map((rule) =>
-        describeRuleForField(
-          rule,
-          field,
-          fields,
-          typedValues,
-          resolvedConditions,
-          typedPrev,
-          availability,
-          baseRuleCache,
-        ),
-      )
+    const directReasons = targetRules.map((rule) =>
+      describeRuleForField(
+        rule,
+        field,
+        fields,
+        typedValues,
+        resolvedConditions,
+        typedPrev,
+        availability,
+        baseRuleCache,
+      ),
+    )
 
     const oneOfRule = targetRules.find((rule) => {
       const metadata = getInternalRuleMetadata(rule)
       return metadata?.kind === 'oneOf'
     })
-    const oneOfMetadata = oneOfRule ? getInternalRuleMetadata(oneOfRule) : undefined
+    const oneOfMetadata = oneOfRule
+      ? getInternalRuleMetadata(oneOfRule)
+      : undefined
     const oneOfResolution =
       oneOfMetadata?.kind === 'oneOf'
         ? {
@@ -1108,8 +1245,14 @@ export function umpire<
   ): ScorecardResult<NormalizeFields<FInput>, C> {
     const { before, includeChallenge = false } = options
     const typedValues = snapshot.values as FieldValues<NormalizeFields<FInput>>
-    const typedPrev = before?.values as FieldValues<NormalizeFields<FInput>> | undefined
-    const structuralCheck = checkAvailability(typedValues, snapshot.conditions, typedPrev)
+    const typedPrev = before?.values as
+      | FieldValues<NormalizeFields<FInput>>
+      | undefined
+    const structuralCheck = checkAvailability(
+      typedValues,
+      snapshot.conditions,
+      typedPrev,
+    )
     const check = attachValidationMetadata(typedValues, structuralCheck)
     const changedFields = getChangedFields(
       fieldNames,
@@ -1131,8 +1274,12 @@ export function umpire<
     const foulsByField = foulMap(fouls)
     const changedFieldSet = new Set(changedFields)
     const fouledFields = fouls.map((foul) => foul.field)
-    const directlyFouledFields = fouledFields.filter((field) => changedFieldSet.has(field))
-    const cascadingFields = fouledFields.filter((field) => !changedFieldSet.has(field))
+    const directlyFouledFields = fouledFields.filter((field) =>
+      changedFieldSet.has(field),
+    )
+    const cascadingFields = fouledFields.filter(
+      (field) => !changedFieldSet.has(field),
+    )
     const cascadingFieldSet = new Set(cascadingFields)
 
     const scorecardFields = Object.fromEntries(
@@ -1140,7 +1287,10 @@ export function umpire<
         const availability = check[field]
         const value = typedValues[field]
         const present = !isEmptyPresent(value)
-        const scorecardField: ScorecardResult<NormalizeFields<FInput>, C>['fields'][typeof field] = {
+        const scorecardField: ScorecardResult<
+          NormalizeFields<FInput>,
+          C
+        >['fields'][typeof field] = {
           field,
           value,
           present,
@@ -1156,7 +1306,12 @@ export function umpire<
           incoming: incomingByField[field],
           outgoing: outgoingByField[field],
           trace: includeChallenge
-            ? buildChallenge(field, snapshot.values, snapshot.conditions, before?.values)
+            ? buildChallenge(
+                field,
+                snapshot.values,
+                snapshot.conditions,
+                before?.values,
+              )
             : undefined,
         }
 
@@ -1168,10 +1323,7 @@ export function umpire<
           scorecardField.error = availability.error
         }
 
-        return [
-          field,
-          scorecardField,
-        ]
+        return [field, scorecardField]
       }),
     ) as ScorecardResult<NormalizeFields<FInput>, C>['fields']
 
@@ -1192,11 +1344,7 @@ export function umpire<
   }
 
   return {
-    check(
-      values: InputValues,
-      conditions?: C,
-      prev?: InputValues,
-    ) {
+    check(values: InputValues, conditions?: C, prev?: InputValues) {
       const typedValues = values as FieldValues<NormalizeFields<FInput>>
 
       return attachValidationMetadata(

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -21,45 +21,69 @@ type NormalizedValidationResult =
 
 // `check()` remains boolean-only at the public API boundary, but the runtime
 // validator shapes are otherwise shared with richer validation entries.
-type SupportedValidator<T = unknown> = FieldValidator<T> | ValidationValidator<T>
+type SupportedValidator<T = unknown> =
+  | FieldValidator<T>
+  | ValidationValidator<T>
 
 type ValidationEntryObject<T = unknown> = {
   validator: ValidationValidator<T>
   error?: string
 }
 
-function isSafeParseValidator<T = unknown>(validator: unknown): validator is SafeParseValidator<T> {
+function isSafeParseValidator<T = unknown>(
+  validator: unknown,
+): validator is SafeParseValidator<T> {
   return isRecord(validator) && typeof validator.safeParse === 'function'
 }
 
-function isStringTestValidator(validator: unknown): validator is StringTestValidator {
+function isStringTestValidator(
+  validator: unknown,
+): validator is StringTestValidator {
   return isRecord(validator) && typeof validator.test === 'function'
 }
 
-export function isNamedCheck<T = unknown>(validator: unknown): validator is NamedCheck<T> {
-  return isRecord(validator) &&
+export function isNamedCheck<T = unknown>(
+  validator: unknown,
+): validator is NamedCheck<T> {
+  return (
+    isRecord(validator) &&
     typeof validator.__check === 'string' &&
     typeof validator.validate === 'function'
+  )
 }
 
-function isSupportedValidator<T = unknown>(validator: unknown): validator is SupportedValidator<T> {
-  return typeof validator === 'function' ||
+function isSupportedValidator<T = unknown>(
+  validator: unknown,
+): validator is SupportedValidator<T> {
+  return (
+    typeof validator === 'function' ||
     isNamedCheck<T>(validator) ||
     isSafeParseValidator<T>(validator) ||
     isStringTestValidator(validator)
+  )
 }
 
 function isValidationResult(result: unknown): result is ValidationResult {
-  return isRecord(result) &&
+  return (
+    isRecord(result) &&
     typeof result.valid === 'boolean' &&
-    (!('error' in result) || result.error === undefined || typeof result.error === 'string')
+    (!('error' in result) ||
+      result.error === undefined ||
+      typeof result.error === 'string')
+  )
 }
 
-function isValidationEntryObject<T = unknown>(entry: unknown): entry is ValidationEntryObject<T> {
-  return isRecord(entry) &&
+function isValidationEntryObject<T = unknown>(
+  entry: unknown,
+): entry is ValidationEntryObject<T> {
+  return (
+    isRecord(entry) &&
     'validator' in entry &&
     isSupportedValidator<T>(entry.validator) &&
-    (!('error' in entry) || entry.error === undefined || typeof entry.error === 'string')
+    (!('error' in entry) ||
+      entry.error === undefined ||
+      typeof entry.error === 'string')
+  )
 }
 
 function normalizeValidationResult(
@@ -78,7 +102,7 @@ function normalizeValidationResult(
     if (shouldWarnInDev()) {
       console.warn(
         '[@umpire/core] Validation functions must return a boolean or { valid, error? }. ' +
-        'Received an unsupported result and treated it as invalid.',
+          'Received an unsupported result and treated it as invalid.',
       )
     }
 

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -5,8 +5,5 @@
     "composite": false,
     "rootDir": "."
   },
-  "include": [
-    "src",
-    "type-tests/**/*.ts"
-  ]
+  "include": ["src", "type-tests/**/*.ts"]
 }

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -12,7 +12,7 @@ export default defineConfig([
     sourcemap: true,
   },
   {
-    entry: { 'index': 'src/index.ts' },
+    entry: { index: 'src/index.ts' },
     format: ['iife'],
     globalName: 'Umpire',
     platform: 'browser',

--- a/packages/core/type-tests/foul-suggested-value.type-test.ts
+++ b/packages/core/type-tests/foul-suggested-value.type-test.ts
@@ -66,15 +66,16 @@ if (maybePlayedFoul && maybePlayedFoul.field === 'notes') {
   void value
 }
 
-const struck = strike<Fields>(
-  { plan: 'free', seats: 1, notes: 'hello' },
-  [{ field: 'seats', reason: 'reset seats', suggestedValue: 3 }],
-)
+const struck = strike<Fields>({ plan: 'free', seats: 1, notes: 'hello' }, [
+  { field: 'seats', reason: 'reset seats', suggestedValue: 3 },
+])
 
 const struckSeats: number | undefined = struck.seats
 
-// @ts-expect-error seats foul suggestedValue must be number | undefined
-strike<Fields>({}, [{ field: 'seats', reason: 'wrong type', suggestedValue: '3' }])
+strike<Fields>({}, [
+  // @ts-expect-error seats foul suggestedValue must be number | undefined
+  { field: 'seats', reason: 'wrong type', suggestedValue: '3' },
+])
 
 // @ts-expect-error seats suggestedValue must be number | undefined
 const invalidFoul: Foul<Fields> = {

--- a/packages/core/type-tests/one-of-active-branch.type-test.ts
+++ b/packages/core/type-tests/one-of-active-branch.type-test.ts
@@ -15,32 +15,49 @@ const fields = {
 umpire<Fields>({
   fields,
   rules: [
-    oneOf('strategy', {
-      first: ['alpha'],
-      second: ['beta'],
-    }, {
-      activeBranch: (values) => (values.mode === 'second' ? 'second' : 'first'),
-    }),
+    oneOf(
+      'strategy',
+      {
+        first: ['alpha'],
+        second: ['beta'],
+      },
+      {
+        activeBranch: (values) =>
+          values.mode === 'second' ? 'second' : 'first',
+      },
+    ),
   ],
 })
 
-oneOf('strategy', {
-  first: ['alpha'],
-  second: ['beta'],
-}, { activeBranch: 'first' })
+oneOf(
+  'strategy',
+  {
+    first: ['alpha'],
+    second: ['beta'],
+  },
+  { activeBranch: 'first' },
+)
 
-oneOf('strategy', {
-  first: ['alpha'],
-  second: ['beta'],
-}, {
-  // @ts-expect-error unknown static branch should fail
-  activeBranch: 'third',
-})
+oneOf(
+  'strategy',
+  {
+    first: ['alpha'],
+    second: ['beta'],
+  },
+  {
+    // @ts-expect-error unknown static branch should fail
+    activeBranch: 'third',
+  },
+)
 
-oneOf('strategy', {
-  first: ['alpha'],
-  second: ['beta'],
-}, {
-  // @ts-expect-error dynamic branch return must be one of declared branches
-  activeBranch: () => 'third',
-})
+oneOf(
+  'strategy',
+  {
+    first: ['alpha'],
+    second: ['beta'],
+  },
+  {
+    // @ts-expect-error dynamic branch return must be one of declared branches
+    activeBranch: () => 'third',
+  },
+)

--- a/packages/devtools/__tests__/panel.test.ts
+++ b/packages/devtools/__tests__/panel.test.ts
@@ -47,15 +47,20 @@ describe('Panel', () => {
 
     expect(toggle).not.toBeNull()
 
-    toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    toggle?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true }),
+    )
     await flushUi()
 
-    const conditionsTab = [...(root?.querySelectorAll('button') ?? [])]
-      .find((button) => button.textContent?.trim().toLowerCase() === 'conditions')
+    const conditionsTab = [...(root?.querySelectorAll('button') ?? [])].find(
+      (button) => button.textContent?.trim().toLowerCase() === 'conditions',
+    )
 
     expect(conditionsTab).not.toBeNull()
 
-    conditionsTab?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    conditionsTab?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true }),
+    )
     await flushUi()
 
     const text = root?.textContent ?? ''
@@ -69,28 +74,26 @@ describe('Panel', () => {
   })
 
   it('renders custom extension tabs from register options', async () => {
-    register(
-      'signup',
-      demoUmp,
-      { email: 'alex@example.com' },
-      undefined,
-      {
-        extensions: [{
+    register('signup', demoUmp, { email: 'alex@example.com' }, undefined, {
+      extensions: [
+        {
           id: 'validation',
           label: 'validation',
           inspect: () => ({
-            sections: [{
-              kind: 'rows',
-              title: 'Summary',
-              rows: [
-                { label: 'status', value: 'blocked' },
-                { label: 'issueCount', value: 2 },
-              ],
-            }],
+            sections: [
+              {
+                kind: 'rows',
+                title: 'Summary',
+                rows: [
+                  { label: 'status', value: 'blocked' },
+                  { label: 'issueCount', value: 2 },
+                ],
+              },
+            ],
           }),
-        }],
-      },
-    )
+        },
+      ],
+    })
 
     mount()
 
@@ -100,15 +103,20 @@ describe('Panel', () => {
 
     expect(toggle).not.toBeNull()
 
-    toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    toggle?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true }),
+    )
     await flushUi()
 
-    const validationTab = [...(root?.querySelectorAll('button') ?? [])]
-      .find((button) => button.textContent?.trim().toLowerCase() === 'validation')
+    const validationTab = [...(root?.querySelectorAll('button') ?? [])].find(
+      (button) => button.textContent?.trim().toLowerCase() === 'validation',
+    )
 
     expect(validationTab).not.toBeNull()
 
-    validationTab?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    validationTab?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true }),
+    )
     await flushUi()
 
     const text = root?.textContent ?? ''
@@ -136,13 +144,9 @@ describe('Panel', () => {
       ],
     })
 
-    register(
-      'signup',
-      readsUmp,
-      { email: 'alex@example.com' },
-      undefined,
-      { reads },
-    )
+    register('signup', readsUmp, { email: 'alex@example.com' }, undefined, {
+      reads,
+    })
 
     mount({ defaultTab: 'reads' })
 
@@ -152,7 +156,9 @@ describe('Panel', () => {
 
     expect(toggle).not.toBeNull()
 
-    toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    toggle?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true }),
+    )
     await flushUi()
 
     const text = root?.textContent ?? ''
@@ -204,15 +210,20 @@ describe('Panel', () => {
 
     expect(toggle).not.toBeNull()
 
-    toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    toggle?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true }),
+    )
     await flushUi()
 
-    const submitRow = [...(root?.querySelectorAll('tr') ?? [])]
-      .find((row) => row.textContent?.includes('submit'))
+    const submitRow = [...(root?.querySelectorAll('tr') ?? [])].find((row) =>
+      row.textContent?.includes('submit'),
+    )
 
     expect(submitRow).not.toBeNull()
 
-    submitRow?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+    submitRow?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true }),
+    )
     await flushUi()
 
     const text = root?.textContent ?? ''

--- a/packages/devtools/__tests__/react.test.tsx
+++ b/packages/devtools/__tests__/react.test.tsx
@@ -94,10 +94,7 @@ describe('react hooks', () => {
     })
 
     expect(registerSpy).toHaveBeenCalledTimes(2)
-    expect(renders).toEqual([
-      { fouls: [] },
-      { fouls: ['target'] },
-    ])
+    expect(renders).toEqual([{ fouls: [] }, { fouls: ['target'] }])
     expect(registry.snapshot().get('demo')?.previous?.values.gate).toBe('open')
   })
 })

--- a/packages/devtools/__tests__/registry.test.ts
+++ b/packages/devtools/__tests__/registry.test.ts
@@ -105,7 +105,10 @@ describe('registry', () => {
   })
 
   it('stores precomputed read inspections from register options', () => {
-    const inspection: ReadTableInspection<Record<string, unknown>, Record<string, unknown>> = {
+    const inspection: ReadTableInspection<
+      Record<string, unknown>,
+      Record<string, unknown>
+    > = {
       bridges: [],
       graph: {
         edges: [],
@@ -181,16 +184,20 @@ describe('registry', () => {
       { from: 'status', to: 'summary', type: 'read' },
       { from: 'status', to: 'target', type: 'bridge' },
     ])
-    expect(readsInspection?.nodes.status).toEqual(expect.objectContaining({
-      dependsOnFields: ['gate'],
-      dependsOnReads: [],
-      value: 'open',
-    }))
-    expect(readsInspection?.nodes.summary).toEqual(expect.objectContaining({
-      dependsOnFields: [],
-      dependsOnReads: ['status'],
-      value: 'open::open',
-    }))
+    expect(readsInspection?.nodes.status).toEqual(
+      expect.objectContaining({
+        dependsOnFields: ['gate'],
+        dependsOnReads: [],
+        value: 'open',
+      }),
+    )
+    expect(readsInspection?.nodes.summary).toEqual(
+      expect.objectContaining({
+        dependsOnFields: [],
+        dependsOnReads: ['status'],
+        value: 'open::open',
+      }),
+    )
     expect(readsInspection?.values).toEqual({
       status: 'open',
       summary: 'open::open',
@@ -232,7 +239,9 @@ describe('registry', () => {
     )
 
     expect(inspect).toHaveBeenCalledWith({ externalGate: 'override' })
-    expect(snapshot().get('demo')?.reads?.values).toEqual({ status: 'override' })
+    expect(snapshot().get('demo')?.reads?.values).toEqual({
+      status: 'override',
+    })
     expect(snapshot().get('demo')?.extensions).toEqual([])
   })
 
@@ -319,14 +328,16 @@ describe('registry', () => {
 
   it('stores resolved custom extensions from register options', () => {
     const inspect = mock(() => ({
-      sections: [{
-        kind: 'rows' as const,
-        title: 'Summary',
-        rows: [
-          { label: 'status', value: 'blocked' },
-          { label: 'reason', value: 'gate required' },
-        ],
-      }],
+      sections: [
+        {
+          kind: 'rows' as const,
+          title: 'Summary',
+          rows: [
+            { label: 'status', value: 'blocked' },
+            { label: 'reason', value: 'gate required' },
+          ],
+        },
+      ],
     }))
 
     register(
@@ -338,34 +349,40 @@ describe('registry', () => {
       },
       { flow: 'signup' },
       {
-        extensions: [{
-          id: 'validation',
-          label: 'validation',
-          inspect,
-        }],
+        extensions: [
+          {
+            id: 'validation',
+            label: 'validation',
+            inspect,
+          },
+        ],
       },
     )
 
-    expect(inspect).toHaveBeenCalledWith(expect.objectContaining({
-      conditions: { flow: 'signup' },
-      previous: null,
-      values: {
-        gate: '',
-        target: 'kept',
-      },
-    }))
+    expect(inspect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conditions: { flow: 'signup' },
+        previous: null,
+        values: {
+          gate: '',
+          target: 'kept',
+        },
+      }),
+    )
     expect(snapshot().get('demo')?.extensions).toContainEqual({
       id: 'validation',
       label: 'validation',
       view: {
-        sections: [{
-          kind: 'rows',
-          title: 'Summary',
-          rows: [
-            { label: 'status', value: 'blocked' },
-            { label: 'reason', value: 'gate required' },
-          ],
-        }],
+        sections: [
+          {
+            kind: 'rows',
+            title: 'Summary',
+            rows: [
+              { label: 'status', value: 'blocked' },
+              { label: 'reason', value: 'gate required' },
+            ],
+          },
+        ],
       },
     })
   })

--- a/packages/devtools/entrypoints/react.ts
+++ b/packages/devtools/entrypoints/react.ts
@@ -11,9 +11,7 @@ import { snapshotValue } from '@umpire/core/snapshot'
 import type { RegisterOptions } from '../src/types.js'
 import { register, unregister } from '../src/registry.js'
 
-function formatUmpireDebugValue<
-  F extends Record<string, FieldDef>,
->(value: {
+function formatUmpireDebugValue<F extends Record<string, FieldDef>>(value: {
   check: AvailabilityMap<F>
   fouls: Foul<F>[]
 }) {
@@ -73,9 +71,12 @@ export function useUmpireWithDevtools<
   // If React ever warns about this, useLayoutEffect is the correct upgrade path.
   register(id, ump, values, conditions, options)
 
-  useEffect(() => () => {
-    unregister(id)
-  }, [id])
+  useEffect(
+    () => () => {
+      unregister(id)
+    },
+    [id],
+  )
 
   return { check, fouls }
 }

--- a/packages/devtools/happydom.ts
+++ b/packages/devtools/happydom.ts
@@ -1,5 +1,6 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
 
 GlobalRegistrator.register()
-
-;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+;(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true

--- a/packages/devtools/smoke/build.ts
+++ b/packages/devtools/smoke/build.ts
@@ -24,7 +24,9 @@ describe('devtools dist smoke', () => {
   test('slim bundle can register and mount built devtools state', () => {
     slimBundle.register(smokeId, demoUmp, { email: 'alex@example.com' })
 
-    expect(slimBundle.snapshot().get(smokeId)?.snapshot.values.email).toBe('alex@example.com')
+    expect(slimBundle.snapshot().get(smokeId)?.snapshot.values.email).toBe(
+      'alex@example.com',
+    )
 
     const cleanup = slimBundle.mount()
 

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,6 +1,12 @@
 import { h, render } from 'preact'
 import { Panel } from './panel/Panel.js'
-import { register, setFoulLogDepth, snapshot, subscribe, unregister } from './registry.js'
+import {
+  register,
+  setFoulLogDepth,
+  snapshot,
+  subscribe,
+  unregister,
+} from './registry.js'
 import { createShadowHost, removeShadowHost } from './shadow.js'
 import type { MountOptions } from './types.js'
 

--- a/packages/devtools/src/panel/ChallengeDrawer.tsx
+++ b/packages/devtools/src/panel/ChallengeDrawer.tsx
@@ -1,7 +1,4 @@
-import type {
-  ChallengeTrace,
-  ChallengeTraceAttachment,
-} from '@umpire/core'
+import type { ChallengeTrace, ChallengeTraceAttachment } from '@umpire/core'
 import { formatValue, getReasonMeta, getTraceMeta } from './format.js'
 import type { ReasonLike } from './format.js'
 import {
@@ -28,11 +25,7 @@ type BranchReasonGroup = {
   inner: ReasonLike[]
 }
 
-function MetaRows({
-  entries,
-}: {
-  entries: Array<[string, unknown]>
-}) {
+function MetaRows({ entries }: { entries: Array<[string, unknown]> }) {
   if (entries.length === 0) {
     return null
   }
@@ -49,10 +42,16 @@ function MetaRows({
     >
       {entries.map(([key, value]) => (
         <>
-          <dt key={`${key}:label`} style={{ color: theme.fgMuted, fontSize: 11 }}>
+          <dt
+            key={`${key}:label`}
+            style={{ color: theme.fgMuted, fontSize: 11 }}
+          >
             {key}
           </dt>
-          <dd key={`${key}:value`} style={{ color: theme.fg, fontSize: 11, margin: 0 }}>
+          <dd
+            key={`${key}:value`}
+            style={{ color: theme.fg, fontSize: 11, margin: 0 }}
+          >
             {formatValue(value, 80)}
           </dd>
         </>
@@ -82,16 +81,34 @@ function BranchGroupsView({
             padding: 12,
           }}
         >
-          <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
-            <strong style={{ color: theme.fg, fontSize: 12 }}>{branchName}</strong>
-            <span style={pillStyle(branch.passed ? theme.enabled : theme.disabled, true)}>
+          <div
+            style={{
+              alignItems: 'center',
+              display: 'flex',
+              gap: 8,
+              justifyContent: 'space-between',
+            }}
+          >
+            <strong style={{ color: theme.fg, fontSize: 12 }}>
+              {branchName}
+            </strong>
+            <span
+              style={pillStyle(
+                branch.passed ? theme.enabled : theme.disabled,
+                true,
+              )}
+            >
               {branch.passed ? 'match' : 'no match'}
             </span>
           </div>
 
           <div style={{ display: 'grid', gap: 0 }}>
             {branch.inner.map((entry, index) => (
-              <ReasonView key={`${branchName}:${entry.rule}:${index}`} depth={depth + 1} reason={entry} />
+              <ReasonView
+                key={`${branchName}:${entry.rule}:${index}`}
+                depth={depth + 1}
+                reason={entry}
+              />
             ))}
           </div>
         </div>
@@ -120,7 +137,10 @@ function TraceAttachmentView({ trace }: { trace: ChallengeTraceAttachment }) {
 
       {trace.dependencies && trace.dependencies.length > 0 && (
         <div style={{ color: theme.fgMuted, fontSize: 11 }}>
-          depends on: {trace.dependencies.map((dependency) => `${dependency.kind}:${dependency.id}`).join(', ')}
+          depends on:{' '}
+          {trace.dependencies
+            .map((dependency) => `${dependency.kind}:${dependency.id}`)
+            .join(', ')}
         </div>
       )}
     </div>
@@ -129,14 +149,15 @@ function TraceAttachmentView({ trace }: { trace: ChallengeTraceAttachment }) {
 
 function ReasonView({ depth = 0, reason }: ReasonProps) {
   const tone = getRuleTone(reason.rule)
-  const inner = Array.isArray(reason.inner) ? reason.inner as ReasonLike[] : []
-  const branches = (
+  const inner = Array.isArray(reason.inner)
+    ? (reason.inner as ReasonLike[])
+    : []
+  const branches =
     reason.branches &&
     typeof reason.branches === 'object' &&
     !Array.isArray(reason.branches)
-  )
-    ? reason.branches as Record<string, BranchReasonGroup>
-    : null
+      ? (reason.branches as Record<string, BranchReasonGroup>)
+      : null
   const passed = reason.passed ?? false
 
   return (
@@ -150,10 +171,19 @@ function ReasonView({ depth = 0, reason }: ReasonProps) {
         padding: '12px 12px 12px 14px',
       }}
     >
-      <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          gap: 8,
+          justifyContent: 'space-between',
+        }}
+      >
         <div style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
           <span style={pillStyle(tone, true)}>{reason.rule}</span>
-          <span style={pillStyle(passed ? theme.enabled : theme.disabled, true)}>
+          <span
+            style={pillStyle(passed ? theme.enabled : theme.disabled, true)}
+          >
             {passed ? 'pass' : 'fail'}
           </span>
         </div>
@@ -170,7 +200,10 @@ function ReasonView({ depth = 0, reason }: ReasonProps) {
       {Array.isArray(reason.trace) && reason.trace.length > 0 && (
         <div>
           {reason.trace.map((trace) => (
-            <TraceAttachmentView key={`${trace.kind}:${trace.id}`} trace={trace} />
+            <TraceAttachmentView
+              key={`${trace.kind}:${trace.id}`}
+              trace={trace}
+            />
           ))}
         </div>
       )}
@@ -182,7 +215,11 @@ function ReasonView({ depth = 0, reason }: ReasonProps) {
       {inner.length > 0 && (
         <div style={{ display: 'grid', gap: 0 }}>
           {inner.map((entry, index) => (
-            <ReasonView key={`${entry.rule}:${index}`} depth={depth + 1} reason={entry} />
+            <ReasonView
+              key={`${entry.rule}:${index}`}
+              depth={depth + 1}
+              reason={entry}
+            />
           ))}
         </div>
       )}
@@ -192,7 +229,13 @@ function ReasonView({ depth = 0, reason }: ReasonProps) {
 
 export function ChallengeDrawer({ field, onBack, trace }: Props) {
   return (
-    <div style={{ display: 'grid', gridTemplateRows: 'auto minmax(0, 1fr)', height: '100%' }}>
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateRows: 'auto minmax(0, 1fr)',
+        height: '100%',
+      }}
+    >
       <div
         style={{
           alignItems: 'center',
@@ -227,17 +270,26 @@ export function ChallengeDrawer({ field, onBack, trace }: Props) {
         </div>
 
         <div style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
-          <span style={pillStyle(trace.enabled ? theme.enabled : theme.disabled, true)}>
+          <span
+            style={pillStyle(
+              trace.enabled ? theme.enabled : theme.disabled,
+              true,
+            )}
+          >
             {trace.enabled ? 'enabled' : 'disabled'}
           </span>
-          <span style={pillStyle(trace.fair ? theme.enabled : theme.fair, true)}>
+          <span
+            style={pillStyle(trace.fair ? theme.enabled : theme.fair, true)}
+          >
             {trace.fair ? 'fair' : 'fair fail'}
           </span>
         </div>
       </div>
 
       <div style={scrollPaneStyle()}>
-        <section style={{ borderBottom: `1px solid ${theme.border}`, padding: 14 }}>
+        <section
+          style={{ borderBottom: `1px solid ${theme.border}`, padding: 14 }}
+        >
           <h3 style={sectionHeadingStyle()}>Direct Reasons</h3>
         </section>
         <div style={{ display: 'grid' }}>
@@ -246,7 +298,9 @@ export function ChallengeDrawer({ field, onBack, trace }: Props) {
           ))}
         </div>
 
-        <section style={{ borderBottom: `1px solid ${theme.border}`, padding: 14 }}>
+        <section
+          style={{ borderBottom: `1px solid ${theme.border}`, padding: 14 }}
+        >
           <h3 style={sectionHeadingStyle()}>Transitive Dependencies</h3>
         </section>
         {trace.transitiveDeps.length === 0 ? (
@@ -264,9 +318,23 @@ export function ChallengeDrawer({ field, onBack, trace }: Props) {
                 padding: 14,
               }}
             >
-              <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
-                <strong style={{ color: theme.fg, fontSize: 12 }}>{dependency.field}</strong>
-                <span style={pillStyle(dependency.enabled ? theme.enabled : theme.disabled, true)}>
+              <div
+                style={{
+                  alignItems: 'center',
+                  display: 'flex',
+                  gap: 8,
+                  justifyContent: 'space-between',
+                }}
+              >
+                <strong style={{ color: theme.fg, fontSize: 12 }}>
+                  {dependency.field}
+                </strong>
+                <span
+                  style={pillStyle(
+                    dependency.enabled ? theme.enabled : theme.disabled,
+                    true,
+                  )}
+                >
                   {dependency.enabled ? 'enabled' : 'disabled'}
                 </span>
               </div>
@@ -290,7 +358,9 @@ export function ChallengeDrawer({ field, onBack, trace }: Props) {
 
         {trace.oneOfResolution && (
           <>
-            <section style={{ borderBottom: `1px solid ${theme.border}`, padding: 14 }}>
+            <section
+              style={{ borderBottom: `1px solid ${theme.border}`, padding: 14 }}
+            >
               <h3 style={sectionHeadingStyle()}>oneOf Resolution</h3>
             </section>
             <div
@@ -302,34 +372,47 @@ export function ChallengeDrawer({ field, onBack, trace }: Props) {
               }}
             >
               <div style={{ color: theme.fgMuted, fontSize: 11 }}>
-                group: <span style={{ color: theme.fg }}>{trace.oneOfResolution.group}</span>
+                group:{' '}
+                <span style={{ color: theme.fg }}>
+                  {trace.oneOfResolution.group}
+                </span>
               </div>
               <div style={{ color: theme.fgMuted, fontSize: 11 }}>
-                active branch: <span style={{ color: theme.fg }}>{trace.oneOfResolution.activeBranch ?? 'none'}</span>
+                active branch:{' '}
+                <span style={{ color: theme.fg }}>
+                  {trace.oneOfResolution.activeBranch ?? 'none'}
+                </span>
               </div>
               <div style={{ color: theme.fgMuted, fontSize: 11 }}>
-                method: <span style={{ color: theme.fg }}>{trace.oneOfResolution.method}</span>
+                method:{' '}
+                <span style={{ color: theme.fg }}>
+                  {trace.oneOfResolution.method}
+                </span>
               </div>
 
-              {Object.entries(trace.oneOfResolution.branches).map(([branch, detail]) => (
-                <div
-                  key={branch}
-                  style={{
-                    borderTop: `1px solid ${theme.border}`,
-                    display: 'grid',
-                    gap: 6,
-                    paddingTop: 10,
-                  }}
-                >
-                  <strong style={{ color: theme.fg, fontSize: 12 }}>{branch}</strong>
-                  <div style={{ color: theme.fgMuted, fontSize: 11 }}>
-                    fields: {detail.fields.join(', ')}
+              {Object.entries(trace.oneOfResolution.branches).map(
+                ([branch, detail]) => (
+                  <div
+                    key={branch}
+                    style={{
+                      borderTop: `1px solid ${theme.border}`,
+                      display: 'grid',
+                      gap: 6,
+                      paddingTop: 10,
+                    }}
+                  >
+                    <strong style={{ color: theme.fg, fontSize: 12 }}>
+                      {branch}
+                    </strong>
+                    <div style={{ color: theme.fgMuted, fontSize: 11 }}>
+                      fields: {detail.fields.join(', ')}
+                    </div>
+                    <div style={{ color: theme.fgMuted, fontSize: 11 }}>
+                      any satisfied: {detail.anySatisfied ? 'yes' : 'no'}
+                    </div>
                   </div>
-                  <div style={{ color: theme.fgMuted, fontSize: 11 }}>
-                    any satisfied: {detail.anySatisfied ? 'yes' : 'no'}
-                  </div>
-                </div>
-              ))}
+                ),
+              )}
             </div>
           </>
         )}

--- a/packages/devtools/src/panel/Panel.tsx
+++ b/packages/devtools/src/panel/Panel.tsx
@@ -13,7 +13,13 @@ import { ExtensionTab } from './tabs/ExtensionTab.js'
 import { FoulLog } from './tabs/FoulLog.js'
 import { FieldMatrix } from './tabs/FieldMatrix.js'
 import { GraphTab } from './tabs/GraphTab.js'
-import { fontFamily, scrollPaneStyle, sectionHeadingStyle, tabStyle, theme } from './theme.js'
+import {
+  fontFamily,
+  scrollPaneStyle,
+  sectionHeadingStyle,
+  tabStyle,
+  theme,
+} from './theme.js'
 import { ReadsTab } from './tabs/ReadsTab.js'
 
 type Props = {
@@ -35,7 +41,10 @@ function useRegistryEntries() {
   return entries
 }
 
-function panelAnchor(position: Required<MountOptions>['position'], offset: Required<MountOptions>['offset']) {
+function panelAnchor(
+  position: Required<MountOptions>['position'],
+  offset: Required<MountOptions>['offset'],
+) {
   const anchor: Record<string, string | number> = {}
 
   if (position.startsWith('top')) {
@@ -98,8 +107,13 @@ function EmptyState() {
       }}
     >
       <div>
-        <div style={{ color: theme.fg, marginBottom: 8 }}>No Umpire instances registered.</div>
-        <div>Call register(id, ump, values, conditions) from your app to populate the panel.</div>
+        <div style={{ color: theme.fg, marginBottom: 8 }}>
+          No Umpire instances registered.
+        </div>
+        <div>
+          Call register(id, ump, values, conditions) from your app to populate
+          the panel.
+        </div>
       </div>
     </div>
   )
@@ -109,24 +123,32 @@ export function Panel({ options }: Props) {
   const entries = useRegistryEntries()
   const entryList = useMemo(() => [...entries.values()], [entries])
   const [open, setOpen] = useState(false)
-  const [preferredActiveId, setPreferredActiveId] = useState<string | null>(null)
+  const [preferredActiveId, setPreferredActiveId] = useState<string | null>(
+    null,
+  )
   const [selectedFieldState, setSelectedFieldState] = useState<{
     entryId: string
     field: string
   } | null>(null)
-  const [preferredTab, setPreferredTab] = useState<DevtoolsTab>(options.defaultTab)
+  const [preferredTab, setPreferredTab] = useState<DevtoolsTab>(
+    options.defaultTab,
+  )
 
-  const activeId = preferredActiveId && entries.has(preferredActiveId)
-    ? preferredActiveId
-    : entryList[0]?.id ?? null
-  const activeEntry = activeId ? entries.get(activeId) ?? null : null
+  const activeId =
+    preferredActiveId && entries.has(preferredActiveId)
+      ? preferredActiveId
+      : (entryList[0]?.id ?? null)
+  const activeEntry = activeId ? (entries.get(activeId) ?? null) : null
   const activeTabs = resolveTabs(activeEntry)
   const activeScorecard = activeEntry?.scorecard ?? null
-  const tab = activeTabs.some((entryTab) => entryTab.id === preferredTab) ? preferredTab : 'matrix'
-  const selectedField = selectedFieldState?.entryId === activeId &&
-      selectedFieldState.field in (activeScorecard?.fields ?? {})
-    ? selectedFieldState.field
-    : null
+  const tab = activeTabs.some((entryTab) => entryTab.id === preferredTab)
+    ? preferredTab
+    : 'matrix'
+  const selectedField =
+    selectedFieldState?.entryId === activeId &&
+    selectedFieldState.field in (activeScorecard?.fields ?? {})
+      ? selectedFieldState.field
+      : null
 
   const challenge = useMemo(() => {
     if (!activeEntry || !selectedField) {
@@ -142,8 +164,12 @@ export function Panel({ options }: Props) {
   }, [activeEntry, selectedField])
 
   const anchor = panelAnchor(options.position, options.offset)
-  const stackDirection = options.position.startsWith('bottom') ? 'column-reverse' : 'column'
-  const alignItems = options.position.endsWith('left') ? 'flex-start' : 'flex-end'
+  const stackDirection = options.position.startsWith('bottom')
+    ? 'column-reverse'
+    : 'column'
+  const alignItems = options.position.endsWith('left')
+    ? 'flex-start'
+    : 'flex-end'
 
   return (
     <div
@@ -214,9 +240,12 @@ export function Panel({ options }: Props) {
             }}
           >
             <div style={{ display: 'grid', gap: 5 }}>
-              <strong style={{ color: theme.fg, fontSize: 13 }}>Umpire DevTools</strong>
+              <strong style={{ color: theme.fg, fontSize: 13 }}>
+                Umpire DevTools
+              </strong>
               <span style={{ color: theme.fgMuted, fontSize: 11 }}>
-                {entryList.length} registered {entryList.length === 1 ? 'instance' : 'instances'}
+                {entryList.length} registered{' '}
+                {entryList.length === 1 ? 'instance' : 'instances'}
               </span>
             </div>
 
@@ -235,7 +264,10 @@ export function Panel({ options }: Props) {
               padding: 12,
             }}
           >
-            <label htmlFor="umpire-devtools-instance" style={sectionHeadingStyle()}>
+            <label
+              htmlFor="umpire-devtools-instance"
+              style={sectionHeadingStyle()}
+            >
               Instance
             </label>
             <select
@@ -342,12 +374,7 @@ function PanelBody({
   }
 
   if (tab === 'conditions') {
-    return (
-      <ConditionsTab
-        current={entry.snapshot}
-        previous={entry.previous}
-      />
-    )
+    return <ConditionsTab current={entry.snapshot} previous={entry.previous} />
   }
 
   if (tab === 'graph') {
@@ -364,7 +391,8 @@ function PanelBody({
     return <ReadsTab inspection={entry.reads} />
   }
 
-  const extension = entry.extensions.find((candidate) => candidate.id === tab) ?? null
+  const extension =
+    entry.extensions.find((candidate) => candidate.id === tab) ?? null
 
   if (extension) {
     return <ExtensionTab extension={extension} />

--- a/packages/devtools/src/panel/format.ts
+++ b/packages/devtools/src/panel/format.ts
@@ -27,7 +27,9 @@ export function formatValue(value: unknown, maxLength = 44): string {
   }
 
   if (typeof value === 'string') {
-    return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value
+    return value.length > maxLength
+      ? `${value.slice(0, maxLength - 1)}…`
+      : value
   }
 
   if (typeof value === 'number' || typeof value === 'boolean') {
@@ -37,7 +39,9 @@ export function formatValue(value: unknown, maxLength = 44): string {
   if (Array.isArray(value)) {
     const compact = `[${value.map((entry) => formatValue(entry, 20)).join(', ')}]`
 
-    return compact.length > maxLength ? `${compact.slice(0, maxLength - 1)}…` : compact
+    return compact.length > maxLength
+      ? `${compact.slice(0, maxLength - 1)}…`
+      : compact
   }
 
   try {
@@ -47,7 +51,9 @@ export function formatValue(value: unknown, maxLength = 44): string {
       return String(value)
     }
 
-    return compact.length > maxLength ? `${compact.slice(0, maxLength - 1)}…` : compact
+    return compact.length > maxLength
+      ? `${compact.slice(0, maxLength - 1)}…`
+      : compact
   } catch {
     return String(value)
   }
@@ -62,21 +68,21 @@ export function formatTimestamp(value: number) {
 }
 
 export function getReasonMeta(reason: ReasonLike) {
-  return Object.entries(reason)
-    .filter(([key, value]) => (
+  return Object.entries(reason).filter(
+    ([key, value]) =>
       !skippedReasonKeys.has(key) &&
       value !== undefined &&
-      (typeof value !== 'object' || value === null || Array.isArray(value))
-    ))
+      (typeof value !== 'object' || value === null || Array.isArray(value)),
+  )
 }
 
 export function getTraceMeta(trace: ChallengeTraceAttachment) {
-  return Object.entries(trace)
-    .filter(([key, value]) => (
+  return Object.entries(trace).filter(
+    ([key, value]) =>
       key !== 'dependencies' &&
       key !== 'id' &&
       key !== 'kind' &&
       value !== undefined &&
-      (typeof value !== 'object' || value === null || Array.isArray(value))
-    ))
+      (typeof value !== 'object' || value === null || Array.isArray(value)),
+  )
 }

--- a/packages/devtools/src/panel/graph.ts
+++ b/packages/devtools/src/panel/graph.ts
@@ -1,7 +1,4 @@
-import type {
-  ScorecardResult,
-  UmpireGraphEdge,
-} from '@umpire/core'
+import type { ScorecardResult, UmpireGraphEdge } from '@umpire/core'
 import { getFieldTone, getRuleTone } from './theme.js'
 
 export type GraphLayout = {
@@ -32,8 +29,8 @@ export type GraphLayout = {
 }
 
 export const NODE_FONT_SIZE = 10
-const NODE_CHAR_WIDTH = 9.15  // tweak if text overflows nodes
-const NODE_PAD_X = 16  // 8px each side
+const NODE_CHAR_WIDTH = 9.15 // tweak if text overflows nodes
+const NODE_PAD_X = 16 // 8px each side
 const NODE_MIN_WIDTH = 50
 const NODE_HEIGHT = 28
 const COLUMN_GAP = 48
@@ -42,12 +39,19 @@ const PADDING_X = 24
 const PADDING_Y = 20
 
 function calcNodeWidth(fieldName: string): number {
-  return Math.max(NODE_MIN_WIDTH, Math.ceil(fieldName.length * NODE_CHAR_WIDTH + NODE_PAD_X))
+  return Math.max(
+    NODE_MIN_WIDTH,
+    Math.ceil(fieldName.length * NODE_CHAR_WIDTH + NODE_PAD_X),
+  )
 }
 
-function buildRanks(graph: ScorecardResult<Record<string, {}>, Record<string, unknown>>['graph']) {
+function buildRanks(
+  graph: ScorecardResult<Record<string, {}>, Record<string, unknown>>['graph'],
+) {
   const incoming = new Map<string, number>(graph.nodes.map((node) => [node, 0]))
-  const outgoing = new Map<string, string[]>(graph.nodes.map((node) => [node, []]))
+  const outgoing = new Map<string, string[]>(
+    graph.nodes.map((node) => [node, []]),
+  )
 
   for (const edge of graph.edges) {
     outgoing.get(edge.from)?.push(edge.to)
@@ -55,7 +59,9 @@ function buildRanks(graph: ScorecardResult<Record<string, {}>, Record<string, un
   }
 
   const queue = graph.nodes.filter((node) => (incoming.get(node) ?? 0) === 0)
-  const rankByNode = new Map<string, number>(graph.nodes.map((node) => [node, 0]))
+  const rankByNode = new Map<string, number>(
+    graph.nodes.map((node) => [node, 0]),
+  )
 
   while (queue.length > 0) {
     const current = queue.shift()
@@ -152,7 +158,7 @@ export function layoutGraph(
         x,
         y,
       }
-    })
+    }),
   )
 
   const edges = scorecard.graph.edges
@@ -162,11 +168,17 @@ export function layoutGraph(
   const lastRank = sortedRanks.at(-1) ?? 0
   const lastColumnX = columnX.get(lastRank) ?? PADDING_X
   const lastColumnWidth = columnWidths.get(lastRank) ?? NODE_MIN_WIDTH
-  const tallestColumn = Math.max(...[...columns.values()].map((col) => col.length), 1)
+  const tallestColumn = Math.max(
+    ...[...columns.values()].map((col) => col.length),
+    1,
+  )
 
   return {
     edges,
-    height: PADDING_Y * 2 + tallestColumn * NODE_HEIGHT + (tallestColumn - 1) * ROW_GAP,
+    height:
+      PADDING_Y * 2 +
+      tallestColumn * NODE_HEIGHT +
+      (tallestColumn - 1) * ROW_GAP,
     nodes,
     width: lastColumnX + lastColumnWidth + PADDING_X,
   }

--- a/packages/devtools/src/panel/tabs/ConditionsTab.tsx
+++ b/packages/devtools/src/panel/tabs/ConditionsTab.tsx
@@ -1,7 +1,12 @@
 import { isPlainRecord } from '@umpire/core/guards'
 import type { AnySnapshot } from '../../types.js'
 import { formatValue } from '../format.js'
-import { fontFamily, scrollPaneStyle, sectionHeadingStyle, theme } from '../theme.js'
+import {
+  fontFamily,
+  scrollPaneStyle,
+  sectionHeadingStyle,
+  theme,
+} from '../theme.js'
 
 type Props = {
   current: AnySnapshot
@@ -11,9 +16,7 @@ type Props = {
 function ConditionsValue({ value }: { value: unknown }) {
   if (value === undefined) {
     return (
-      <div style={{ color: theme.fgMuted, fontSize: 11 }}>
-        No conditions
-      </div>
+      <div style={{ color: theme.fgMuted, fontSize: 11 }}>No conditions</div>
     )
   }
 
@@ -29,9 +32,7 @@ function ConditionsValue({ value }: { value: unknown }) {
 
   if (entries.length === 0) {
     return (
-      <div style={{ color: theme.fgMuted, fontSize: 11 }}>
-        Empty object
-      </div>
+      <div style={{ color: theme.fgMuted, fontSize: 11 }}>Empty object</div>
     )
   }
 
@@ -47,10 +48,16 @@ function ConditionsValue({ value }: { value: unknown }) {
     >
       {entries.map(([key, entryValue]) => (
         <>
-          <dt key={`${key}:label`} style={{ color: theme.fgMuted, fontSize: 11 }}>
+          <dt
+            key={`${key}:label`}
+            style={{ color: theme.fgMuted, fontSize: 11 }}
+          >
             {key}
           </dt>
-          <dd key={`${key}:value`} style={{ color: theme.fg, fontSize: 11, margin: 0 }}>
+          <dd
+            key={`${key}:value`}
+            style={{ color: theme.fg, fontSize: 11, margin: 0 }}
+          >
             {formatValue(entryValue, 80)}
           </dd>
         </>
@@ -59,13 +66,7 @@ function ConditionsValue({ value }: { value: unknown }) {
   )
 }
 
-function ConditionsCard({
-  title,
-  value,
-}: {
-  title: string
-  value: unknown
-}) {
+function ConditionsCard({ title, value }: { title: string; value: unknown }) {
   return (
     <section
       style={{
@@ -75,9 +76,7 @@ function ConditionsCard({
         padding: 12,
       }}
     >
-      <h3 style={sectionHeadingStyle()}>
-        {title}
-      </h3>
+      <h3 style={sectionHeadingStyle()}>{title}</h3>
       <ConditionsValue value={value} />
     </section>
   )
@@ -88,7 +87,10 @@ export function ConditionsTab({ current, previous }: Props) {
     <div style={scrollPaneStyle()}>
       <ConditionsCard title="Current Conditions" value={current.conditions} />
       {previous && (
-        <ConditionsCard title="Previous Conditions" value={previous.conditions} />
+        <ConditionsCard
+          title="Previous Conditions"
+          value={previous.conditions}
+        />
       )}
     </div>
   )

--- a/packages/devtools/src/panel/tabs/ExtensionTab.tsx
+++ b/packages/devtools/src/panel/tabs/ExtensionTab.tsx
@@ -4,7 +4,12 @@ import type {
   ResolvedDevtoolsExtension,
 } from '../../types.js'
 import { formatValue } from '../format.js'
-import { pillStyle, scrollPaneStyle, sectionHeadingStyle, theme } from '../theme.js'
+import {
+  pillStyle,
+  scrollPaneStyle,
+  sectionHeadingStyle,
+  theme,
+} from '../theme.js'
 
 type Props = {
   extension: ResolvedDevtoolsExtension
@@ -59,10 +64,16 @@ function MetaRows({
     >
       {rows.map((row) => (
         <>
-          <dt key={`${row.label}:label`} style={{ color: theme.fgMuted, fontSize: 11 }}>
+          <dt
+            key={`${row.label}:label`}
+            style={{ color: theme.fgMuted, fontSize: 11 }}
+          >
             {row.label}
           </dt>
-          <dd key={`${row.label}:value`} style={{ color: theme.fg, fontSize: 11, margin: 0 }}>
+          <dd
+            key={`${row.label}:value`}
+            style={{ color: theme.fg, fontSize: 11, margin: 0 }}
+          >
             {formatValue(row.value, 80)}
           </dd>
         </>
@@ -71,11 +82,7 @@ function MetaRows({
   )
 }
 
-function Section({
-  section,
-}: {
-  section: DevtoolsExtensionSection
-}) {
+function Section({ section }: { section: DevtoolsExtensionSection }) {
   return (
     <section
       style={{
@@ -85,25 +92,29 @@ function Section({
         padding: 12,
       }}
     >
-      {section.title && (
-        <h3 style={sectionHeadingStyle()}>
-          {section.title}
-        </h3>
-      )}
+      {section.title && <h3 style={sectionHeadingStyle()}>{section.title}</h3>}
 
       {section.kind === 'badges' && (
-        <div style={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <div
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 8,
+          }}
+        >
           {section.badges.map((badge, index) => (
-            <span key={`${index}:${String(badge.value)}`} style={pillStyle(toneColor(badge.tone), true)}>
+            <span
+              key={`${index}:${String(badge.value)}`}
+              style={pillStyle(toneColor(badge.tone), true)}
+            >
               {formatValue(badge.value, 80)}
             </span>
           ))}
         </div>
       )}
 
-      {section.kind === 'rows' && (
-        <MetaRows rows={section.rows} />
-      )}
+      {section.kind === 'rows' && <MetaRows rows={section.rows} />}
 
       {section.kind === 'items' && (
         <div style={{ display: 'grid', gap: 0 }}>
@@ -117,7 +128,13 @@ function Section({
                 paddingTop: index === 0 ? 0 : 10,
               }}
             >
-              <div style={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between' }}>
+              <div
+                style={{
+                  alignItems: 'center',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                }}
+              >
                 <strong style={{ color: theme.fg, fontSize: 12 }}>
                   {item.title}
                 </strong>
@@ -129,9 +146,7 @@ function Section({
               </div>
 
               {item.body && (
-                <div style={{ color: theme.fg, fontSize: 12 }}>
-                  {item.body}
-                </div>
+                <div style={{ color: theme.fg, fontSize: 12 }}>{item.body}</div>
               )}
 
               {item.rows && item.rows.length > 0 && (
@@ -169,7 +184,10 @@ export function ExtensionTab({ extension }: Props) {
   return (
     <div style={scrollPaneStyle()}>
       {sections.map((section, index) => (
-        <Section key={`${extension.id}:${section.kind}:${section.title ?? index}`} section={section} />
+        <Section
+          key={`${extension.id}:${section.kind}:${section.title ?? index}`}
+          section={section}
+        />
       ))}
     </div>
   )

--- a/packages/devtools/src/panel/tabs/FieldMatrix.tsx
+++ b/packages/devtools/src/panel/tabs/FieldMatrix.tsx
@@ -39,12 +39,18 @@ const boolCellStyle = {
 }
 
 function flag(value: boolean) {
-  return value
-    ? <span style={{ color: theme.enabled }}>✓</span>
-    : <span style={{ color: theme.unavailable }}>✗</span>
+  return value ? (
+    <span style={{ color: theme.enabled }}>✓</span>
+  ) : (
+    <span style={{ color: theme.unavailable }}>✗</span>
+  )
 }
 
-export function FieldMatrix({ onSelectField, scorecard, selectedField }: Props) {
+export function FieldMatrix({
+  onSelectField,
+  scorecard,
+  selectedField,
+}: Props) {
   const fields = scorecard.graph.nodes
     .map((field) => scorecard.fields[field])
     .filter(Boolean)
@@ -79,7 +85,9 @@ export function FieldMatrix({ onSelectField, scorecard, selectedField }: Props) 
                 }}
               >
                 <td style={bodyCellStyle}>
-                  <div style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
+                  <div
+                    style={{ alignItems: 'center', display: 'flex', gap: 8 }}
+                  >
                     <span
                       style={{
                         background: tone,
@@ -90,9 +98,13 @@ export function FieldMatrix({ onSelectField, scorecard, selectedField }: Props) 
                         width: 8,
                       }}
                     />
-                    <strong style={{ color: theme.fg, fontSize: 12 }}>{field.field}</strong>
+                    <strong style={{ color: theme.fg, fontSize: 12 }}>
+                      {field.field}
+                    </strong>
                   </div>
-                  <div style={{ color: theme.fgMuted, fontSize: 11, marginTop: 6 }}>
+                  <div
+                    style={{ color: theme.fgMuted, fontSize: 11, marginTop: 6 }}
+                  >
                     {field.reason ?? 'Inspect trace'}
                   </div>
                 </td>

--- a/packages/devtools/src/panel/tabs/FoulLog.tsx
+++ b/packages/devtools/src/panel/tabs/FoulLog.tsx
@@ -20,7 +20,8 @@ export function FoulLog({ events }: Props) {
           textAlign: 'center',
         }}
       >
-        No fouls yet. This log fills when a field becomes disabled while still holding a value.
+        No fouls yet. This log fills when a field becomes disabled while still
+        holding a value.
       </div>
     )
   }
@@ -37,9 +38,20 @@ export function FoulLog({ events }: Props) {
             padding: 12,
           }}
         >
-          <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
-            <strong style={{ color: theme.fg, fontSize: 12 }}>{event.field}</strong>
-            <span style={pillStyle(event.cascaded ? theme.fair : theme.disabled)}>
+          <div
+            style={{
+              alignItems: 'center',
+              display: 'flex',
+              gap: 8,
+              justifyContent: 'space-between',
+            }}
+          >
+            <strong style={{ color: theme.fg, fontSize: 12 }}>
+              {event.field}
+            </strong>
+            <span
+              style={pillStyle(event.cascaded ? theme.fair : theme.disabled)}
+            >
               {event.cascaded ? 'cascade' : 'direct'}
             </span>
           </div>

--- a/packages/devtools/src/panel/tabs/GraphTab.tsx
+++ b/packages/devtools/src/panel/tabs/GraphTab.tsx
@@ -13,7 +13,13 @@ export function GraphTab({ onSelectField, scorecard, selectedField }: Props) {
   const edgeTypes = [...new Set(layout.edges.map((edge) => edge.type))]
 
   return (
-    <div style={{ ...scrollPaneStyle(), display: 'grid', gridTemplateRows: 'auto minmax(0, 1fr)' }}>
+    <div
+      style={{
+        ...scrollPaneStyle(),
+        display: 'grid',
+        gridTemplateRows: 'auto minmax(0, 1fr)',
+      }}
+    >
       <div
         style={{
           alignItems: 'center',
@@ -25,7 +31,14 @@ export function GraphTab({ onSelectField, scorecard, selectedField }: Props) {
         }}
       >
         {edgeTypes.map((type) => (
-          <span key={type} style={pillStyle(layout.edges.find((edge) => edge.type === type)?.color ?? theme.accent, true)}>
+          <span
+            key={type}
+            style={pillStyle(
+              layout.edges.find((edge) => edge.type === type)?.color ??
+                theme.accent,
+              true,
+            )}
+          >
             {type}
           </span>
         ))}
@@ -112,7 +125,7 @@ export function GraphTab({ onSelectField, scorecard, selectedField }: Props) {
                   fontSize={NODE_FONT_SIZE}
                   textAnchor="start"
                   x={node.x + 6}
-                  y={node.y + (node.height / 2) + (NODE_FONT_SIZE / 2)}
+                  y={node.y + node.height / 2 + NODE_FONT_SIZE / 2}
                 >
                   {node.field}
                 </text>

--- a/packages/devtools/src/panel/tabs/ReadsTab.tsx
+++ b/packages/devtools/src/panel/tabs/ReadsTab.tsx
@@ -35,7 +35,9 @@ export function ReadsTab({ inspection }: Props) {
   }
 
   const allReadIds = inspection.graph.nodes
-  const visibleReadIds = showAllReads ? allReadIds : allReadIds.slice(0, MAX_READ_ITEMS)
+  const visibleReadIds = showAllReads
+    ? allReadIds
+    : allReadIds.slice(0, MAX_READ_ITEMS)
   const hiddenCount = allReadIds.length - visibleReadIds.length
 
   return (
@@ -52,7 +54,10 @@ export function ReadsTab({ inspection }: Props) {
           }}
         >
           {inspection.bridges.map((bridge) => (
-            <span key={`${bridge.type}:${bridge.read}:${bridge.field}`} style={pillStyle(theme.accent, true)}>
+            <span
+              key={`${bridge.type}:${bridge.read}:${bridge.field}`}
+              style={pillStyle(theme.accent, true)}
+            >
               {bridge.read} {'->'} {bridge.field} ({bridge.type})
             </span>
           ))}
@@ -72,8 +77,16 @@ export function ReadsTab({ inspection }: Props) {
               padding: 12,
             }}
           >
-            <div style={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between' }}>
-              <strong style={{ color: theme.fg, fontSize: 12 }}>{readId}</strong>
+            <div
+              style={{
+                alignItems: 'center',
+                display: 'flex',
+                justifyContent: 'space-between',
+              }}
+            >
+              <strong style={{ color: theme.fg, fontSize: 12 }}>
+                {readId}
+              </strong>
               <span style={pillStyle(theme.ruleOneOf, true)}>
                 {formatValue(node.value)}
               </span>
@@ -115,7 +128,9 @@ export function ReadsTab({ inspection }: Props) {
             }}
             type="button"
           >
-            {showAllReads ? 'Show fewer reads' : `Show all reads (+${hiddenCount})`}
+            {showAllReads
+              ? 'Show fewer reads'
+              : `Show all reads (+${hiddenCount})`}
           </button>
         </div>
       )}

--- a/packages/devtools/src/panel/theme.ts
+++ b/packages/devtools/src/panel/theme.ts
@@ -25,7 +25,8 @@ export const theme = {
   unavailable: '#6c7288',
 } as const
 
-export const fontFamily = "'JetBrains Mono', 'IBM Plex Mono', ui-monospace, monospace"
+export const fontFamily =
+  "'JetBrains Mono', 'IBM Plex Mono', ui-monospace, monospace"
 
 export function getFieldTone(
   field: ScorecardField<Record<string, { required?: boolean }>>,

--- a/packages/devtools/src/registry.ts
+++ b/packages/devtools/src/registry.ts
@@ -5,9 +5,7 @@ import type {
   Snapshot,
   Umpire,
 } from '@umpire/core'
-import type {
-  ReadTableInspection,
-} from '@umpire/reads'
+import type { ReadTableInspection } from '@umpire/reads'
 import type {
   AnyReadInspection,
   ResolvedDevtoolsExtension,
@@ -40,24 +38,29 @@ function notify() {
 
 function isReadInspection(
   value: unknown,
-): value is ReadTableInspection<Record<string, unknown>, Record<string, unknown>> {
-  return typeof value === 'object' &&
+): value is ReadTableInspection<
+  Record<string, unknown>,
+  Record<string, unknown>
+> {
+  return (
+    typeof value === 'object' &&
     value !== null &&
     'graph' in value &&
     'nodes' in value &&
     'values' in value
+  )
 }
 
-function hasReadInspect(
-  value: unknown,
-): value is {
+function hasReadInspect(value: unknown): value is {
   inspect(input: Record<string, unknown>): AnyReadInspection
 } {
-  return typeof value === 'function' ||
+  return (
+    typeof value === 'function' ||
     (typeof value === 'object' &&
       value !== null &&
       'inspect' in value &&
       typeof value.inspect === 'function')
+  )
 }
 
 function resolveReadsInspection<
@@ -165,7 +168,10 @@ export const register: RegisterFn = <
   conditions?: C,
   options?: RegisterOptions<F, C, ReadInput, Reads>,
 ) => {
-  if (process.env.NODE_ENV === 'production' && process.env.UMPIRE_INTERNAL !== 'true') {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.UMPIRE_INTERNAL !== 'true'
+  ) {
     return
   }
 
@@ -218,7 +224,11 @@ export const register: RegisterFn = <
     updatedAt: Date.now(),
   }
 
-  nextEntry.foulLog = buildFoulLog(existing?.foulLog ?? [], nextEntry, renderIndex)
+  nextEntry.foulLog = buildFoulLog(
+    existing?.foulLog ?? [],
+    nextEntry,
+    renderIndex,
+  )
 
   registry.set(id, nextEntry)
   registryVersion += 1

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -26,7 +26,12 @@ export type MountOptions = {
   defaultTab?: DevtoolsTab
 }
 
-export type DevtoolsExtensionTone = 'accent' | 'enabled' | 'disabled' | 'fair' | 'muted'
+export type DevtoolsExtensionTone =
+  | 'accent'
+  | 'enabled'
+  | 'disabled'
+  | 'fair'
+  | 'muted'
 
 export type DevtoolsExtensionRow = {
   label: string
@@ -109,10 +114,22 @@ export type DevtoolsFoulEvent = {
 }
 
 export type AnySnapshot = Snapshot<Record<string, unknown>>
-export type AnyScorecard = ScorecardResult<Record<string, FieldDef>, Record<string, unknown>>
-export type AnyUmpire = Umpire<Record<string, FieldDef>, Record<string, unknown>>
-export type AnyReadInspection = ReadTableInspection<Record<string, unknown>, Record<string, unknown>>
-export type AnyDevtoolsExtension = DevtoolsExtension<Record<string, FieldDef>, Record<string, unknown>>
+export type AnyScorecard = ScorecardResult<
+  Record<string, FieldDef>,
+  Record<string, unknown>
+>
+export type AnyUmpire = Umpire<
+  Record<string, FieldDef>,
+  Record<string, unknown>
+>
+export type AnyReadInspection = ReadTableInspection<
+  Record<string, unknown>,
+  Record<string, unknown>
+>
+export type AnyDevtoolsExtension = DevtoolsExtension<
+  Record<string, FieldDef>,
+  Record<string, unknown>
+>
 
 export type ResolvedDevtoolsExtension = {
   id: string

--- a/packages/devtools/tsconfig.json
+++ b/packages/devtools/tsconfig.json
@@ -12,8 +12,5 @@
     }
   },
   "include": ["src", "entrypoints"],
-  "references": [
-    { "path": "../core" },
-    { "path": "../reads" }
-  ]
+  "references": [{ "path": "../core" }, { "path": "../reads" }]
 }

--- a/packages/devtools/tsdown.config.ts
+++ b/packages/devtools/tsdown.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'tsdown'
 
-const sharedNeverBundle = ['@umpire/core', '@umpire/reads', 'react', 'react/jsx-runtime']
+const sharedNeverBundle = [
+  '@umpire/core',
+  '@umpire/reads',
+  'react',
+  'react/jsx-runtime',
+]
 
 export default defineConfig([
   // Standalone bundle — Preact inlined. For users without Preact.

--- a/packages/dsl/__tests__/compile.test.ts
+++ b/packages/dsl/__tests__/compile.test.ts
@@ -26,8 +26,12 @@ describe('compileExpr', () => {
       { fieldNames, conditions },
     )
 
-    expect(predicate({ accountType: 'business', quantity: 5, enabled: true }, {})).toBe(true)
-    expect(predicate({ accountType: 'business', quantity: 5, enabled: false }, {})).toBe(false)
+    expect(
+      predicate({ accountType: 'business', quantity: 5, enabled: true }, {}),
+    ).toBe(true)
+    expect(
+      predicate({ accountType: 'business', quantity: 5, enabled: false }, {}),
+    ).toBe(false)
     expect(predicate._checkField).toBeUndefined()
   })
 
@@ -73,7 +77,9 @@ describe('compileExpr', () => {
       { fieldNames, conditions },
     )
 
-    expect(() => predicate({}, {})).toThrow('Missing runtime condition "isAdmin"')
+    expect(() => predicate({}, {})).toThrow(
+      'Missing runtime condition "isAdmin"',
+    )
   })
 
   test('throws on unknown fields and invalid fieldInCond condition types', () => {
@@ -120,7 +126,11 @@ describe('compileExpr', () => {
   test('throws on unknown expression ops', () => {
     expect(() =>
       compileExpr(
-        { op: 'eqIgnoreCase', field: 'accountType', value: 'business' } as unknown as Parameters<typeof compileExpr>[0],
+        {
+          op: 'eqIgnoreCase',
+          field: 'accountType',
+          value: 'business',
+        } as unknown as Parameters<typeof compileExpr>[0],
         { fieldNames, conditions },
       ),
     ).toThrow('Unknown expression op "eqIgnoreCase"')

--- a/packages/dsl/__tests__/expr.test.ts
+++ b/packages/dsl/__tests__/expr.test.ts
@@ -5,7 +5,11 @@ describe('expr builders', () => {
     const allowedLeagues = ['al', 'nl']
     const weatherBands = ['clear', 'windy']
     const slider = { op: 'eq', field: 'pitchType', value: 'slider' } as const
-    const curveball = { op: 'eq', field: 'pitchType', value: 'curveball' } as const
+    const curveball = {
+      op: 'eq',
+      field: 'pitchType',
+      value: 'curveball',
+    } as const
 
     const built = {
       neq: expr.neq('pitchType', 'sinker'),
@@ -42,8 +46,16 @@ describe('expr builders', () => {
       notIn: { op: 'notIn', field: 'league', values: ['al', 'nl'] },
       cond: { op: 'cond', condition: 'isPlayoffs' },
       condEq: { op: 'condEq', condition: 'weatherBand', value: 'windy' },
-      condIn: { op: 'condIn', condition: 'weatherBand', values: ['clear', 'windy'] },
-      fieldInCond: { op: 'fieldInCond', field: 'starter', condition: 'availableStarters' },
+      condIn: {
+        op: 'condIn',
+        condition: 'weatherBand',
+        values: ['clear', 'windy'],
+      },
+      fieldInCond: {
+        op: 'fieldInCond',
+        field: 'starter',
+        condition: 'availableStarters',
+      },
       and: {
         op: 'and',
         exprs: [

--- a/packages/dsl/src/compile.ts
+++ b/packages/dsl/src/compile.ts
@@ -21,7 +21,9 @@ type CompileExprOptions = {
 
 function assertField(field: string, op: string, fieldNames: Set<string>) {
   if (!fieldNames.has(field)) {
-    throw new Error(`[@umpire/dsl] Unknown field "${field}" in "${op}" expression`)
+    throw new Error(
+      `[@umpire/dsl] Unknown field "${field}" in "${op}" expression`,
+    )
   }
 }
 
@@ -33,13 +35,18 @@ function getConditionDef(
   const definition = conditions?.[condition]
 
   if (!definition) {
-    throw new Error(`[@umpire/dsl] Unknown condition "${condition}" in "${op}" expression`)
+    throw new Error(
+      `[@umpire/dsl] Unknown condition "${condition}" in "${op}" expression`,
+    )
   }
 
   return definition
 }
 
-function getConditionValue<C extends Record<string, unknown>>(condition: string, conditions: C): unknown {
+function getConditionValue<C extends Record<string, unknown>>(
+  condition: string,
+  conditions: C,
+): unknown {
   if (!(condition in conditions) || conditions[condition] === undefined) {
     throw new Error(`[@umpire/dsl] Missing runtime condition "${condition}"`)
   }
@@ -91,30 +98,36 @@ function compileInner<
   switch (expression.op) {
     case 'eq':
       assertField(expression.field, expression.op, options.fieldNames)
-      return (values) => values[expression.field as keyof F & string] === expression.value
+      return (values) =>
+        values[expression.field as keyof F & string] === expression.value
     case 'neq':
       assertField(expression.field, expression.op, options.fieldNames)
-      return (values) => values[expression.field as keyof F & string] !== expression.value
+      return (values) =>
+        values[expression.field as keyof F & string] !== expression.value
     case 'gt':
       assertField(expression.field, expression.op, options.fieldNames)
       return (values) =>
         typeof values[expression.field as keyof F & string] === 'number' &&
-        (values[expression.field as keyof F & string] as number) > expression.value
+        (values[expression.field as keyof F & string] as number) >
+          expression.value
     case 'gte':
       assertField(expression.field, expression.op, options.fieldNames)
       return (values) =>
         typeof values[expression.field as keyof F & string] === 'number' &&
-        (values[expression.field as keyof F & string] as number) >= expression.value
+        (values[expression.field as keyof F & string] as number) >=
+          expression.value
     case 'lt':
       assertField(expression.field, expression.op, options.fieldNames)
       return (values) =>
         typeof values[expression.field as keyof F & string] === 'number' &&
-        (values[expression.field as keyof F & string] as number) < expression.value
+        (values[expression.field as keyof F & string] as number) <
+          expression.value
     case 'lte':
       assertField(expression.field, expression.op, options.fieldNames)
       return (values) =>
         typeof values[expression.field as keyof F & string] === 'number' &&
-        (values[expression.field as keyof F & string] as number) <= expression.value
+        (values[expression.field as keyof F & string] as number) <=
+          expression.value
     case 'present':
       assertField(expression.field, expression.op, options.fieldNames)
       return (values) => {
@@ -135,32 +148,49 @@ function compileInner<
       return (values) => !values[expression.field as keyof F & string]
     case 'in':
       assertField(expression.field, expression.op, options.fieldNames)
-      return (values) => expression.values.includes(values[expression.field as keyof F & string] as never)
+      return (values) =>
+        expression.values.includes(
+          values[expression.field as keyof F & string] as never,
+        )
     case 'notIn':
       assertField(expression.field, expression.op, options.fieldNames)
-      return (values) => !expression.values.includes(values[expression.field as keyof F & string] as never)
+      return (values) =>
+        !expression.values.includes(
+          values[expression.field as keyof F & string] as never,
+        )
     case 'cond':
       if (!options.allowUndeclaredConditions) {
         getConditionDef(expression.condition, expression.op, options.conditions)
       }
-      return (_values, conditions) => Boolean(getConditionValue(expression.condition, conditions))
+      return (_values, conditions) =>
+        Boolean(getConditionValue(expression.condition, conditions))
     case 'condEq':
       if (!options.allowUndeclaredConditions) {
         getConditionDef(expression.condition, expression.op, options.conditions)
       }
-      return (_values, conditions) => getConditionValue(expression.condition, conditions) === expression.value
+      return (_values, conditions) =>
+        getConditionValue(expression.condition, conditions) === expression.value
     case 'condIn':
       if (!options.allowUndeclaredConditions) {
         getConditionDef(expression.condition, expression.op, options.conditions)
       }
       return (_values, conditions) =>
-        expression.values.includes(getConditionValue(expression.condition, conditions) as never)
+        expression.values.includes(
+          getConditionValue(expression.condition, conditions) as never,
+        )
     case 'fieldInCond': {
       assertField(expression.field, expression.op, options.fieldNames)
       if (!options.allowUndeclaredConditions) {
-        const conditionDef = getConditionDef(expression.condition, expression.op, options.conditions)
+        const conditionDef = getConditionDef(
+          expression.condition,
+          expression.op,
+          options.conditions,
+        )
 
-        if (conditionDef.type !== 'string[]' && conditionDef.type !== 'number[]') {
+        if (
+          conditionDef.type !== 'string[]' &&
+          conditionDef.type !== 'number[]'
+        ) {
           throw new Error(
             `[@umpire/dsl] "fieldInCond" requires an array condition, but "${expression.condition}" is "${conditionDef.type}"`,
           )
@@ -168,29 +198,42 @@ function compileInner<
       }
 
       return (values, conditions) => {
-        const conditionValue = getConditionValue(expression.condition, conditions)
+        const conditionValue = getConditionValue(
+          expression.condition,
+          conditions,
+        )
         if (!Array.isArray(conditionValue)) {
           throw new Error(
             `[@umpire/dsl] Runtime condition "${expression.condition}" must be an array for "fieldInCond"`,
           )
         }
 
-        return conditionValue.includes(values[expression.field as keyof F & string] as never)
+        return conditionValue.includes(
+          values[expression.field as keyof F & string] as never,
+        )
       }
     }
     case 'and': {
       if (!Array.isArray(expression.exprs)) {
-        throw new Error('[@umpire/dsl] "and" expression requires an exprs array')
+        throw new Error(
+          '[@umpire/dsl] "and" expression requires an exprs array',
+        )
       }
-      const predicates = expression.exprs.map((entry) => compileInner<F, C>(entry, options))
-      return (values, conditions) => predicates.every((predicate) => predicate(values, conditions))
+      const predicates = expression.exprs.map((entry) =>
+        compileInner<F, C>(entry, options),
+      )
+      return (values, conditions) =>
+        predicates.every((predicate) => predicate(values, conditions))
     }
     case 'or': {
       if (!Array.isArray(expression.exprs)) {
         throw new Error('[@umpire/dsl] "or" expression requires an exprs array')
       }
-      const predicates = expression.exprs.map((entry) => compileInner<F, C>(entry, options))
-      return (values, conditions) => predicates.some((predicate) => predicate(values, conditions))
+      const predicates = expression.exprs.map((entry) =>
+        compileInner<F, C>(entry, options),
+      )
+      return (values, conditions) =>
+        predicates.some((predicate) => predicate(values, conditions))
     }
     case 'not': {
       const predicate = compileInner<F, C>(expression.expr, options)
@@ -206,11 +249,11 @@ function compileInner<
 export function compileExpr<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  expression: Expr,
-  options: CompileExprOptions,
-): ExprPredicate<F, C> {
-  const predicate = compileInner<F, C>(expression, options) as ExprPredicate<F, C>
+>(expression: Expr, options: CompileExprOptions): ExprPredicate<F, C> {
+  const predicate = compileInner<F, C>(expression, options) as ExprPredicate<
+    F,
+    C
+  >
   const fieldRefs = getExprFieldRefs(expression)
 
   if (fieldRefs.length === 1) {

--- a/packages/dsl/src/expr.ts
+++ b/packages/dsl/src/expr.ts
@@ -3,7 +3,10 @@ import { deepClone } from './clone.js'
 
 import type { ExprBuilder } from './types.js'
 
-export const expr: ExprBuilder<Record<string, FieldDef>, Record<string, unknown>> = {
+export const expr: ExprBuilder<
+  Record<string, FieldDef>,
+  Record<string, unknown>
+> = {
   eq(field, value) {
     return { op: 'eq', field, value }
   },

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -25,13 +25,13 @@ export default [
 
 ## Rules
 
-| Rule | Severity | What it catches |
-|------|----------|-----------------|
-| `no-unknown-fields` | `warn` | Field names in rules that aren't declared in `fields` |
-| `no-inline-umpire-init` | `warn` | `umpire()` called inside a component or hook body without `useMemo` |
-| `no-self-disable` | `error` | A field listed as both source and target of `disables()` |
-| `no-contradicting-rules` | `error` | `requires`/`disables` pairs that make a field permanently unavailable |
-| `no-circular-requires` | `error` | Circular `requires` chains where fields mutually depend on each other |
+| Rule                     | Severity | What it catches                                                       |
+| ------------------------ | -------- | --------------------------------------------------------------------- |
+| `no-unknown-fields`      | `warn`   | Field names in rules that aren't declared in `fields`                 |
+| `no-inline-umpire-init`  | `warn`   | `umpire()` called inside a component or hook body without `useMemo`   |
+| `no-self-disable`        | `error`  | A field listed as both source and target of `disables()`              |
+| `no-contradicting-rules` | `error`  | `requires`/`disables` pairs that make a field permanently unavailable |
+| `no-circular-requires`   | `error`  | Circular `requires` chains where fields mutually depend on each other |
 
 ## Docs
 

--- a/packages/eslint-plugin/__tests__/no-contradicting-rules.test.ts
+++ b/packages/eslint-plugin/__tests__/no-contradicting-rules.test.ts
@@ -141,10 +141,7 @@ tester.run('no-contradicting-rules', rule, {
           ],
         })
       `,
-      errors: [
-        { messageId: 'contradiction' },
-        { messageId: 'contradiction' },
-      ],
+      errors: [{ messageId: 'contradiction' }, { messageId: 'contradiction' }],
     },
   ],
 })

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/estree": "^1.0.7",
-    "eslint": "^9.0.0"
+    "eslint": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/src/rules/no-circular-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-circular-requires.ts
@@ -18,8 +18,7 @@ const rule: Rule.RuleModule = {
   meta: {
     type: 'problem',
     docs: {
-      description:
-        'Disallow circular requires dependencies between fields.',
+      description: 'Disallow circular requires dependencies between fields.',
       recommended: true,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/no-inline-umpire-init.ts
+++ b/packages/eslint-plugin/src/rules/no-inline-umpire-init.ts
@@ -28,8 +28,9 @@ const rule: Rule.RuleModule = {
       CallExpression(node: estree.CallExpression) {
         if (!isUmpireCall(node)) return
 
-        const ancestors: estree.Node[] =
-          context.sourceCode.getAncestors(node as estree.Node)
+        const ancestors: estree.Node[] = context.sourceCode.getAncestors(
+          node as estree.Node,
+        )
 
         let reactFunctionDepth = -1
         let useMemoDepth = -1
@@ -51,10 +52,7 @@ const rule: Rule.RuleModule = {
 
           // Record the nearest React component or hook boundary so useMemo only
           // suppresses when it sits inside that boundary.
-          const name = resolveFunctionName(
-            ancestor as estree.Function,
-            parent,
-          )
+          const name = resolveFunctionName(ancestor as estree.Function, parent)
           if (name && isReactName(name) && reactFunctionDepth === -1) {
             reactFunctionDepth = i
           }
@@ -64,7 +62,10 @@ const rule: Rule.RuleModule = {
           useMemoDepth !== -1 && useMemoDepth > reactFunctionDepth
 
         if (reactFunctionDepth !== -1 && !wrappedInUseMemo) {
-          context.report({ node: node as unknown as estree.Node, messageId: 'inlineInit' })
+          context.report({
+            node: node as unknown as estree.Node,
+            messageId: 'inlineInit',
+          })
         }
       },
     }
@@ -105,7 +106,10 @@ function resolveFunctionName(
     return fn.id.name
   }
   // const MyComp = () => {} or const MyComp = function() {}
-  if (parent?.type === 'VariableDeclarator' && parent.id.type === 'Identifier') {
+  if (
+    parent?.type === 'VariableDeclarator' &&
+    parent.id.type === 'Identifier'
+  ) {
     return parent.id.name
   }
   // { render: function() {} } — named property

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -48,7 +48,9 @@ export function getFieldsConfig(
 /**
  * Returns the set of statically known field names from a `fields` object.
  */
-export function getFieldNames(fieldsNode: estree.ObjectExpression): Set<string> {
+export function getFieldNames(
+  fieldsNode: estree.ObjectExpression,
+): Set<string> {
   const names = new Set<string>()
   for (const prop of fieldsNode.properties) {
     if (prop.type !== 'Property' || prop.computed) continue

--- a/packages/integration-tests/__tests__/json-zod-pipeline.integration.test.ts
+++ b/packages/integration-tests/__tests__/json-zod-pipeline.integration.test.ts
@@ -31,12 +31,15 @@ describe('json + zod pipeline', () => {
     expect(toJson(parsed)).toEqual(schema)
 
     const runtime = umpire(parsed)
-    const guestAvailability = runtime.check({
-      accountType: 'guest',
-      displayName: 'Ada',
-      inviteCode: 'SHOULD-NOT-MATTER',
-      email: 'ada@example.com',
-    }, { accountType: 'guest' })
+    const guestAvailability = runtime.check(
+      {
+        accountType: 'guest',
+        displayName: 'Ada',
+        inviteCode: 'SHOULD-NOT-MATTER',
+        email: 'ada@example.com',
+      },
+      { accountType: 'guest' },
+    )
 
     expect(guestAvailability.inviteCode).toMatchObject({
       enabled: false,

--- a/packages/integration-tests/__tests__/react-zod-signup.integration.test.ts
+++ b/packages/integration-tests/__tests__/react-zod-signup.integration.test.ts
@@ -1,5 +1,11 @@
 import { renderHook } from '@testing-library/react'
-import { enabledWhen, fairWhen, requires, type FieldDef, umpire } from '@umpire/core'
+import {
+  enabledWhen,
+  fairWhen,
+  requires,
+  type FieldDef,
+  umpire,
+} from '@umpire/core'
 import { createZodAdapter } from '@umpire/zod'
 import { z } from 'zod'
 import { useUmpire } from '@umpire/react'
@@ -21,11 +27,19 @@ describe('react + zod signup flow', () => {
     build(baseSchema) {
       return baseSchema.superRefine((data, ctx) => {
         if (data.email === 'filter@example.com') {
-          ctx.addIssue({ code: 'custom', path: ['password'], message: 'Password is not needed for SSO' })
+          ctx.addIssue({
+            code: 'custom',
+            path: ['password'],
+            message: 'Password is not needed for SSO',
+          })
         }
 
         if (data.confirmPassword !== data.password) {
-          ctx.addIssue({ code: 'custom', path: ['confirmPassword'], message: 'Passwords do not match' })
+          ctx.addIssue({
+            code: 'custom',
+            path: ['confirmPassword'],
+            message: 'Passwords do not match',
+          })
         }
       })
     },
@@ -36,9 +50,13 @@ describe('react + zod signup flow', () => {
     fields,
     rules: [
       requires('confirmPassword', 'password'),
-      fairWhen('confirmPassword', (confirmPassword, values) => confirmPassword === values.password, {
-        reason: 'Passwords do not match',
-      }),
+      fairWhen(
+        'confirmPassword',
+        (confirmPassword, values) => confirmPassword === values.password,
+        {
+          reason: 'Passwords do not match',
+        },
+      ),
       enabledWhen('password', (_values, conditions) => !conditions.sso),
       enabledWhen('confirmPassword', (_values, conditions) => !conditions.sso),
     ],
@@ -49,20 +67,31 @@ describe('react + zod signup flow', () => {
       ({ values, conditions }) => useUmpire(signupUmp, values, conditions),
       {
         initialProps: {
-          values: { email: 'user@example.com', password: 'hunter22', confirmPassword: 'hunter22' },
+          values: {
+            email: 'user@example.com',
+            password: 'hunter22',
+            confirmPassword: 'hunter22',
+          },
           conditions: { sso: false },
         },
       },
     )
 
     rerender({
-      values: { email: 'filter@example.com', password: 'hunter22', confirmPassword: 'hunter22' },
+      values: {
+        email: 'filter@example.com',
+        password: 'hunter22',
+        confirmPassword: 'hunter22',
+      },
       conditions: { sso: true },
     })
 
     expect(result.current.check.password.enabled).toBe(false)
     expect(result.current.check.confirmPassword.enabled).toBe(false)
-    expect(result.current.fouls.map((foul) => foul.field).sort()).toEqual(['confirmPassword', 'password'])
+    expect(result.current.fouls.map((foul) => foul.field).sort()).toEqual([
+      'confirmPassword',
+      'password',
+    ])
 
     const parsed = validation.run(result.current.check, {
       email: 'filter@example.com',
@@ -79,14 +108,22 @@ describe('react + zod signup flow', () => {
       ({ values, conditions }) => useUmpire(signupUmp, values, conditions),
       {
         initialProps: {
-          values: { email: 'user@example.com', password: 'hunter22', confirmPassword: 'hunter22' },
+          values: {
+            email: 'user@example.com',
+            password: 'hunter22',
+            confirmPassword: 'hunter22',
+          },
           conditions: { sso: false },
         },
       },
     )
 
     rerender({
-      values: { email: 'user@example.com', password: 'hunter22', confirmPassword: 'mismatch' },
+      values: {
+        email: 'user@example.com',
+        password: 'hunter22',
+        confirmPassword: 'mismatch',
+      },
       conditions: { sso: false },
     })
 

--- a/packages/json/__tests__/builders.test.ts
+++ b/packages/json/__tests__/builders.test.ts
@@ -51,9 +51,13 @@ describe('portable JSON builders', () => {
           reason: 'Needs a curveball call',
         }),
       ),
-      fairWhenExpr('starter', expr.fieldInCond('starter', 'availableStarters'), {
-        reason: 'Starter must be on tonight\'s card',
-      }),
+      fairWhenExpr(
+        'starter',
+        expr.fieldInCond('starter', 'availableStarters'),
+        {
+          reason: "Starter must be on tonight's card",
+        },
+      ),
       requiresJson(
         'bullpenCart',
         'pitchType',
@@ -70,13 +74,11 @@ describe('portable JSON builders', () => {
         },
       ),
       disablesExpr(
-        expr.or(
-          expr.condEq('weatherBand', 'windy'),
-          expr.truthy('walkSignal'),
-        ),
+        expr.or(expr.condEq('weatherBand', 'windy'), expr.truthy('walkSignal')),
         ['dugoutTablet'],
         {
-          reason: 'Review board locked during windy or intentional-walk moments',
+          reason:
+            'Review board locked during windy or intentional-walk moments',
         },
       ),
     ]
@@ -113,8 +115,12 @@ describe('portable JSON builders', () => {
         {
           type: 'fairWhen',
           field: 'starter',
-          when: { op: 'fieldInCond', field: 'starter', condition: 'availableStarters' },
-          reason: 'Starter must be on tonight\'s card',
+          when: {
+            op: 'fieldInCond',
+            field: 'starter',
+            condition: 'availableStarters',
+          },
+          reason: "Starter must be on tonight's card",
         },
         {
           type: 'requires',
@@ -132,7 +138,11 @@ describe('portable JSON builders', () => {
         {
           type: 'requires',
           field: 'bullpenCart',
-          when: { op: 'fieldInCond', field: 'starter', condition: 'availableStarters' },
+          when: {
+            op: 'fieldInCond',
+            field: 'starter',
+            condition: 'availableStarters',
+          },
           reason: 'Bullpen cart waits for an available starter',
         },
         {
@@ -145,7 +155,8 @@ describe('portable JSON builders', () => {
             ],
           },
           targets: ['dugoutTablet'],
-          reason: 'Review board locked during windy or intentional-walk moments',
+          reason:
+            'Review board locked during windy or intentional-walk moments',
         },
       ],
     }
@@ -187,9 +198,13 @@ describe('portable JSON builders', () => {
           reason: 'Needs a curveball call',
         }),
       ),
-      fairWhenExpr('starter', expr.fieldInCond('starter', 'availableStarters'), {
-        reason: 'Starter must be on tonight\'s card',
-      }),
+      fairWhenExpr(
+        'starter',
+        expr.fieldInCond('starter', 'availableStarters'),
+        {
+          reason: "Starter must be on tonight's card",
+        },
+      ),
       requiresJson(
         'bullpenCart',
         'pitchType',
@@ -206,13 +221,11 @@ describe('portable JSON builders', () => {
         },
       ),
       disablesExpr(
-        expr.or(
-          expr.condEq('weatherBand', 'windy'),
-          expr.truthy('walkSignal'),
-        ),
+        expr.or(expr.condEq('weatherBand', 'windy'), expr.truthy('walkSignal')),
         ['dugoutTablet'],
         {
-          reason: 'Review board locked during windy or intentional-walk moments',
+          reason:
+            'Review board locked during windy or intentional-walk moments',
         },
       ),
     ]
@@ -222,36 +235,40 @@ describe('portable JSON builders', () => {
       rules,
     })
 
-    expect(runtime.check(
-      {
-        pitchType: 'slider',
-        starter: 'Cole',
-        walkSignal: false,
-      },
-      {
-        weatherBand: 'cold',
-        availableStarters: ['Cole'],
-      },
-    )).toMatchObject({
+    expect(
+      runtime.check(
+        {
+          pitchType: 'slider',
+          starter: 'Cole',
+          walkSignal: false,
+        },
+        {
+          weatherBand: 'cold',
+          availableStarters: ['Cole'],
+        },
+      ),
+    ).toMatchObject({
       warmupNotice: { enabled: true, reason: null },
       starter: { fair: true, reason: null },
       bullpenCart: { enabled: true, reason: null },
       dugoutTablet: { enabled: true, reason: null },
     })
 
-    expect(runtime.check(
-      {
-        pitchType: 'fastball',
-        starter: 'Cole',
-        walkSignal: true,
-      },
-      {
-        weatherBand: 'windy',
-        availableStarters: ['Holmes'],
-      },
-    )).toMatchObject({
+    expect(
+      runtime.check(
+        {
+          pitchType: 'fastball',
+          starter: 'Cole',
+          walkSignal: true,
+        },
+        {
+          weatherBand: 'windy',
+          availableStarters: ['Holmes'],
+        },
+      ),
+    ).toMatchObject({
       warmupNotice: { enabled: false, reason: 'Needs a slider call' },
-      starter: { fair: false, reason: 'Starter must be on tonight\'s card' },
+      starter: { fair: false, reason: "Starter must be on tonight's card" },
       bullpenCart: {
         enabled: false,
         reason: 'Bullpen cart waits for an available starter',
@@ -271,7 +288,10 @@ describe('portable JSON builders', () => {
 
     type Conditions = Record<string, unknown>
 
-    const { expr, enabledWhenExpr } = createJsonRules<typeof fields, Conditions>()
+    const { expr, enabledWhenExpr } = createJsonRules<
+      typeof fields,
+      Conditions
+    >()
 
     expect(() =>
       anyOfJson(
@@ -299,10 +319,12 @@ describe('portable JSON builders', () => {
       },
     )
 
-    expect(toJson({
-      fields,
-      rules: [rule],
-    })).toEqual({
+    expect(
+      toJson({
+        fields,
+        rules: [rule],
+      }),
+    ).toEqual({
       version: 1,
       fields: {
         email: {},
@@ -335,14 +357,20 @@ describe('portable JSON builders', () => {
 
     const { expr, fairWhenExpr } = createJsonRules<typeof fields>()
 
-    const rule = fairWhenExpr('submit', expr.check('email', namedValidators.email()), {
-      reason: 'Submit stays foul until the scorer email is valid',
-    })
+    const rule = fairWhenExpr(
+      'submit',
+      expr.check('email', namedValidators.email()),
+      {
+        reason: 'Submit stays foul until the scorer email is valid',
+      },
+    )
 
-    expect(toJson({
-      fields,
-      rules: [rule],
-    })).toEqual({
+    expect(
+      toJson({
+        fields,
+        rules: [rule],
+      }),
+    ).toEqual({
       version: 1,
       fields: {
         email: {},
@@ -368,7 +396,11 @@ describe('portable JSON builders', () => {
     const allowedLeagues = ['al', 'nl']
     const weatherBands = ['clear', 'windy']
     const slider = { op: 'eq', field: 'pitchType', value: 'slider' } as const
-    const curveball = { op: 'eq', field: 'pitchType', value: 'curveball' } as const
+    const curveball = {
+      op: 'eq',
+      field: 'pitchType',
+      value: 'curveball',
+    } as const
 
     const built = {
       neq: expr.neq('pitchType', 'sinker'),
@@ -405,8 +437,16 @@ describe('portable JSON builders', () => {
       notIn: { op: 'notIn', field: 'league', values: ['al', 'nl'] },
       cond: { op: 'cond', condition: 'isPlayoffs' },
       condEq: { op: 'condEq', condition: 'weatherBand', value: 'windy' },
-      condIn: { op: 'condIn', condition: 'weatherBand', values: ['clear', 'windy'] },
-      fieldInCond: { op: 'fieldInCond', field: 'starter', condition: 'availableStarters' },
+      condIn: {
+        op: 'condIn',
+        condition: 'weatherBand',
+        values: ['clear', 'windy'],
+      },
+      fieldInCond: {
+        op: 'fieldInCond',
+        field: 'starter',
+        condition: 'availableStarters',
+      },
       and: {
         op: 'and',
         exprs: [
@@ -456,9 +496,9 @@ describe('portable JSON builders', () => {
   test('requiresJson requires at least one dependency', () => {
     const { requiresJson } = createJsonRules<Record<string, {}>>()
 
-    expect(() =>
-      requiresJson('bullpenCart'),
-    ).toThrow('requiresJson("bullpenCart") requires at least one dependency')
+    expect(() => requiresJson('bullpenCart')).toThrow(
+      'requiresJson("bullpenCart") requires at least one dependency',
+    )
   })
 
   test('eitherOfJson serializes to exact JSON shape', () => {
@@ -479,19 +519,30 @@ describe('portable JSON builders', () => {
       magicLinkEnabled: { type: 'boolean' as const },
     }
 
-    const { expr, enabledWhenExpr, eitherOfJson } = createJsonRules<typeof fields, Conditions>()
+    const { expr, enabledWhenExpr, eitherOfJson } = createJsonRules<
+      typeof fields,
+      Conditions
+    >()
 
     const rules = [
       eitherOfJson('authPath', {
         password: [
-          enabledWhenExpr('submit', expr.present('email'), { reason: 'Enter your email' }),
+          enabledWhenExpr('submit', expr.present('email'), {
+            reason: 'Enter your email',
+          }),
         ],
         sso: [
-          enabledWhenExpr('submit', expr.cond('ssoAvailable'), { reason: 'SSO not available for this account' }),
+          enabledWhenExpr('submit', expr.cond('ssoAvailable'), {
+            reason: 'SSO not available for this account',
+          }),
         ],
         magicLink: [
-          enabledWhenExpr('submit', expr.present('email'), { reason: 'Enter your email' }),
-          enabledWhenExpr('submit', expr.cond('magicLinkEnabled'), { reason: 'Magic link not enabled' }),
+          enabledWhenExpr('submit', expr.present('email'), {
+            reason: 'Enter your email',
+          }),
+          enabledWhenExpr('submit', expr.cond('magicLinkEnabled'), {
+            reason: 'Magic link not enabled',
+          }),
         ],
       }),
     ]
@@ -511,14 +562,34 @@ describe('portable JSON builders', () => {
           group: 'authPath',
           branches: {
             password: [
-              { type: 'enabledWhen', field: 'submit', when: { op: 'present', field: 'email' }, reason: 'Enter your email' },
+              {
+                type: 'enabledWhen',
+                field: 'submit',
+                when: { op: 'present', field: 'email' },
+                reason: 'Enter your email',
+              },
             ],
             sso: [
-              { type: 'enabledWhen', field: 'submit', when: { op: 'cond', condition: 'ssoAvailable' }, reason: 'SSO not available for this account' },
+              {
+                type: 'enabledWhen',
+                field: 'submit',
+                when: { op: 'cond', condition: 'ssoAvailable' },
+                reason: 'SSO not available for this account',
+              },
             ],
             magicLink: [
-              { type: 'enabledWhen', field: 'submit', when: { op: 'present', field: 'email' }, reason: 'Enter your email' },
-              { type: 'enabledWhen', field: 'submit', when: { op: 'cond', condition: 'magicLinkEnabled' }, reason: 'Magic link not enabled' },
+              {
+                type: 'enabledWhen',
+                field: 'submit',
+                when: { op: 'present', field: 'email' },
+                reason: 'Enter your email',
+              },
+              {
+                type: 'enabledWhen',
+                field: 'submit',
+                when: { op: 'cond', condition: 'magicLinkEnabled' },
+                reason: 'Magic link not enabled',
+              },
             ],
           },
         },
@@ -541,15 +612,22 @@ describe('portable JSON builders', () => {
       ssoAvailable: { type: 'boolean' as const },
     }
 
-    const { expr, enabledWhenExpr, eitherOfJson } = createJsonRules<typeof fields, Conditions>()
+    const { expr, enabledWhenExpr, eitherOfJson } = createJsonRules<
+      typeof fields,
+      Conditions
+    >()
 
     const rules = [
       eitherOfJson('authPath', {
         password: [
-          enabledWhenExpr('submit', expr.present('email'), { reason: 'Enter your email' }),
+          enabledWhenExpr('submit', expr.present('email'), {
+            reason: 'Enter your email',
+          }),
         ],
         sso: [
-          enabledWhenExpr('submit', expr.cond('ssoAvailable'), { reason: 'SSO not available' }),
+          enabledWhenExpr('submit', expr.cond('ssoAvailable'), {
+            reason: 'SSO not available',
+          }),
         ],
       }),
     ]
@@ -561,8 +639,22 @@ describe('portable JSON builders', () => {
       type: 'eitherOf',
       group: 'authPath',
       branches: {
-        password: [{ type: 'enabledWhen', field: 'submit', when: { op: 'present', field: 'email' }, reason: 'Enter your email' }],
-        sso: [{ type: 'enabledWhen', field: 'submit', when: { op: 'cond', condition: 'ssoAvailable' }, reason: 'SSO not available' }],
+        password: [
+          {
+            type: 'enabledWhen',
+            field: 'submit',
+            when: { op: 'present', field: 'email' },
+            reason: 'Enter your email',
+          },
+        ],
+        sso: [
+          {
+            type: 'enabledWhen',
+            field: 'submit',
+            when: { op: 'cond', condition: 'ssoAvailable' },
+            reason: 'SSO not available',
+          },
+        ],
       },
     })
 
@@ -570,22 +662,22 @@ describe('portable JSON builders', () => {
     const runtime = umpire({ fields: parsed.fields, rules: parsed.rules })
 
     // sso branch passes → submit enabled
-    expect(runtime.check(
-      { email: '', ssoToken: '' },
-      { ssoAvailable: true },
-    ).submit).toMatchObject({ enabled: true, reason: null })
+    expect(
+      runtime.check({ email: '', ssoToken: '' }, { ssoAvailable: true }).submit,
+    ).toMatchObject({ enabled: true, reason: null })
 
     // password branch passes → submit enabled
-    expect(runtime.check(
-      { email: 'user@example.com', ssoToken: '' },
-      { ssoAvailable: false },
-    ).submit).toMatchObject({ enabled: true, reason: null })
+    expect(
+      runtime.check(
+        { email: 'user@example.com', ssoToken: '' },
+        { ssoAvailable: false },
+      ).submit,
+    ).toMatchObject({ enabled: true, reason: null })
 
     // both branches fail → submit disabled
-    expect(runtime.check(
-      {},
-      { ssoAvailable: false },
-    ).submit).toMatchObject({ enabled: false })
+    expect(runtime.check({}, { ssoAvailable: false }).submit).toMatchObject({
+      enabled: false,
+    })
   })
 
   test('eitherOfJson requires every inner rule to carry JSON metadata', () => {

--- a/packages/json/__tests__/check-ops.test.ts
+++ b/packages/json/__tests__/check-ops.test.ts
@@ -14,10 +14,34 @@ import {
 
 describe('namedValidators', () => {
   test.each([
-    ['email', namedValidators.email(), 'user@example.com', 'invalid', 'Must be a valid email address'],
-    ['url', namedValidators.url(), 'https://example.com', '/relative', 'Must be a valid URL'],
-    ['minLength', namedValidators.minLength(3), 'abcd', 'ab', 'Must be at least 3 characters'],
-    ['maxLength', namedValidators.maxLength(3), 'abc', 'abcd', 'Must be 3 characters or fewer'],
+    [
+      'email',
+      namedValidators.email(),
+      'user@example.com',
+      'invalid',
+      'Must be a valid email address',
+    ],
+    [
+      'url',
+      namedValidators.url(),
+      'https://example.com',
+      '/relative',
+      'Must be a valid URL',
+    ],
+    [
+      'minLength',
+      namedValidators.minLength(3),
+      'abcd',
+      'ab',
+      'Must be at least 3 characters',
+    ],
+    [
+      'maxLength',
+      namedValidators.maxLength(3),
+      'abc',
+      'abcd',
+      'Must be 3 characters or fewer',
+    ],
     ['min', namedValidators.min(3), 4, 2, 'Must be at least 3'],
     ['max', namedValidators.max(3), 2, 4, 'Must be 3 or less'],
     ['range', namedValidators.range(2, 4), 3, 5, 'Must be between 2 and 4'],
@@ -36,20 +60,27 @@ describe('namedValidators', () => {
 
     expect(validator.validate('umpire_ok')).toBe(true)
     expect(validator.validate('Not OK')).toBe(false)
-    expect(defaultValidatorMessage(validator)).toBe('Must match the required format')
+    expect(defaultValidatorMessage(validator)).toBe(
+      'Must match the required format',
+    )
   })
 
   test('email accepts common valid forms and rejects obvious invalid dot forms', () => {
     const validator = namedValidators.email()
 
-    expect(validator.validate("first.last+tag_o'reilly@example-domain.com")).toBe(true)
+    expect(
+      validator.validate("first.last+tag_o'reilly@example-domain.com"),
+    ).toBe(true)
     expect(validator.validate('.leading-dot@example.com')).toBe(false)
     expect(validator.validate('double..dot@example.com')).toBe(false)
   })
 
   test('produces named check metadata compatible with core check()', () => {
     const validator = namedValidators.maxLength(5)
-    const predicate = check<Record<string, {}>, Record<string, unknown>>('email', validator)
+    const predicate = check<Record<string, {}>, Record<string, unknown>>(
+      'email',
+      validator,
+    )
 
     expect(getNamedCheckMetadata(predicate)).toEqual({
       __check: 'maxLength',
@@ -74,18 +105,22 @@ describe('namedValidators', () => {
   })
 
   test('serializes named-check metadata back into portable specs', () => {
-    expect(createValidatorSpecFromMetadata({
-      __check: 'matches',
-      params: { pattern: '^[a-z]+$' },
-    })).toEqual({
+    expect(
+      createValidatorSpecFromMetadata({
+        __check: 'matches',
+        params: { pattern: '^[a-z]+$' },
+      }),
+    ).toEqual({
       op: 'matches',
       pattern: '^[a-z]+$',
     })
 
-    expect(createValidatorSpecFromMetadata({
-      __check: 'range',
-      params: { min: 2, max: 4 },
-    })).toEqual({
+    expect(
+      createValidatorSpecFromMetadata({
+        __check: 'range',
+        params: { min: 2, max: 4 },
+      }),
+    ).toEqual({
       op: 'range',
       min: 2,
       max: 4,
@@ -113,22 +148,26 @@ describe('namedValidators', () => {
   })
 
   test('creates portable check rules and omits default reasons', () => {
-    expect(createCheckRuleFromMetadata(
-      'score',
-      { __check: 'min', params: { value: 3 } },
-      'Must be at least 3',
-    )).toEqual({
+    expect(
+      createCheckRuleFromMetadata(
+        'score',
+        { __check: 'min', params: { value: 3 } },
+        'Must be at least 3',
+      ),
+    ).toEqual({
       type: 'check',
       field: 'score',
       op: 'min',
       value: 3,
     })
 
-    expect(createCheckRuleFromMetadata(
-      'score',
-      { __check: 'min', params: { value: 3 } },
-      'Need at least three runs',
-    )).toEqual({
+    expect(
+      createCheckRuleFromMetadata(
+        'score',
+        { __check: 'min', params: { value: 3 } },
+        'Need at least three runs',
+      ),
+    ).toEqual({
       type: 'check',
       field: 'score',
       op: 'min',
@@ -136,16 +175,22 @@ describe('namedValidators', () => {
       reason: 'Need at least three runs',
     })
 
-    expect(createCheckRuleFromMetadata(
-      'score',
-      { __check: 'range', params: { min: 1 } },
-      'Broken metadata',
-    )).toBeUndefined()
+    expect(
+      createCheckRuleFromMetadata(
+        'score',
+        { __check: 'range', params: { min: 1 } },
+        'Broken metadata',
+      ),
+    ).toBeUndefined()
   })
 
   test('falls back for unknown reason labels and rejects invalid specs', () => {
-    expect(defaultValidatorMessage({ __check: 'custom' } as never)).toBe('Invalid value')
-    expect(() => hydrateIsEmptyStrategy('mystery' as never)).toThrow('Unknown isEmpty strategy')
+    expect(defaultValidatorMessage({ __check: 'custom' } as never)).toBe(
+      'Invalid value',
+    )
+    expect(() => hydrateIsEmptyStrategy('mystery' as never)).toThrow(
+      'Unknown isEmpty strategy',
+    )
 
     expect(() =>
       assertValidValidatorSpec({ op: 'min', value: Number.NaN }),
@@ -155,8 +200,8 @@ describe('namedValidators', () => {
       assertValidValidatorSpec({ op: 'range', min: 1, max: Number.NaN }),
     ).toThrow('Validator "range" requires numeric min and max values')
 
-    expect(() =>
-      assertValidValidatorSpec({ op: 'custom' } as never),
-    ).toThrow('Unknown validator op "custom"')
+    expect(() => assertValidValidatorSpec({ op: 'custom' } as never)).toThrow(
+      'Unknown validator op "custom"',
+    )
   })
 })

--- a/packages/json/__tests__/conformance.test.ts
+++ b/packages/json/__tests__/conformance.test.ts
@@ -73,8 +73,11 @@ function loadFixtures(): ConformanceFixture[] {
   return readdirSync(fixturesDir)
     .filter((fileName) => fileName.endsWith('.json'))
     .sort()
-    .map((fileName) =>
-      JSON.parse(readFileSync(path.join(fixturesDir, fileName), 'utf8')) as ConformanceFixture,
+    .map(
+      (fileName) =>
+        JSON.parse(
+          readFileSync(path.join(fixturesDir, fileName), 'utf8'),
+        ) as ConformanceFixture,
     )
 }
 
@@ -82,8 +85,11 @@ function loadFailureFixtures(): FailureFixture[] {
   return readdirSync(failureFixturesDir)
     .filter((fileName) => fileName.endsWith('.json'))
     .sort()
-    .map((fileName) =>
-      JSON.parse(readFileSync(path.join(failureFixturesDir, fileName), 'utf8')) as FailureFixture,
+    .map(
+      (fileName) =>
+        JSON.parse(
+          readFileSync(path.join(failureFixturesDir, fileName), 'utf8'),
+        ) as FailureFixture,
     )
 }
 
@@ -102,64 +108,75 @@ function assertFailureFixtureShape(fixture: FailureFixture): void {
 describe('JSON conformance fixtures', () => {
   const fixtures = loadFixtures()
 
-  test.each(fixtures)('$id round-trips the schema exactly', ({ schema, ...fixture }) => {
-    assertFixtureShape({ schema, ...fixture })
-    validateSchema(schema)
+  test.each(fixtures)(
+    '$id round-trips the schema exactly',
+    ({ schema, ...fixture }) => {
+      assertFixtureShape({ schema, ...fixture })
+      validateSchema(schema)
 
-    const parsed = fromJson(schema)
-    expect(toJson(parsed)).toEqual(schema)
-  })
+      const parsed = fromJson(schema)
+      expect(toJson(parsed)).toEqual(schema)
+    },
+  )
 
-  test.each(fixtures)('$id matches reference availability output', ({ schema, cases, ...fixture }) => {
-    assertFixtureShape({ schema, cases, ...fixture })
-    validateSchema(schema)
+  test.each(fixtures)(
+    '$id matches reference availability output',
+    ({ schema, cases, ...fixture }) => {
+      assertFixtureShape({ schema, cases, ...fixture })
+      validateSchema(schema)
 
-    const parsed = fromJson(schema)
-    const runtime = umpire({
-      fields: parsed.fields,
-      rules: parsed.rules,
-      validators: parsed.validators,
-    })
-
-    for (const testCase of cases) {
-      const actual = runtime.check(
-        testCase.values as Record<string, unknown>,
-        testCase.conditions as Record<string, unknown> | undefined,
-        testCase.prev as Record<string, unknown> | undefined,
-      ) as AvailabilityMap<Record<string, FieldDef>>
-
-      expect(actual).toEqual(testCase.expectedAvailability)
-    }
-  })
-})
-
-describe('JSON conformance failure fixtures', () => {
-  const fixtures = loadFailureFixtures()
-
-  test.each(fixtures)('$id produces the expected failures', ({ failures, ...fixture }) => {
-    assertFailureFixtureShape({ failures, ...fixture })
-
-    for (const failure of failures) {
-      if (failure.phase === 'validate') {
-        expect(() => validateSchema(failure.schema)).toThrow(failure.errorIncludes)
-        continue
-      }
-
-      validateSchema(failure.schema)
-      const parsed = fromJson(failure.schema)
+      const parsed = fromJson(schema)
       const runtime = umpire({
         fields: parsed.fields,
         rules: parsed.rules,
         validators: parsed.validators,
       })
 
-      expect(() =>
-        runtime.check(
-          (failure.values ?? {}) as Record<string, unknown>,
-          failure.conditions as Record<string, unknown> | undefined,
-          failure.prev as Record<string, unknown> | undefined,
-        ),
-      ).toThrow(failure.errorIncludes)
-    }
-  })
+      for (const testCase of cases) {
+        const actual = runtime.check(
+          testCase.values as Record<string, unknown>,
+          testCase.conditions as Record<string, unknown> | undefined,
+          testCase.prev as Record<string, unknown> | undefined,
+        ) as AvailabilityMap<Record<string, FieldDef>>
+
+        expect(actual).toEqual(testCase.expectedAvailability)
+      }
+    },
+  )
+})
+
+describe('JSON conformance failure fixtures', () => {
+  const fixtures = loadFailureFixtures()
+
+  test.each(fixtures)(
+    '$id produces the expected failures',
+    ({ failures, ...fixture }) => {
+      assertFailureFixtureShape({ failures, ...fixture })
+
+      for (const failure of failures) {
+        if (failure.phase === 'validate') {
+          expect(() => validateSchema(failure.schema)).toThrow(
+            failure.errorIncludes,
+          )
+          continue
+        }
+
+        validateSchema(failure.schema)
+        const parsed = fromJson(failure.schema)
+        const runtime = umpire({
+          fields: parsed.fields,
+          rules: parsed.rules,
+          validators: parsed.validators,
+        })
+
+        expect(() =>
+          runtime.check(
+            (failure.values ?? {}) as Record<string, unknown>,
+            failure.conditions as Record<string, unknown> | undefined,
+            failure.prev as Record<string, unknown> | undefined,
+          ),
+        ).toThrow(failure.errorIncludes)
+      }
+    },
+  )
 })

--- a/packages/json/__tests__/expr.test.ts
+++ b/packages/json/__tests__/expr.test.ts
@@ -21,7 +21,9 @@ describe('json expr bridge', () => {
   })
 
   test('getExprFieldRefs includes check field and delegated refs', () => {
-    expect(getExprFieldRefs({ op: 'check', field: 'email', check: { op: 'email' } })).toEqual(['email'])
+    expect(
+      getExprFieldRefs({ op: 'check', field: 'email', check: { op: 'email' } }),
+    ).toEqual(['email'])
 
     expect(
       getExprFieldRefs({
@@ -47,7 +49,9 @@ describe('json expr bridge', () => {
     )
 
     expect(predicate({ accountType: 'business', submit: true }, {})).toBe(true)
-    expect(predicate({ accountType: 'business', submit: false }, {})).toBe(false)
+    expect(predicate({ accountType: 'business', submit: false }, {})).toBe(
+      false,
+    )
   })
 
   test('compileExpr supports nested check expressions inside combinators', () => {
@@ -62,12 +66,20 @@ describe('json expr bridge', () => {
       { fieldNames },
     )
 
-    expect(predicate({ email: 'alex@example.com', accountType: 'business' }, {})).toBe(true)
-    expect(predicate({ email: 'invalid', accountType: 'business' }, {})).toBe(false)
+    expect(
+      predicate({ email: 'alex@example.com', accountType: 'business' }, {}),
+    ).toBe(true)
+    expect(predicate({ email: 'invalid', accountType: 'business' }, {})).toBe(
+      false,
+    )
   })
 
   test('compileExpr handles deeply nested trees with mixed check and non-check nodes', () => {
-    let expression = { op: 'check', field: 'email', check: { op: 'email' } } as const
+    let expression = {
+      op: 'check',
+      field: 'email',
+      check: { op: 'email' },
+    } as const
 
     for (let i = 0; i < 200; i++) {
       expression = {
@@ -81,8 +93,12 @@ describe('json expr bridge', () => {
 
     const predicate = compileExpr(expression, { fieldNames })
 
-    expect(predicate({ email: 'alex@example.com', accountType: 'business' }, {})).toBe(true)
-    expect(predicate({ email: 'invalid', accountType: 'business' }, {})).toBe(false)
+    expect(
+      predicate({ email: 'alex@example.com', accountType: 'business' }, {}),
+    ).toBe(true)
+    expect(predicate({ email: 'invalid', accountType: 'business' }, {})).toBe(
+      false,
+    )
     expect(getExprFieldRefs(expression)).toEqual(['email', 'accountType'])
   })
 

--- a/packages/json/__tests__/parse.test.ts
+++ b/packages/json/__tests__/parse.test.ts
@@ -1,6 +1,13 @@
 import { umpire } from '@umpire/core'
 
-import { fromJson, fromJsonSafe, getJsonDef, parseJsonSchema, toJson, validateSchema } from '../src/index.js'
+import {
+  fromJson,
+  fromJsonSafe,
+  getJsonDef,
+  parseJsonSchema,
+  toJson,
+  validateSchema,
+} from '../src/index.js'
 import type { UmpireJsonSchema } from '../src/index.js'
 
 describe('fromJson', () => {
@@ -195,25 +202,48 @@ describe('parseJsonSchema', () => {
 
     expect(parsed).toEqual({
       ok: false,
-      errors: ['[@umpire/json] Rule "requires" references unknown field "missing"'],
+      errors: [
+        '[@umpire/json] Rule "requires" references unknown field "missing"',
+      ],
     })
   })
 
   test.each([
     [null, '[@umpire/json] Schema must be an object'],
     [{ version: 1 }, '[@umpire/json] Schema must include a "fields" object'],
-    [{ version: 1, fields: [], rules: [] }, '[@umpire/json] Schema must include a "fields" object'],
-    [{ version: 1, fields: {}, rules: null }, '[@umpire/json] Schema must include a "rules" array'],
-    [{ version: 1, fields: {}, rules: [], validators: 'nope' }, '[@umpire/json] Schema "validators" must be an object when provided'],
-    [{ version: 1, fields: {}, rules: [], validators: [] }, '[@umpire/json] Schema "validators" must be an object when provided'],
-    [{ version: 2, fields: {}, rules: [] }, '[@umpire/json] Unsupported schema version "2"'],
-    [{ fields: {}, rules: [] }, '[@umpire/json] Schema must include a "version" field'],
-  ])('returns boundary errors for malformed raw schemas: %j', (raw, message) => {
-    expect(parseJsonSchema(raw)).toEqual({
-      ok: false,
-      errors: [message],
-    })
-  })
+    [
+      { version: 1, fields: [], rules: [] },
+      '[@umpire/json] Schema must include a "fields" object',
+    ],
+    [
+      { version: 1, fields: {}, rules: null },
+      '[@umpire/json] Schema must include a "rules" array',
+    ],
+    [
+      { version: 1, fields: {}, rules: [], validators: 'nope' },
+      '[@umpire/json] Schema "validators" must be an object when provided',
+    ],
+    [
+      { version: 1, fields: {}, rules: [], validators: [] },
+      '[@umpire/json] Schema "validators" must be an object when provided',
+    ],
+    [
+      { version: 2, fields: {}, rules: [] },
+      '[@umpire/json] Unsupported schema version "2"',
+    ],
+    [
+      { fields: {}, rules: [] },
+      '[@umpire/json] Schema must include a "version" field',
+    ],
+  ])(
+    'returns boundary errors for malformed raw schemas: %j',
+    (raw, message) => {
+      expect(parseJsonSchema(raw)).toEqual({
+        ok: false,
+        errors: [message],
+      })
+    },
+  )
 })
 
 describe('fromJsonSafe', () => {
@@ -237,7 +267,11 @@ describe('fromJsonSafe', () => {
       throw new Error('Expected fromJsonSafe to succeed')
     }
 
-    const runtime = umpire({ fields: parsed.fields, rules: parsed.rules, validators: parsed.validators })
+    const runtime = umpire({
+      fields: parsed.fields,
+      rules: parsed.rules,
+      validators: parsed.validators,
+    })
     expect(runtime.check({ email: 'invalid' }).email.valid).toBe(false)
     expect(parsed.schema).toEqual(raw)
   })
@@ -257,7 +291,9 @@ describe('fromJsonSafe', () => {
 
     expect(parsed).toEqual({
       ok: false,
-      errors: ['[@umpire/json] Rule "requires" references unknown field "missing"'],
+      errors: [
+        '[@umpire/json] Rule "requires" references unknown field "missing"',
+      ],
     })
   })
 
@@ -314,12 +350,15 @@ describe('fromJsonSafe', () => {
       },
       '[@umpire/json] Schema "excluded" must be an array when provided',
     ],
-  ])('returns boundary errors for malformed schema sections: %j', (raw, message) => {
-    expect(fromJsonSafe(raw)).toEqual({
-      ok: false,
-      errors: [message],
-    })
-  })
+  ])(
+    'returns boundary errors for malformed schema sections: %j',
+    (raw, message) => {
+      expect(fromJsonSafe(raw)).toEqual({
+        ok: false,
+        errors: [message],
+      })
+    },
+  )
 
   test('matches fromJson output shape and behavior for valid schemas', () => {
     const schema: UmpireJsonSchema = {
@@ -351,7 +390,11 @@ describe('fromJsonSafe', () => {
       throw new Error('Expected fromJsonSafe to succeed')
     }
 
-    const safeRuntime = umpire({ fields: safe.fields, rules: safe.rules, validators: safe.validators })
+    const safeRuntime = umpire({
+      fields: safe.fields,
+      rules: safe.rules,
+      validators: safe.validators,
+    })
     const typedRuntime = umpire(typed)
 
     const values = {
@@ -361,9 +404,13 @@ describe('fromJsonSafe', () => {
     }
 
     expect(Object.keys(safe.fields)).toEqual(Object.keys(typed.fields))
-    expect(toJson({ fields: safe.fields, rules: safe.rules, validators: safe.validators })).toEqual(
-      toJson(typed),
-    )
+    expect(
+      toJson({
+        fields: safe.fields,
+        rules: safe.rules,
+        validators: safe.validators,
+      }),
+    ).toEqual(toJson(typed))
     expect(safeRuntime.check(values)).toEqual(typedRuntime.check(values))
   })
 })

--- a/packages/json/__tests__/serialize.test.ts
+++ b/packages/json/__tests__/serialize.test.ts
@@ -13,7 +13,12 @@ import {
   type Rule,
 } from '@umpire/core'
 
-import { fromJson, hydrateIsEmptyStrategy, namedValidators, toJson } from '../src/index.js'
+import {
+  fromJson,
+  hydrateIsEmptyStrategy,
+  namedValidators,
+  toJson,
+} from '../src/index.js'
 import type { UmpireJsonSchema } from '../src/index.js'
 
 describe('toJson', () => {
@@ -76,18 +81,20 @@ describe('toJson', () => {
       slug: {},
     }
 
-    expect(toJson({
-      fields,
-      rules: [],
-      validators: {
-        email: namedValidators.email(),
-        username: {
-          validator: namedValidators.minLength(3),
-          error: 'Username must be at least 3 characters',
+    expect(
+      toJson({
+        fields,
+        rules: [],
+        validators: {
+          email: namedValidators.email(),
+          username: {
+            validator: namedValidators.minLength(3),
+            error: 'Username must be at least 3 characters',
+          },
+          slug: /^[a-z-]+$/,
         },
-        slug: /^[a-z-]+$/,
-      },
-    })).toEqual({
+      }),
+    ).toEqual({
       version: 1,
       fields: {
         email: {},
@@ -109,7 +116,8 @@ describe('toJson', () => {
         {
           type: 'field:validator',
           field: 'slug',
-          description: 'Field validator cannot be serialized unless it uses portable validator metadata from @umpire/json',
+          description:
+            'Field validator cannot be serialized unless it uses portable validator metadata from @umpire/json',
           key: 'field:slug:validator',
         },
       ],
@@ -131,9 +139,14 @@ describe('toJson', () => {
       requires<typeof fields>('submit', 'email', 'username', {
         reason: 'Need an identity field',
       }),
-      requires<typeof fields>('submit', check('email', namedValidators.email()), 'password', {
-        reason: 'Need a valid email and password',
-      }),
+      requires<typeof fields>(
+        'submit',
+        check('email', namedValidators.email()),
+        'password',
+        {
+          reason: 'Need a valid email and password',
+        },
+      ),
       disables<typeof fields>('mode', ['submit']),
       oneOf<typeof fields>('accessMode', {
         credential: ['email', 'password'],
@@ -209,20 +222,23 @@ describe('toJson', () => {
         {
           type: 'field:isEmpty',
           field: 'extra',
-          description: 'Field isEmpty uses a custom function and cannot be serialized',
+          description:
+            'Field isEmpty uses a custom function and cannot be serialized',
           key: 'field:extra:isEmpty',
           signature: '(value) => boolean',
         },
         {
           type: 'field:default',
           field: 'profile',
-          description: 'Field default is not a JSON primitive and cannot be serialized',
+          description:
+            'Field default is not a JSON primitive and cannot be serialized',
           key: 'field:profile:default',
         },
         {
           type: 'enabledWhen',
           field: 'submit',
-          description: 'enabledWhen() predicates are only serializable when hydrated from JSON or when they map to a portable validator',
+          description:
+            'enabledWhen() predicates are only serializable when hydrated from JSON or when they map to a portable validator',
           key: 'rule:enabledWhen:submit',
         },
       ],
@@ -246,24 +262,27 @@ describe('toJson', () => {
         },
         {
           type: 'oneOf',
-          description: 'Prior runtime could not serialize access mode branching',
+          description:
+            'Prior runtime could not serialize access mode branching',
           key: 'rule:oneOf:accessMode',
         },
       ],
     })
 
-    expect(toJson({
-      fields: {
-        ...parsed.fields,
-        email: { isEmpty: isEmptyString },
-      },
-      rules: [
-        oneOf('accessMode', {
-          account: ['email'],
-          handle: ['username'],
-        }),
-      ],
-    })).toEqual({
+    expect(
+      toJson({
+        fields: {
+          ...parsed.fields,
+          email: { isEmpty: isEmptyString },
+        },
+        rules: [
+          oneOf('accessMode', {
+            account: ['email'],
+            handle: ['username'],
+          }),
+        ],
+      }),
+    ).toEqual({
       version: 1,
       fields: {
         email: { isEmpty: 'string' },
@@ -300,15 +319,17 @@ describe('toJson', () => {
       ],
     })
 
-    expect(toJson({
-      fields: parsed.fields,
-      rules: [
-        eitherOf('auth', {
-          password: [requires('submit', 'email')],
-          sso: [requires('submit', 'ssoToken')],
-        }),
-      ],
-    })).toEqual({
+    expect(
+      toJson({
+        fields: parsed.fields,
+        rules: [
+          eitherOf('auth', {
+            password: [requires('submit', 'email')],
+            sso: [requires('submit', 'ssoToken')],
+          }),
+        ],
+      }),
+    ).toEqual({
       version: 1,
       fields: {
         submit: {},
@@ -357,13 +378,15 @@ describe('toJson', () => {
       ],
     })
 
-    expect(toJson({
-      fields: {
-        ...parsed.fields,
-        extra: { isEmpty: (value: unknown) => value == null || value === '' },
-      },
-      rules: parsed.rules,
-    })).toEqual({
+    expect(
+      toJson({
+        fields: {
+          ...parsed.fields,
+          extra: { isEmpty: (value: unknown) => value == null || value === '' },
+        },
+        rules: parsed.rules,
+      }),
+    ).toEqual({
       version: 1,
       fields: {
         extra: {},
@@ -373,7 +396,8 @@ describe('toJson', () => {
         {
           type: 'field:isEmpty',
           field: 'extra',
-          description: 'Field isEmpty uses a custom function and cannot be serialized',
+          description:
+            'Field isEmpty uses a custom function and cannot be serialized',
           key: 'field:extra:isEmpty',
           signature: '(value) => boolean',
         },
@@ -444,7 +468,8 @@ describe('toJson', () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: 'eitherOf',
-          description: 'eitherOf() contains inner rules that cannot be serialized one-to-one into JSON',
+          description:
+            'eitherOf() contains inner rules that cannot be serialized one-to-one into JSON',
           key: 'rule:eitherOf:auth',
         }),
       ]),
@@ -509,7 +534,9 @@ describe('toJson', () => {
     const result = toJson({
       fields,
       rules: [
-        enabledWhen('submit', check('email', namedValidators.email()), { reason: () => 'dynamic' }),
+        enabledWhen('submit', check('email', namedValidators.email()), {
+          reason: () => 'dynamic',
+        }),
         requires('submit', 'email', { reason: () => 'dynamic' }),
         fairWhen('email', namedValidators.email(), { reason: () => 'dynamic' }),
         disables('mode', ['submit'], { reason: () => 'dynamic' }),
@@ -537,7 +564,11 @@ describe('toJson', () => {
     const result = toJson({
       fields,
       rules: [
-        oneOf('modeSelect', { email: ['email'], submit: ['submit'] }, { activeBranch: 'email' }),
+        oneOf(
+          'modeSelect',
+          { email: ['email'], submit: ['submit'] },
+          { activeBranch: 'email' },
+        ),
         anyOf(enabledWhen('submit', (values) => values.mode === 'open')),
       ],
     })
@@ -570,7 +601,8 @@ describe('toJson', () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: 'opaqueRule',
-          description: 'Rule "opaqueRule" could not be inspected for JSON serialization',
+          description:
+            'Rule "opaqueRule" could not be inspected for JSON serialization',
         }),
       ]),
     )

--- a/packages/json/__tests__/validate.test.ts
+++ b/packages/json/__tests__/validate.test.ts
@@ -344,9 +344,9 @@ describe('validateSchema', () => {
       'Validator for field "email" must use a string error when provided',
     ],
   ])('%s', (_label, schema, expectedMessage) => {
-    expect(() =>
-      validateSchema(schema as unknown as UmpireJsonSchema),
-    ).toThrow(expectedMessage)
+    expect(() => validateSchema(schema as unknown as UmpireJsonSchema)).toThrow(
+      expectedMessage,
+    )
   })
 
   test('accepts nested anyOf/eitherOf composites with matching targets and constraints', () => {

--- a/packages/json/conformance/failures/bad-call-sheet-failures.json
+++ b/packages/json/conformance/failures/bad-call-sheet-failures.json
@@ -37,7 +37,11 @@
           {
             "type": "enabledWhen",
             "field": "starterGate",
-            "when": { "op": "fieldInCond", "field": "starter", "condition": "weatherBand" }
+            "when": {
+              "op": "fieldInCond",
+              "field": "starter",
+              "condition": "weatherBand"
+            }
           }
         ]
       },

--- a/packages/json/conformance/fixtures/box-score-checks.json
+++ b/packages/json/conformance/fixtures/box-score-checks.json
@@ -77,14 +77,8 @@
         "scorerEmail": "pressbox@ballpark.example",
         "highlightUrl": "https://mlb.example/highlights/9th-inning",
         "jerseyNumber": "27",
-        "benchBats": [
-          "Soto"
-        ],
-        "walkupClips": [
-          "intro",
-          "chorus",
-          "outro"
-        ],
+        "benchBats": ["Soto"],
+        "walkupClips": ["intro", "chorus", "outro"],
         "pitchCount": 1,
         "bullpenArms": 8,
         "lineupSlot": 4,
@@ -172,12 +166,7 @@
         "highlightUrl": "/highlights/9th",
         "jerseyNumber": "100",
         "benchBats": [],
-        "walkupClips": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ],
+        "walkupClips": ["a", "b", "c", "d"],
         "pitchCount": 0,
         "bullpenArms": 9,
         "lineupSlot": 10,
@@ -189,9 +178,7 @@
           "fair": false,
           "required": false,
           "reason": "Must be a valid email address",
-          "reasons": [
-            "Must be a valid email address"
-          ],
+          "reasons": ["Must be a valid email address"],
           "satisfied": true
         },
         "highlightUrl": {
@@ -199,9 +186,7 @@
           "fair": false,
           "required": false,
           "reason": "Must be a valid URL",
-          "reasons": [
-            "Must be a valid URL"
-          ],
+          "reasons": ["Must be a valid URL"],
           "satisfied": true
         },
         "jerseyNumber": {
@@ -209,9 +194,7 @@
           "fair": false,
           "required": false,
           "reason": "Must match the required format",
-          "reasons": [
-            "Must match the required format"
-          ],
+          "reasons": ["Must match the required format"],
           "satisfied": true
         },
         "benchBats": {
@@ -219,9 +202,7 @@
           "fair": false,
           "required": false,
           "reason": "Must be at least 1 characters",
-          "reasons": [
-            "Must be at least 1 characters"
-          ],
+          "reasons": ["Must be at least 1 characters"],
           "satisfied": true
         },
         "walkupClips": {
@@ -229,9 +210,7 @@
           "fair": false,
           "required": false,
           "reason": "Must be 3 characters or fewer",
-          "reasons": [
-            "Must be 3 characters or fewer"
-          ],
+          "reasons": ["Must be 3 characters or fewer"],
           "satisfied": true
         },
         "pitchCount": {
@@ -239,9 +218,7 @@
           "fair": false,
           "required": false,
           "reason": "Must be at least 1",
-          "reasons": [
-            "Must be at least 1"
-          ],
+          "reasons": ["Must be at least 1"],
           "satisfied": true
         },
         "bullpenArms": {
@@ -249,9 +226,7 @@
           "fair": false,
           "required": false,
           "reason": "Must be 8 or less",
-          "reasons": [
-            "Must be 8 or less"
-          ],
+          "reasons": ["Must be 8 or less"],
           "satisfied": true
         },
         "lineupSlot": {
@@ -259,9 +234,7 @@
           "fair": false,
           "required": false,
           "reason": "Must be between 1 and 9",
-          "reasons": [
-            "Must be between 1 and 9"
-          ],
+          "reasons": ["Must be between 1 and 9"],
           "satisfied": true
         },
         "inning": {
@@ -269,9 +242,7 @@
           "fair": false,
           "required": false,
           "reason": "Must be a whole number",
-          "reasons": [
-            "Must be a whole number"
-          ],
+          "reasons": ["Must be a whole number"],
           "satisfied": true
         }
       }

--- a/packages/json/conformance/fixtures/bullpen-structural.json
+++ b/packages/json/conformance/fixtures/bullpen-structural.json
@@ -46,12 +46,8 @@
         "type": "oneOf",
         "group": "bullpenCall",
         "branches": {
-          "phone": [
-            "bullpenPhone"
-          ],
-          "signal": [
-            "outfieldSignal"
-          ]
+          "phone": ["bullpenPhone"],
+          "signal": ["outfieldSignal"]
         }
       },
       {
@@ -133,18 +129,12 @@
         "pitcherCard": {
           "fastball": 62
         },
-        "benchBats": [
-          "Soto",
-          "Verdugo"
-        ],
+        "benchBats": ["Soto", "Verdugo"],
         "stealCoverOn": false
       },
       "conditions": {
         "isPlayoffs": false,
-        "availablePitchers": [
-          "Cole",
-          "Holmes"
-        ]
+        "availablePitchers": ["Cole", "Holmes"]
       },
       "expectedAvailability": {
         "startingPitcher": {
@@ -168,9 +158,7 @@
           "fair": true,
           "required": false,
           "reason": "conflicts with phone strategy",
-          "reasons": [
-            "conflicts with phone strategy"
-          ],
+          "reasons": ["conflicts with phone strategy"],
           "satisfied": false
         },
         "closerReady": {
@@ -233,10 +221,7 @@
         "pitcherCard": {
           "fastball": 62
         },
-        "benchBats": [
-          "Soto",
-          "Verdugo"
-        ],
+        "benchBats": ["Soto", "Verdugo"],
         "stealCoverOn": true
       },
       "prev": {
@@ -246,18 +231,12 @@
         "pitcherCard": {
           "fastball": 62
         },
-        "benchBats": [
-          "Soto",
-          "Verdugo"
-        ],
+        "benchBats": ["Soto", "Verdugo"],
         "stealCoverOn": true
       },
       "conditions": {
         "isPlayoffs": false,
-        "availablePitchers": [
-          "Cole",
-          "Holmes"
-        ]
+        "availablePitchers": ["Cole", "Holmes"]
       },
       "expectedAvailability": {
         "startingPitcher": {
@@ -273,9 +252,7 @@
           "fair": true,
           "required": false,
           "reason": "conflicts with signal strategy",
-          "reasons": [
-            "conflicts with signal strategy"
-          ],
+          "reasons": ["conflicts with signal strategy"],
           "satisfied": true
         },
         "outfieldSignal": {
@@ -348,16 +325,12 @@
         "pitcherCard": {
           "fastball": 62
         },
-        "benchBats": [
-          "Soto"
-        ],
+        "benchBats": ["Soto"],
         "stealCoverOn": true
       },
       "conditions": {
         "isPlayoffs": false,
-        "availablePitchers": [
-          "Holmes"
-        ]
+        "availablePitchers": ["Holmes"]
       },
       "expectedAvailability": {
         "startingPitcher": {
@@ -365,9 +338,7 @@
           "fair": false,
           "required": true,
           "reason": "Starting pitcher is not available tonight",
-          "reasons": [
-            "Starting pitcher is not available tonight"
-          ],
+          "reasons": ["Starting pitcher is not available tonight"],
           "satisfied": true
         },
         "bullpenPhone": {
@@ -375,9 +346,7 @@
           "fair": true,
           "required": false,
           "reason": "requires startingPitcher",
-          "reasons": [
-            "requires startingPitcher"
-          ],
+          "reasons": ["requires startingPitcher"],
           "satisfied": true
         },
         "outfieldSignal": {
@@ -385,9 +354,7 @@
           "fair": true,
           "required": false,
           "reason": "conflicts with phone strategy",
-          "reasons": [
-            "conflicts with phone strategy"
-          ],
+          "reasons": ["conflicts with phone strategy"],
           "satisfied": false
         },
         "closerReady": {

--- a/packages/json/conformance/fixtures/dsl-matrix.json
+++ b/packages/json/conformance/fixtures/dsl-matrix.json
@@ -165,10 +165,7 @@
         "when": {
           "op": "in",
           "field": "benchBat",
-          "values": [
-            "Soto",
-            "Judge"
-          ]
+          "values": ["Soto", "Judge"]
         },
         "reason": "Need one of the middle-order bats"
       },
@@ -178,10 +175,7 @@
         "when": {
           "op": "notIn",
           "field": "benchBat",
-          "values": [
-            "Cabrera",
-            "Volpe"
-          ]
+          "values": ["Cabrera", "Volpe"]
         },
         "reason": "Bench bat is already committed elsewhere"
       },
@@ -210,10 +204,7 @@
         "when": {
           "op": "condIn",
           "condition": "weatherBand",
-          "values": [
-            "cold",
-            "windy"
-          ]
+          "values": ["cold", "windy"]
         },
         "reason": "Only for cold or windy prep"
       },
@@ -310,9 +301,7 @@
             }
           ]
         },
-        "targets": [
-          "dugoutTablet"
-        ],
+        "targets": ["dugoutTablet"],
         "reason": "Review board locked during windy or intentional-walk moments"
       }
     ]
@@ -333,10 +322,7 @@
       "conditions": {
         "isPlayoffs": true,
         "weatherBand": "cold",
-        "availableStarters": [
-          "Cole",
-          "Holmes"
-        ]
+        "availableStarters": ["Cole", "Holmes"]
       },
       "expectedAvailability": {
         "inning": {
@@ -448,9 +434,7 @@
           "fair": true,
           "required": false,
           "reason": "Need one out or fewer",
-          "reasons": [
-            "Need one out or fewer"
-          ],
+          "reasons": ["Need one out or fewer"],
           "satisfied": false
         },
         "presentGate": {
@@ -466,9 +450,7 @@
           "fair": true,
           "required": false,
           "reason": "Spray card must be absent",
-          "reasons": [
-            "Spray card must be absent"
-          ],
+          "reasons": ["Spray card must be absent"],
           "satisfied": false
         },
         "truthyGate": {
@@ -540,9 +522,7 @@
           "fair": true,
           "required": false,
           "reason": "Only active outside October",
-          "reasons": [
-            "Only active outside October"
-          ],
+          "reasons": ["Only active outside October"],
           "satisfied": false
         },
         "comboGate": {
@@ -585,9 +565,7 @@
       "conditions": {
         "isPlayoffs": false,
         "weatherBand": "windy",
-        "availableStarters": [
-          "Holmes"
-        ]
+        "availableStarters": ["Holmes"]
       },
       "expectedAvailability": {
         "inning": {
@@ -659,9 +637,7 @@
           "fair": true,
           "required": false,
           "reason": "Needs a slider call",
-          "reasons": [
-            "Needs a slider call"
-          ],
+          "reasons": ["Needs a slider call"],
           "satisfied": false
         },
         "neqGate": {
@@ -669,9 +645,7 @@
           "fair": true,
           "required": false,
           "reason": "Cannot be straight heat",
-          "reasons": [
-            "Cannot be straight heat"
-          ],
+          "reasons": ["Cannot be straight heat"],
           "satisfied": false
         },
         "gtGate": {
@@ -687,9 +661,7 @@
           "fair": true,
           "required": false,
           "reason": "Need two outs",
-          "reasons": [
-            "Need two outs"
-          ],
+          "reasons": ["Need two outs"],
           "satisfied": false
         },
         "ltGate": {
@@ -697,9 +669,7 @@
           "fair": true,
           "required": false,
           "reason": "Must be before the ninth",
-          "reasons": [
-            "Must be before the ninth"
-          ],
+          "reasons": ["Must be before the ninth"],
           "satisfied": false
         },
         "lteGate": {
@@ -715,9 +685,7 @@
           "fair": true,
           "required": false,
           "reason": "Spray card must be present",
-          "reasons": [
-            "Spray card must be present"
-          ],
+          "reasons": ["Spray card must be present"],
           "satisfied": false
         },
         "absentGate": {
@@ -733,9 +701,7 @@
           "fair": true,
           "required": false,
           "reason": "Bullpen must be ready",
-          "reasons": [
-            "Bullpen must be ready"
-          ],
+          "reasons": ["Bullpen must be ready"],
           "satisfied": false
         },
         "falsyGate": {
@@ -743,9 +709,7 @@
           "fair": true,
           "required": false,
           "reason": "Walk signal must be off",
-          "reasons": [
-            "Walk signal must be off"
-          ],
+          "reasons": ["Walk signal must be off"],
           "satisfied": false
         },
         "inGate": {
@@ -753,9 +717,7 @@
           "fair": true,
           "required": false,
           "reason": "Need one of the middle-order bats",
-          "reasons": [
-            "Need one of the middle-order bats"
-          ],
+          "reasons": ["Need one of the middle-order bats"],
           "satisfied": false
         },
         "notInGate": {
@@ -763,9 +725,7 @@
           "fair": true,
           "required": false,
           "reason": "Bench bat is already committed elsewhere",
-          "reasons": [
-            "Bench bat is already committed elsewhere"
-          ],
+          "reasons": ["Bench bat is already committed elsewhere"],
           "satisfied": false
         },
         "condGate": {
@@ -773,9 +733,7 @@
           "fair": true,
           "required": false,
           "reason": "Only active in October",
-          "reasons": [
-            "Only active in October"
-          ],
+          "reasons": ["Only active in October"],
           "satisfied": false
         },
         "condEqGate": {
@@ -783,9 +741,7 @@
           "fair": true,
           "required": false,
           "reason": "Only for cold-weather prep",
-          "reasons": [
-            "Only for cold-weather prep"
-          ],
+          "reasons": ["Only for cold-weather prep"],
           "satisfied": false
         },
         "condInGate": {
@@ -801,9 +757,7 @@
           "fair": true,
           "required": false,
           "reason": "Starter must be on tonight's card",
-          "reasons": [
-            "Starter must be on tonight's card"
-          ],
+          "reasons": ["Starter must be on tonight's card"],
           "satisfied": false
         },
         "notGate": {
@@ -819,9 +773,7 @@
           "fair": true,
           "required": false,
           "reason": "Complex scouting combo failed",
-          "reasons": [
-            "Complex scouting combo failed"
-          ],
+          "reasons": ["Complex scouting combo failed"],
           "satisfied": false
         },
         "bullpenCart": {

--- a/packages/json/conformance/fixtures/dugout-emptiness.json
+++ b/packages/json/conformance/fixtures/dugout-emptiness.json
@@ -121,9 +121,7 @@
       "id": "false-and-numbers-can-still-be-present",
       "values": {
         "scoutingNote": "Attack away early",
-        "benchBats": [
-          "Verdugo"
-        ],
+        "benchBats": ["Verdugo"],
         "pitcherCard": {
           "firstPitch": "four-seam"
         },

--- a/packages/json/conformance/fixtures/plan-either-of-fair.json
+++ b/packages/json/conformance/fixtures/plan-either-of-fair.json
@@ -100,10 +100,7 @@
         "planId": "pro"
       },
       "conditions": {
-        "activePlans": [
-          "pro",
-          "starter"
-        ],
+        "activePlans": ["pro", "starter"],
         "billingReady": true,
         "allowLegacyPlan": false,
         "betaPlans": [],
@@ -126,10 +123,7 @@
         "planId": "legacy-gold"
       },
       "conditions": {
-        "activePlans": [
-          "pro",
-          "starter"
-        ],
+        "activePlans": ["pro", "starter"],
         "billingReady": false,
         "allowLegacyPlan": true,
         "betaPlans": [],
@@ -152,14 +146,10 @@
         "planId": "beta-x"
       },
       "conditions": {
-        "activePlans": [
-          "pro"
-        ],
+        "activePlans": ["pro"],
         "billingReady": false,
         "allowLegacyPlan": false,
-        "betaPlans": [
-          "beta-x"
-        ],
+        "betaPlans": ["beta-x"],
         "betaEnabled": true
       },
       "expectedAvailability": {
@@ -179,14 +169,10 @@
         "planId": "starter"
       },
       "conditions": {
-        "activePlans": [
-          "starter"
-        ],
+        "activePlans": ["starter"],
         "billingReady": true,
         "allowLegacyPlan": false,
-        "betaPlans": [
-          "starter"
-        ],
+        "betaPlans": ["starter"],
         "betaEnabled": true
       },
       "expectedAvailability": {
@@ -206,9 +192,7 @@
         "planId": "pro"
       },
       "conditions": {
-        "activePlans": [
-          "pro"
-        ],
+        "activePlans": ["pro"],
         "billingReady": false,
         "allowLegacyPlan": false,
         "betaPlans": [],

--- a/packages/json/conformance/fixtures/rain-delay-chain.json
+++ b/packages/json/conformance/fixtures/rain-delay-chain.json
@@ -22,9 +22,7 @@
       {
         "type": "disables",
         "source": "rainDelay",
-        "targets": [
-          "starterWarmup"
-        ]
+        "targets": ["starterWarmup"]
       },
       {
         "type": "requires",
@@ -61,9 +59,7 @@
           "fair": true,
           "required": false,
           "reason": "overridden by rainDelay",
-          "reasons": [
-            "overridden by rainDelay"
-          ],
+          "reasons": ["overridden by rainDelay"],
           "satisfied": true
         },
         "moundVisitPlan": {
@@ -71,9 +67,7 @@
           "fair": true,
           "required": false,
           "reason": "requires starterWarmup",
-          "reasons": [
-            "requires starterWarmup"
-          ],
+          "reasons": ["requires starterWarmup"],
           "satisfied": true
         },
         "bullpenPhone": {
@@ -81,9 +75,7 @@
           "fair": true,
           "required": false,
           "reason": "requires moundVisitPlan",
-          "reasons": [
-            "requires moundVisitPlan"
-          ],
+          "reasons": ["requires moundVisitPlan"],
           "satisfied": true
         }
       }

--- a/packages/json/conformance/fixtures/rotation-cascade.json
+++ b/packages/json/conformance/fixtures/rotation-cascade.json
@@ -54,9 +54,7 @@
         "bullpenPhone": "call the bridge arm"
       },
       "conditions": {
-        "availablePitchers": [
-          "Holmes"
-        ]
+        "availablePitchers": ["Holmes"]
       },
       "expectedAvailability": {
         "startingPitcher": {
@@ -64,9 +62,7 @@
           "fair": false,
           "required": true,
           "reason": "Starting pitcher is not available tonight",
-          "reasons": [
-            "Starting pitcher is not available tonight"
-          ],
+          "reasons": ["Starting pitcher is not available tonight"],
           "satisfied": true
         },
         "catcherPlan": {
@@ -74,9 +70,7 @@
           "fair": true,
           "required": false,
           "reason": "requires startingPitcher",
-          "reasons": [
-            "requires startingPitcher"
-          ],
+          "reasons": ["requires startingPitcher"],
           "satisfied": true
         },
         "bullpenPhone": {
@@ -84,9 +78,7 @@
           "fair": true,
           "required": false,
           "reason": "requires catcherPlan",
-          "reasons": [
-            "requires catcherPlan"
-          ],
+          "reasons": ["requires catcherPlan"],
           "satisfied": true
         }
       }
@@ -99,10 +91,7 @@
         "bullpenPhone": "call the bridge arm"
       },
       "conditions": {
-        "availablePitchers": [
-          "Cole",
-          "Holmes"
-        ]
+        "availablePitchers": ["Cole", "Holmes"]
       },
       "expectedAvailability": {
         "startingPitcher": {

--- a/packages/json/conformance/fixtures/scoreboard-source-checks.json
+++ b/packages/json/conformance/fixtures/scoreboard-source-checks.json
@@ -55,9 +55,7 @@
             "value": 5
           }
         },
-        "targets": [
-          "replayBoard"
-        ],
+        "targets": ["replayBoard"],
         "reason": "Replay board locks once a scouting note is posted"
       }
     ]
@@ -146,9 +144,7 @@
           "fair": true,
           "required": false,
           "reason": "Need a valid scorer email and password before submit",
-          "reasons": [
-            "Need a valid scorer email and password before submit"
-          ],
+          "reasons": ["Need a valid scorer email and password before submit"],
           "satisfied": true
         },
         "replayBoard": {
@@ -156,9 +152,7 @@
           "fair": true,
           "required": false,
           "reason": "Replay board needs a valid scorer email",
-          "reasons": [
-            "Replay board needs a valid scorer email"
-          ],
+          "reasons": ["Replay board needs a valid scorer email"],
           "satisfied": true
         },
         "scoutingNote": {
@@ -210,9 +204,7 @@
           "fair": true,
           "required": false,
           "reason": "Replay board locks once a scouting note is posted",
-          "reasons": [
-            "Replay board locks once a scouting note is posted"
-          ],
+          "reasons": ["Replay board locks once a scouting note is posted"],
           "satisfied": true
         },
         "scoutingNote": {

--- a/packages/json/conformance/fixtures/stale-signal-disables.json
+++ b/packages/json/conformance/fixtures/stale-signal-disables.json
@@ -19,16 +19,12 @@
       {
         "type": "disables",
         "source": "rainDelay",
-        "targets": [
-          "catcherSignal"
-        ]
+        "targets": ["catcherSignal"]
       },
       {
         "type": "disables",
         "source": "catcherSignal",
-        "targets": [
-          "bullpenPhone"
-        ]
+        "targets": ["bullpenPhone"]
       }
     ]
   },
@@ -53,9 +49,7 @@
           "fair": true,
           "required": false,
           "reason": "overridden by rainDelay",
-          "reasons": [
-            "overridden by rainDelay"
-          ],
+          "reasons": ["overridden by rainDelay"],
           "satisfied": true
         },
         "bullpenPhone": {
@@ -63,9 +57,7 @@
           "fair": true,
           "required": false,
           "reason": "overridden by catcherSignal",
-          "reasons": [
-            "overridden by catcherSignal"
-          ],
+          "reasons": ["overridden by catcherSignal"],
           "satisfied": false
         }
       }
@@ -89,9 +81,7 @@
           "fair": true,
           "required": false,
           "reason": "overridden by rainDelay",
-          "reasons": [
-            "overridden by rainDelay"
-          ],
+          "reasons": ["overridden by rainDelay"],
           "satisfied": false
         },
         "bullpenPhone": {
@@ -131,9 +121,7 @@
           "fair": true,
           "required": false,
           "reason": "overridden by catcherSignal",
-          "reasons": [
-            "overridden by catcherSignal"
-          ],
+          "reasons": ["overridden by catcherSignal"],
           "satisfied": false
         }
       }

--- a/packages/json/conformance/fixtures/validator-surface.json
+++ b/packages/json/conformance/fixtures/validator-surface.json
@@ -47,9 +47,7 @@
           "fair": true,
           "required": false,
           "reason": "Email entry is disabled",
-          "reasons": [
-            "Email entry is disabled"
-          ],
+          "reasons": ["Email entry is disabled"],
           "satisfied": true
         }
       }

--- a/packages/json/src/builders.ts
+++ b/packages/json/src/builders.ts
@@ -1,7 +1,4 @@
-import {
-  expr as baseExpr,
-  type ExprBuilder,
-} from '@umpire/dsl'
+import { expr as baseExpr, type ExprBuilder } from '@umpire/dsl'
 
 import {
   anyOf,
@@ -38,11 +35,16 @@ function isPortableRuleOptions(value: unknown): value is PortableRuleOptions {
   return typeof value === 'object' && value !== null && !('op' in value)
 }
 
-function createPortableCheckExpr(field: string, validator: NamedCheck<unknown>): JsonExpr {
+function createPortableCheckExpr(
+  field: string,
+  validator: NamedCheck<unknown>,
+): JsonExpr {
   const spec = createValidatorSpecFromMetadata(validator)
 
   if (!spec) {
-    throw new Error('[@umpire/json] expr.check() requires a portable validator from @umpire/json')
+    throw new Error(
+      '[@umpire/json] expr.check() requires a portable validator from @umpire/json',
+    )
   }
 
   return {
@@ -65,10 +67,16 @@ function compilePortableExpr<
 function compilePortableFairExpr<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(expression: JsonExpr): JsonFairPredicate<FieldValues<F>, C, keyof F & string> {
+>(
+  expression: JsonExpr,
+): JsonFairPredicate<FieldValues<F>, C, keyof F & string> {
   const predicate = compilePortableExpr<F, C>(expression)
   const fairPredicate = ((_: unknown, values: FieldValues<F>, conditions: C) =>
-    predicate(values, conditions)) as JsonFairPredicate<FieldValues<F>, C, keyof F & string>
+    predicate(values, conditions)) as JsonFairPredicate<
+    FieldValues<F>,
+    C,
+    keyof F & string
+  >
 
   fairPredicate._checkField = predicate._checkField
   fairPredicate._namedCheck = predicate._namedCheck
@@ -83,13 +91,18 @@ function getRequiredJsonDef(
   const jsonDef = getJsonDef<JsonRule>(rule)
 
   if (!jsonDef) {
-    throw new Error(`[@umpire/json] ${caller} requires every inner rule to carry JSON metadata`)
+    throw new Error(
+      `[@umpire/json] ${caller} requires every inner rule to carry JSON metadata`,
+    )
   }
 
   return deepClone(jsonDef)
 }
 
-export const expr: JsonExprBuilder<Record<string, FieldDef>, Record<string, unknown>> = {
+export const expr: JsonExprBuilder<
+  Record<string, FieldDef>,
+  Record<string, unknown>
+> = {
   ...baseExpr,
   check: createPortableCheckExpr,
 }
@@ -147,38 +160,43 @@ export function requiresJson<
 ): Rule<F, C> {
   const maybeOptions = dependencies[dependencies.length - 1]
   const options = isPortableRuleOptions(maybeOptions) ? maybeOptions : undefined
-  const sources = (options ? dependencies.slice(0, -1) : dependencies) as JsonRequiresDependency[]
+  const sources = (
+    options ? dependencies.slice(0, -1) : dependencies
+  ) as JsonRequiresDependency[]
 
   if (sources.length === 0) {
-    throw new Error(`[@umpire/json] requiresJson("${field}") requires at least one dependency`)
+    throw new Error(
+      `[@umpire/json] requiresJson("${field}") requires at least one dependency`,
+    )
   }
 
-  const jsonRule: Extract<JsonRule, { type: 'requires' }> = sources.length === 1
-    ? typeof sources[0] === 'string'
-      ? {
-          type: 'requires',
-          field,
-          dependency: sources[0],
-          ...(options?.reason ? { reason: options.reason } : {}),
-        }
+  const jsonRule: Extract<JsonRule, { type: 'requires' }> =
+    sources.length === 1
+      ? typeof sources[0] === 'string'
+        ? {
+            type: 'requires',
+            field,
+            dependency: sources[0],
+            ...(options?.reason ? { reason: options.reason } : {}),
+          }
+        : {
+            type: 'requires',
+            field,
+            when: deepClone(sources[0]),
+            ...(options?.reason ? { reason: options.reason } : {}),
+          }
       : {
           type: 'requires',
           field,
-          when: deepClone(sources[0]),
+          dependencies: sources.map((source) =>
+            typeof source === 'string' ? source : deepClone(source),
+          ),
           ...(options?.reason ? { reason: options.reason } : {}),
         }
-    : {
-        type: 'requires',
-        field,
-        dependencies: sources.map((source) => (
-          typeof source === 'string' ? source : deepClone(source)
-        )),
-        ...(options?.reason ? { reason: options.reason } : {}),
-      }
 
-  const compiledDependencies = sources.map((source) => (
-    typeof source === 'string' ? source : compilePortableExpr<F, C>(source)
-  ))
+  const compiledDependencies = sources.map((source) =>
+    typeof source === 'string' ? source : compilePortableExpr<F, C>(source),
+  )
 
   return attachJsonDef(
     options
@@ -204,7 +222,11 @@ export function disablesExpr<
   }
 
   return attachJsonDef(
-    disables<F, C>(compilePortableExpr<F, C>(jsonRule.when), jsonRule.targets, options),
+    disables<F, C>(
+      compilePortableExpr<F, C>(jsonRule.when),
+      jsonRule.targets,
+      options,
+    ),
     jsonRule,
   )
 }
@@ -225,7 +247,11 @@ export function fairWhenExpr<
   }
 
   return attachJsonDef(
-    fairWhen<F, C>(field, compilePortableFairExpr<F, C>(jsonRule.when), options),
+    fairWhen<F, C>(
+      field,
+      compilePortableFairExpr<F, C>(jsonRule.when),
+      options,
+    ),
     jsonRule,
   )
 }
@@ -233,13 +259,14 @@ export function fairWhenExpr<
 export function anyOfJson<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
->(
-  ...rules: Array<Rule<F, C>>
-): Rule<F, C> {
+>(...rules: Array<Rule<F, C>>): Rule<F, C> {
   const jsonRule: Extract<JsonRule, { type: 'anyOf' }> = {
     type: 'anyOf',
     rules: rules.map((rule) =>
-      getRequiredJsonDef(rule as Rule<Record<string, FieldDef>, Record<string, unknown>>, 'anyOfJson()'),
+      getRequiredJsonDef(
+        rule as Rule<Record<string, FieldDef>, Record<string, unknown>>,
+        'anyOfJson()',
+      ),
     ),
   }
 
@@ -249,10 +276,7 @@ export function anyOfJson<
 export function eitherOfJson<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
->(
-  groupName: string,
-  branches: Record<string, Array<Rule<F, C>>>,
-): Rule<F, C> {
+>(groupName: string, branches: Record<string, Array<Rule<F, C>>>): Rule<F, C> {
   const jsonBranches: Record<string, JsonRule[]> = {}
 
   for (const [branchName, branchRules] of Object.entries(branches)) {
@@ -283,14 +307,26 @@ export function createJsonRules<
       field: keyof F & string,
       ...dependencies: Array<JsonRequiresDependency | PortableRuleOptions>
     ) => requiresJson<F, C>(field, ...dependencies),
-    enabledWhenExpr: (field: keyof F & string, when: JsonExpr, options?: PortableRuleOptions) =>
-      enabledWhenExpr<F, C>(field, when, options),
-    requiresExpr: (field: keyof F & string, when: JsonExpr, options?: PortableRuleOptions) =>
-      requiresExpr<F, C>(field, when, options),
-    disablesExpr: (when: JsonExpr, targets: Array<keyof F & string>, options?: PortableRuleOptions) =>
-      disablesExpr<F, C>(when, targets, options),
-    fairWhenExpr: (field: keyof F & string, when: JsonExpr, options?: PortableRuleOptions) =>
-      fairWhenExpr<F, C>(field, when, options),
+    enabledWhenExpr: (
+      field: keyof F & string,
+      when: JsonExpr,
+      options?: PortableRuleOptions,
+    ) => enabledWhenExpr<F, C>(field, when, options),
+    requiresExpr: (
+      field: keyof F & string,
+      when: JsonExpr,
+      options?: PortableRuleOptions,
+    ) => requiresExpr<F, C>(field, when, options),
+    disablesExpr: (
+      when: JsonExpr,
+      targets: Array<keyof F & string>,
+      options?: PortableRuleOptions,
+    ) => disablesExpr<F, C>(when, targets, options),
+    fairWhenExpr: (
+      field: keyof F & string,
+      when: JsonExpr,
+      options?: PortableRuleOptions,
+    ) => fairWhenExpr<F, C>(field, when, options),
     anyOfJson: (...rules: Array<Rule<F, C>>) => anyOfJson<F, C>(...rules),
     eitherOfJson: (
       groupName: string,

--- a/packages/json/src/check-ops.ts
+++ b/packages/json/src/check-ops.ts
@@ -1,4 +1,8 @@
-import type { JsonPrimitive, NamedCheck, NamedCheckMetadata } from '@umpire/core'
+import type {
+  JsonPrimitive,
+  NamedCheck,
+  NamedCheckMetadata,
+} from '@umpire/core'
 
 import type {
   JsonCheckRule,
@@ -9,7 +13,8 @@ import type {
 
 type Params = Readonly<Record<string, JsonPrimitive>>
 
-const EMAIL_REGEX = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/
+const EMAIL_REGEX =
+  /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/
 
 function createNamedValidator<T>(
   name: JsonValidatorOp,
@@ -31,12 +36,17 @@ function createNamedValidator<T>(
 }
 
 function isLengthLike(value: unknown): value is { length: number } {
-  return (typeof value === 'string' || Array.isArray(value)) && typeof value.length === 'number'
+  return (
+    (typeof value === 'string' || Array.isArray(value)) &&
+    typeof value.length === 'number'
+  )
 }
 
 export const namedValidators = Object.freeze({
   email() {
-    return createNamedValidator<string>('email', (value) => EMAIL_REGEX.test(value))
+    return createNamedValidator<string>('email', (value) =>
+      EMAIL_REGEX.test(value),
+    )
   },
   url() {
     return createNamedValidator<string>('url', (value) => {
@@ -50,25 +60,43 @@ export const namedValidators = Object.freeze({
   },
   matches(pattern: string) {
     const regex = new RegExp(pattern)
-    return createNamedValidator<string>('matches', (value) => regex.test(value), { pattern })
+    return createNamedValidator<string>(
+      'matches',
+      (value) => regex.test(value),
+      { pattern },
+    )
   },
   minLength(value: number) {
-    return createNamedValidator<string | unknown[]>('minLength', (input) =>
-      isLengthLike(input) && input.length >= value, { value })
+    return createNamedValidator<string | unknown[]>(
+      'minLength',
+      (input) => isLengthLike(input) && input.length >= value,
+      { value },
+    )
   },
   maxLength(value: number) {
-    return createNamedValidator<string | unknown[]>('maxLength', (input) =>
-      isLengthLike(input) && input.length <= value, { value })
+    return createNamedValidator<string | unknown[]>(
+      'maxLength',
+      (input) => isLengthLike(input) && input.length <= value,
+      { value },
+    )
   },
   min(value: number) {
-    return createNamedValidator<number>('min', (input) => typeof input === 'number' && input >= value, {
-      value,
-    })
+    return createNamedValidator<number>(
+      'min',
+      (input) => typeof input === 'number' && input >= value,
+      {
+        value,
+      },
+    )
   },
   max(value: number) {
-    return createNamedValidator<number>('max', (input) => typeof input === 'number' && input <= value, {
-      value,
-    })
+    return createNamedValidator<number>(
+      'max',
+      (input) => typeof input === 'number' && input <= value,
+      {
+        value,
+      },
+    )
   },
   range(min: number, max: number) {
     return createNamedValidator<number>(
@@ -78,14 +106,22 @@ export const namedValidators = Object.freeze({
     )
   },
   integer() {
-    return createNamedValidator<number>('integer', (input) => Number.isInteger(input))
+    return createNamedValidator<number>('integer', (input) =>
+      Number.isInteger(input),
+    )
   },
 })
 
-export function defaultValidatorMessage(rule: JsonValidatorSpec | NamedCheckMetadata): string {
-  const metadata = 'op' in rule
-    ? ({ __check: rule.op, params: paramsFromValidatorSpec(rule) } satisfies NamedCheckMetadata)
-    : rule
+export function defaultValidatorMessage(
+  rule: JsonValidatorSpec | NamedCheckMetadata,
+): string {
+  const metadata =
+    'op' in rule
+      ? ({
+          __check: rule.op,
+          params: paramsFromValidatorSpec(rule),
+        } satisfies NamedCheckMetadata)
+      : rule
 
   switch (metadata.__check) {
     case 'email':
@@ -127,7 +163,9 @@ function paramsFromValidatorSpec(rule: JsonValidatorSpec): Params | undefined {
   }
 }
 
-function paramsFromNamedCheckMetadata(metadata: NamedCheckMetadata): Params | undefined {
+function paramsFromNamedCheckMetadata(
+  metadata: NamedCheckMetadata,
+): Params | undefined {
   return metadata.params
 }
 
@@ -169,7 +207,8 @@ export function createCheckRuleFromMetadata(
   metadata: NamedCheckMetadata,
   reason?: string,
 ): JsonCheckRule | undefined {
-  const resolvedReason = reason && reason !== defaultValidatorMessage(metadata) ? reason : undefined
+  const resolvedReason =
+    reason && reason !== defaultValidatorMessage(metadata) ? reason : undefined
   const spec = createValidatorSpecFromMetadata(metadata)
 
   if (!spec) {
@@ -191,12 +230,12 @@ export function createValidatorDefFromMetadata(
     return undefined
   }
 
-  return error === undefined
-    ? spec
-    : { ...spec, error }
+  return error === undefined ? spec : { ...spec, error }
 }
 
-export function createNamedValidatorFromSpec(spec: JsonValidatorSpec): NamedCheck<unknown> {
+export function createNamedValidatorFromSpec(
+  spec: JsonValidatorSpec,
+): NamedCheck<unknown> {
   switch (spec.op) {
     case 'email':
       return namedValidators.email() as NamedCheck<unknown>
@@ -219,7 +258,9 @@ export function createNamedValidatorFromSpec(spec: JsonValidatorSpec): NamedChec
   }
 }
 
-export const createNamedValidatorFromRule: (rule: JsonCheckRule) => NamedCheck<unknown> = createNamedValidatorFromSpec
+export const createNamedValidatorFromRule: (
+  rule: JsonCheckRule,
+) => NamedCheck<unknown> = createNamedValidatorFromSpec
 
 export function assertValidValidatorSpec(rule: JsonValidatorSpec): void {
   switch (rule.op) {
@@ -232,7 +273,9 @@ export function assertValidValidatorSpec(rule: JsonValidatorSpec): void {
         new RegExp(rule.pattern)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        throw new Error(`[@umpire/json] Invalid regex pattern "${rule.pattern}": ${message}`)
+        throw new Error(
+          `[@umpire/json] Invalid regex pattern "${rule.pattern}": ${message}`,
+        )
       }
       return
     case 'minLength':
@@ -240,7 +283,9 @@ export function assertValidValidatorSpec(rule: JsonValidatorSpec): void {
     case 'min':
     case 'max':
       if (typeof rule.value !== 'number' || Number.isNaN(rule.value)) {
-        throw new Error(`[@umpire/json] Validator "${rule.op}" requires a numeric value`)
+        throw new Error(
+          `[@umpire/json] Validator "${rule.op}" requires a numeric value`,
+        )
       }
       return
     case 'range':
@@ -250,11 +295,15 @@ export function assertValidValidatorSpec(rule: JsonValidatorSpec): void {
         typeof rule.max !== 'number' ||
         Number.isNaN(rule.max)
       ) {
-        throw new Error('[@umpire/json] Validator "range" requires numeric min and max values')
+        throw new Error(
+          '[@umpire/json] Validator "range" requires numeric min and max values',
+        )
       }
       return
     default:
-      throw new Error(`[@umpire/json] Unknown validator op "${String((rule as { op?: unknown }).op)}"`)
+      throw new Error(
+        `[@umpire/json] Unknown validator op "${String((rule as { op?: unknown }).op)}"`,
+      )
   }
 }
 

--- a/packages/json/src/expr.ts
+++ b/packages/json/src/expr.ts
@@ -3,9 +3,17 @@ import {
   getExprFieldRefs as getDslExprFieldRefs,
   type Expr,
 } from '@umpire/dsl'
-import { getNamedCheckMetadata, type FieldDef, type FieldValues, type NamedCheckMetadata } from '@umpire/core'
+import {
+  getNamedCheckMetadata,
+  type FieldDef,
+  type FieldValues,
+  type NamedCheckMetadata,
+} from '@umpire/core'
 
-import { assertValidValidatorSpec, createNamedValidatorFromSpec } from './check-ops.js'
+import {
+  assertValidValidatorSpec,
+  createNamedValidatorFromSpec,
+} from './check-ops.js'
 import type { JsonConditionDef, JsonExpr } from './schema.js'
 
 type ExprPredicate<
@@ -24,7 +32,9 @@ type CompileExprOptions = {
 
 function assertField(field: string, op: string, fieldNames: Set<string>) {
   if (!fieldNames.has(field)) {
-    throw new Error(`[@umpire/json] Unknown field "${field}" in "${op}" expression`)
+    throw new Error(
+      `[@umpire/json] Unknown field "${field}" in "${op}" expression`,
+    )
   }
 }
 
@@ -34,7 +44,9 @@ export function getExprFieldRefs(expression: JsonExpr): string[] {
   }
 
   if (expression.op === 'and' || expression.op === 'or') {
-    return [...new Set(expression.exprs.flatMap((entry) => getExprFieldRefs(entry)))]
+    return [
+      ...new Set(expression.exprs.flatMap((entry) => getExprFieldRefs(entry))),
+    ]
   }
 
   if (expression.op === 'not') {
@@ -79,14 +91,12 @@ function compileCheckExpr<
 export function compileExpr<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  expression: JsonExpr,
-  options: CompileExprOptions,
-): ExprPredicate<F, C> {
+>(expression: JsonExpr, options: CompileExprOptions): ExprPredicate<F, C> {
   const compiled = compileInner<F, C>(expression, options)
 
   if (compiled.fieldRefs.size === 1) {
-    compiled.predicate._checkField = [...compiled.fieldRefs][0] as keyof F & string
+    compiled.predicate._checkField = [...compiled.fieldRefs][0] as keyof F &
+      string
   }
 
   return compiled.predicate
@@ -95,10 +105,7 @@ export function compileExpr<
 function compileInner<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  expression: JsonExpr,
-  options: CompileExprOptions,
-): CompiledNode<F, C> {
+>(expression: JsonExpr, options: CompileExprOptions): CompiledNode<F, C> {
   if (expression.op === 'check') {
     return {
       predicate: compileCheckExpr<F, C>(expression, options),
@@ -111,12 +118,18 @@ function compileInner<
       throw new Error('[@umpire/json] "and" expression requires an exprs array')
     }
 
-    const compiledEntries = expression.exprs.map((entry) => compileInner<F, C>(entry, options))
+    const compiledEntries = expression.exprs.map((entry) =>
+      compileInner<F, C>(entry, options),
+    )
     const predicates = compiledEntries.map((entry) => entry.predicate)
     return {
-      predicate: (((values: FieldValues<F>, conditions: C) =>
-        predicates.every((entry) => entry(values, conditions))) as ExprPredicate<F, C>),
-      fieldRefs: new Set(compiledEntries.flatMap((entry) => [...entry.fieldRefs])),
+      predicate: ((values: FieldValues<F>, conditions: C) =>
+        predicates.every((entry) =>
+          entry(values, conditions),
+        )) as ExprPredicate<F, C>,
+      fieldRefs: new Set(
+        compiledEntries.flatMap((entry) => [...entry.fieldRefs]),
+      ),
     }
   }
 
@@ -125,20 +138,27 @@ function compileInner<
       throw new Error('[@umpire/json] "or" expression requires an exprs array')
     }
 
-    const compiledEntries = expression.exprs.map((entry) => compileInner<F, C>(entry, options))
+    const compiledEntries = expression.exprs.map((entry) =>
+      compileInner<F, C>(entry, options),
+    )
     const predicates = compiledEntries.map((entry) => entry.predicate)
     return {
-      predicate: (((values: FieldValues<F>, conditions: C) =>
-        predicates.some((entry) => entry(values, conditions))) as ExprPredicate<F, C>),
-      fieldRefs: new Set(compiledEntries.flatMap((entry) => [...entry.fieldRefs])),
+      predicate: ((values: FieldValues<F>, conditions: C) =>
+        predicates.some((entry) => entry(values, conditions))) as ExprPredicate<
+        F,
+        C
+      >,
+      fieldRefs: new Set(
+        compiledEntries.flatMap((entry) => [...entry.fieldRefs]),
+      ),
     }
   }
 
   if (expression.op === 'not') {
     const inner = compileInner<F, C>(expression.expr, options)
     return {
-      predicate: (((values: FieldValues<F>, conditions: C) =>
-        !inner.predicate(values, conditions)) as ExprPredicate<F, C>),
+      predicate: ((values: FieldValues<F>, conditions: C) =>
+        !inner.predicate(values, conditions)) as ExprPredicate<F, C>,
       fieldRefs: inner.fieldRefs,
     }
   }

--- a/packages/json/src/fair-predicate.ts
+++ b/packages/json/src/fair-predicate.ts
@@ -4,11 +4,7 @@ export type JsonFairPredicate<
   Values extends Record<string, unknown>,
   C extends Record<string, unknown>,
   FieldName extends string = string,
-> = ((
-  value: unknown,
-  values: Values,
-  conditions: C,
-) => boolean) & {
+> = ((value: unknown, values: Values, conditions: C) => boolean) & {
   _checkField?: FieldName
   _namedCheck?: NamedCheckMetadata
 }

--- a/packages/json/src/json-values.ts
+++ b/packages/json/src/json-values.ts
@@ -1,5 +1,10 @@
 import type { JsonPrimitive } from '@umpire/core'
 
 export function isJsonPrimitive(value: unknown): value is JsonPrimitive {
-  return value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
 }

--- a/packages/json/src/parse.ts
+++ b/packages/json/src/parse.ts
@@ -33,7 +33,10 @@ import { hydrateIsEmptyStrategy } from './strategies.js'
 import { validateSchema } from './validate.js'
 
 export type ParsedFields = Record<string, FieldDef>
-export type ParsedRules<C extends Record<string, unknown>> = Rule<ParsedFields, C>[]
+export type ParsedRules<C extends Record<string, unknown>> = Rule<
+  ParsedFields,
+  C
+>[]
 export type ParsedValidators = ValidationMap<ParsedFields>
 type ParsedSchemaMeta = {
   conditions?: Record<string, JsonConditionDef>
@@ -44,7 +47,9 @@ export type JsonSchemaParseResult =
   | { ok: true; schema: UmpireJsonSchema }
   | { ok: false; errors: string[] }
 
-export type FromJsonSafeResult<C extends Record<string, unknown> = Record<string, unknown>> =
+export type FromJsonSafeResult<
+  C extends Record<string, unknown> = Record<string, unknown>,
+> =
   | {
       ok: true
       schema: UmpireJsonSchema
@@ -75,8 +80,14 @@ function compileFairExpr<C extends Record<string, unknown>>(
     conditions: schema.conditions,
   })
 
-  const fairPredicate = ((_: unknown, values: FieldValues<ParsedFields>, conditions: C) =>
-    predicate(values, conditions)) as JsonFairPredicate<FieldValues<ParsedFields>, C>
+  const fairPredicate = ((
+    _: unknown,
+    values: FieldValues<ParsedFields>,
+    conditions: C,
+  ) => predicate(values, conditions)) as JsonFairPredicate<
+    FieldValues<ParsedFields>,
+    C
+  >
 
   fairPredicate._checkField = predicate._checkField
   fairPredicate._namedCheck = predicate._namedCheck
@@ -98,10 +109,13 @@ function parseFieldDefs(fields: UmpireJsonSchema['fields']): ParsedFields {
   return parsed
 }
 
-function parseCheckRule<C extends Record<string, unknown>>(rule: JsonCheckRule): Rule<ParsedFields, C> {
+function parseCheckRule<C extends Record<string, unknown>>(
+  rule: JsonCheckRule,
+): Rule<ParsedFields, C> {
   const validator = createNamedValidatorFromRule(rule)
   const metadata = getNamedCheckMetadata(validator)
-  const predicate = ((value: unknown) => validator.validate(value as never)) as JsonFairPredicate<
+  const predicate = ((value: unknown) =>
+    validator.validate(value as never)) as JsonFairPredicate<
     FieldValues<ParsedFields>,
     C
   >
@@ -127,7 +141,9 @@ function parseValidatorDef(definition: JsonValidatorDef) {
   )
 }
 
-function parseValidators(validators: UmpireJsonSchema['validators']): ParsedValidators {
+function parseValidators(
+  validators: UmpireJsonSchema['validators'],
+): ParsedValidators {
   const parsed = Object.create(null) as ParsedValidators
 
   for (const [field, definition] of Object.entries(validators ?? {})) {
@@ -150,69 +166,123 @@ function parseRule<C extends Record<string, unknown>>(
   switch (rule.type) {
     case 'requires':
       if ('dependency' in rule) {
-        return attachJsonDef(requires<ParsedFields, C>(rule.field, rule.dependency, {
-          reason: rule.reason,
-        }), rule)
+        return attachJsonDef(
+          requires<ParsedFields, C>(rule.field, rule.dependency, {
+            reason: rule.reason,
+          }),
+          rule,
+        )
       }
 
       if ('dependencies' in rule) {
         const dependencies = rule.dependencies.map((dependency) =>
           typeof dependency === 'string'
             ? dependency
-            : compileExpr<ParsedFields, C>(dependency, exprOptions))
+            : compileExpr<ParsedFields, C>(dependency, exprOptions),
+        )
 
         return attachJsonDef(
           rule.reason
-            ? requires<ParsedFields, C>(rule.field, ...dependencies, { reason: rule.reason })
+            ? requires<ParsedFields, C>(rule.field, ...dependencies, {
+                reason: rule.reason,
+              })
             : requires<ParsedFields, C>(rule.field, ...dependencies),
           rule,
         )
       }
 
-      return attachJsonDef(requires<ParsedFields, C>(rule.field, compileExpr(rule.when, exprOptions), {
-        reason: rule.reason,
-      }), rule)
+      return attachJsonDef(
+        requires<ParsedFields, C>(
+          rule.field,
+          compileExpr(rule.when, exprOptions),
+          {
+            reason: rule.reason,
+          },
+        ),
+        rule,
+      )
     case 'enabledWhen':
-      return attachJsonDef(enabledWhen<ParsedFields, C>(rule.field, compileExpr(rule.when, exprOptions), {
-        reason: rule.reason,
-      }), rule)
+      return attachJsonDef(
+        enabledWhen<ParsedFields, C>(
+          rule.field,
+          compileExpr(rule.when, exprOptions),
+          {
+            reason: rule.reason,
+          },
+        ),
+        rule,
+      )
     case 'disables':
       if ('source' in rule) {
-        return attachJsonDef(disables<ParsedFields, C>(rule.source, rule.targets, {
-          reason: rule.reason,
-        }), rule)
+        return attachJsonDef(
+          disables<ParsedFields, C>(rule.source, rule.targets, {
+            reason: rule.reason,
+          }),
+          rule,
+        )
       }
 
-      return attachJsonDef(disables<ParsedFields, C>(compileExpr(rule.when, exprOptions), rule.targets, {
-        reason: rule.reason,
-      }), rule)
+      return attachJsonDef(
+        disables<ParsedFields, C>(
+          compileExpr(rule.when, exprOptions),
+          rule.targets,
+          {
+            reason: rule.reason,
+          },
+        ),
+        rule,
+      )
     case 'oneOf':
-      return attachJsonDef(oneOf<ParsedFields, C>(rule.group, rule.branches), rule)
+      return attachJsonDef(
+        oneOf<ParsedFields, C>(rule.group, rule.branches),
+        rule,
+      )
     case 'fairWhen':
-      return attachJsonDef(fairWhen<ParsedFields, C>(rule.field, compileFairExpr<C>(rule, schema), {
-        reason: rule.reason,
-      }), rule)
+      return attachJsonDef(
+        fairWhen<ParsedFields, C>(
+          rule.field,
+          compileFairExpr<C>(rule, schema),
+          {
+            reason: rule.reason,
+          },
+        ),
+        rule,
+      )
     case 'eitherOf': {
-      const parsedBranches = Object.create(null) as Record<string, Array<Rule<ParsedFields, C>>>
+      const parsedBranches = Object.create(null) as Record<
+        string,
+        Array<Rule<ParsedFields, C>>
+      >
 
       for (const [branchName, branchRules] of Object.entries(rule.branches)) {
-        parsedBranches[branchName] = branchRules.map((innerRule) => parseRule<C>(innerRule, schema))
+        parsedBranches[branchName] = branchRules.map((innerRule) =>
+          parseRule<C>(innerRule, schema),
+        )
       }
 
-      return attachJsonDef(eitherOf<ParsedFields, C>(rule.group, parsedBranches), rule)
+      return attachJsonDef(
+        eitherOf<ParsedFields, C>(rule.group, parsedBranches),
+        rule,
+      )
     }
     case 'anyOf': {
-      const innerRules = rule.rules.map((innerRule) => parseRule<C>(innerRule, schema))
+      const innerRules = rule.rules.map((innerRule) =>
+        parseRule<C>(innerRule, schema),
+      )
       return attachJsonDef(anyOf<ParsedFields, C>(...innerRules), rule)
     }
     case 'check':
       return parseCheckRule<C>(rule)
     default:
-      throw new Error(`[@umpire/json] Unknown rule type "${String((rule as { type?: unknown }).type)}"`)
+      throw new Error(
+        `[@umpire/json] Unknown rule type "${String((rule as { type?: unknown }).type)}"`,
+      )
   }
 }
 
-export function fromJson<C extends Record<string, unknown> = Record<string, unknown>>(
+export function fromJson<
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
   schema: UmpireJsonSchema,
 ): {
   fields: ParsedFields
@@ -224,7 +294,9 @@ export function fromJson<C extends Record<string, unknown> = Record<string, unkn
   return hydrateValidatedSchema<C>(schema)
 }
 
-function hydrateValidatedSchema<C extends Record<string, unknown> = Record<string, unknown>>(
+function hydrateValidatedSchema<
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
   schema: UmpireJsonSchema,
 ): {
   fields: ParsedFields
@@ -237,7 +309,10 @@ function hydrateValidatedSchema<C extends Record<string, unknown> = Record<strin
   }
 
   const fields = attachJsonDef(parseFieldDefs(schema.fields), meta)
-  const rules = attachJsonDef(schema.rules.map((rule) => parseRule<C>(rule, schema)), meta)
+  const rules = attachJsonDef(
+    schema.rules.map((rule) => parseRule<C>(rule, schema)),
+    meta,
+  )
   const validators = parseValidators(schema.validators)
 
   return {
@@ -247,16 +322,18 @@ function hydrateValidatedSchema<C extends Record<string, unknown> = Record<strin
   }
 }
 
-export function fromJsonSafe<C extends Record<string, unknown> = Record<string, unknown>>(
-  raw: unknown,
-): FromJsonSafeResult<C> {
+export function fromJsonSafe<
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(raw: unknown): FromJsonSafeResult<C> {
   const parsedSchema = parseJsonSchema(raw)
 
   if (!parsedSchema.ok) {
     return parsedSchema
   }
 
-  const { fields, rules, validators } = hydrateValidatedSchema<C>(parsedSchema.schema)
+  const { fields, rules, validators } = hydrateValidatedSchema<C>(
+    parsedSchema.schema,
+  )
 
   return {
     ok: true,

--- a/packages/json/src/schema.ts
+++ b/packages/json/src/schema.ts
@@ -1,14 +1,25 @@
 import type { JsonPrimitive } from '@umpire/core'
 import type { Expr } from '@umpire/dsl'
 
-export type JsonConditionType = 'boolean' | 'string' | 'number' | 'string[]' | 'number[]'
+export type JsonConditionType =
+  | 'boolean'
+  | 'string'
+  | 'number'
+  | 'string[]'
+  | 'number[]'
 
 export interface JsonConditionDef {
   type: JsonConditionType
   description?: string
 }
 
-export type JsonIsEmptyStrategy = 'string' | 'number' | 'boolean' | 'array' | 'object' | 'present'
+export type JsonIsEmptyStrategy =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'array'
+  | 'object'
+  | 'present'
 
 export interface JsonFieldDef {
   required?: boolean
@@ -51,7 +62,12 @@ export type JsonRequiresDependency = string | JsonExpr
 
 export type JsonRule =
   | { type: 'requires'; field: string; dependency: string; reason?: string }
-  | { type: 'requires'; field: string; dependencies: JsonRequiresDependency[]; reason?: string }
+  | {
+      type: 'requires'
+      field: string
+      dependencies: JsonRequiresDependency[]
+      reason?: string
+    }
   | { type: 'requires'; field: string; when: JsonExpr; reason?: string }
   | { type: 'enabledWhen'; field: string; when: JsonExpr; reason?: string }
   | { type: 'disables'; source: string; targets: string[]; reason?: string }

--- a/packages/json/src/serialize.ts
+++ b/packages/json/src/serialize.ts
@@ -63,19 +63,35 @@ function createExcluded(
   signature?: string,
 ): ExcludedRule {
   return field
-    ? { type, field, description, ...(key ? { key } : {}), ...(signature ? { signature } : {}) }
-    : { type, description, ...(key ? { key } : {}), ...(signature ? { signature } : {}) }
+    ? {
+        type,
+        field,
+        description,
+        ...(key ? { key } : {}),
+        ...(signature ? { signature } : {}),
+      }
+    : {
+        type,
+        description,
+        ...(key ? { key } : {}),
+        ...(signature ? { signature } : {}),
+      }
 }
 
 function createKey(...parts: string[]): string {
   return parts.map((part) => encodeURIComponent(part)).join(':')
 }
 
-function createFieldSlotKey(field: string, slot: 'default' | 'isEmpty' | 'validator'): string {
+function createFieldSlotKey(
+  field: string,
+  slot: 'default' | 'isEmpty' | 'validator',
+): string {
   return createKey('field', field, slot)
 }
 
-function isValidationEntryObject(value: unknown): value is { validator: unknown; error?: unknown } {
+function isValidationEntryObject(
+  value: unknown,
+): value is { validator: unknown; error?: unknown } {
   return isRecord(value) && 'validator' in value
 }
 
@@ -83,7 +99,9 @@ function createTargetsKeyPart(targets: string[]): string {
   return JSON.stringify([...targets].sort())
 }
 
-function createCheckParamsKeyPart(rule: Extract<JsonRule, { type: 'check' }>): string {
+function createCheckParamsKeyPart(
+  rule: Extract<JsonRule, { type: 'check' }>,
+): string {
   switch (rule.op) {
     case 'matches':
       return JSON.stringify({ pattern: rule.pattern })
@@ -118,15 +136,34 @@ function createRuleKey(rule: JsonRule): string | undefined {
   switch (rule.type) {
     case 'requires':
       return 'dependency' in rule
-        ? createKey('rule', 'requires', rule.field, 'dependency', rule.dependency)
+        ? createKey(
+            'rule',
+            'requires',
+            rule.field,
+            'dependency',
+            rule.dependency,
+          )
         : 'dependencies' in rule
-          ? createKey('rule', 'requires', rule.field, 'dependencies', JSON.stringify(rule.dependencies))
-        : undefined
+          ? createKey(
+              'rule',
+              'requires',
+              rule.field,
+              'dependencies',
+              JSON.stringify(rule.dependencies),
+            )
+          : undefined
     case 'enabledWhen':
       return createKey('rule', 'enabledWhen', rule.field)
     case 'disables':
       return 'source' in rule
-        ? createKey('rule', 'disables', 'source', rule.source, 'targets', createTargetsKeyPart(rule.targets))
+        ? createKey(
+            'rule',
+            'disables',
+            'source',
+            rule.source,
+            'targets',
+            createTargetsKeyPart(rule.targets),
+          )
         : undefined
     case 'oneOf':
       return createKey('rule', 'oneOf', rule.group)
@@ -208,8 +245,10 @@ function mergeExcluded(
   return merged
 }
 
-
-function serializeField(name: string, definition: FieldDef): {
+function serializeField(
+  name: string,
+  definition: FieldDef,
+): {
   field: JsonFieldDef
   excluded: ExcludedRule[]
   coverageKeys: string[]
@@ -227,12 +266,14 @@ function serializeField(name: string, definition: FieldDef): {
       field.default = definition.default
       coverageKeys.push(createFieldSlotKey(name, 'default'))
     } else {
-      excluded.push(createExcluded(
-        'field:default',
-        'Field default is not a JSON primitive and cannot be serialized',
-        name,
-        createFieldSlotKey(name, 'default'),
-      ))
+      excluded.push(
+        createExcluded(
+          'field:default',
+          'Field default is not a JSON primitive and cannot be serialized',
+          name,
+          createFieldSlotKey(name, 'default'),
+        ),
+      )
     }
   }
 
@@ -241,42 +282,52 @@ function serializeField(name: string, definition: FieldDef): {
     field.isEmpty = isEmptyStrategy
     coverageKeys.push(createFieldSlotKey(name, 'isEmpty'))
   } else if (definition.isEmpty !== undefined) {
-    excluded.push(createExcluded(
-      'field:isEmpty',
-      'Field isEmpty uses a custom function and cannot be serialized',
-      name,
-      createFieldSlotKey(name, 'isEmpty'),
-      '(value) => boolean',
-    ))
+    excluded.push(
+      createExcluded(
+        'field:isEmpty',
+        'Field isEmpty uses a custom function and cannot be serialized',
+        name,
+        createFieldSlotKey(name, 'isEmpty'),
+        '(value) => boolean',
+      ),
+    )
   }
 
   return { field, excluded, coverageKeys }
 }
 
-function serializeValidator(field: string, entry: unknown): SerializeValidatorResult {
+function serializeValidator(
+  field: string,
+  entry: unknown,
+): SerializeValidatorResult {
   const coverageKey = createFieldSlotKey(field, 'validator')
   const carried = getJsonDef<JsonValidatorDef>(entry)
 
   if (carried) {
     return {
-          validator: deepClone(carried),
+      validator: deepClone(carried),
       excluded: [],
       coverageKeys: [coverageKey],
     }
   }
 
   const validator = isValidationEntryObject(entry) ? entry.validator : entry
-  const error = isValidationEntryObject(entry) && typeof entry.error === 'string' ? entry.error : undefined
+  const error =
+    isValidationEntryObject(entry) && typeof entry.error === 'string'
+      ? entry.error
+      : undefined
   const metadata = getNamedCheckMetadata(validator)
 
   if (!metadata) {
     return {
-      excluded: [createExcluded(
-        'field:validator',
-        'Field validator cannot be serialized unless it uses portable validator metadata from @umpire/json',
-        field,
-        coverageKey,
-      )],
+      excluded: [
+        createExcluded(
+          'field:validator',
+          'Field validator cannot be serialized unless it uses portable validator metadata from @umpire/json',
+          field,
+          coverageKey,
+        ),
+      ],
       coverageKeys: [],
     }
   }
@@ -285,12 +336,14 @@ function serializeValidator(field: string, entry: unknown): SerializeValidatorRe
 
   if (!serialized) {
     return {
-      excluded: [createExcluded(
-        'field:validator',
-        'Field validator uses metadata that is not part of the JSON validator spec',
-        field,
-        coverageKey,
-      )],
+      excluded: [
+        createExcluded(
+          'field:validator',
+          'Field validator uses metadata that is not part of the JSON validator spec',
+          field,
+          coverageKey,
+        ),
+      ],
       coverageKeys: [],
     }
   }
@@ -309,13 +362,17 @@ function excludeInspection(
   key?: string,
 ): SerializeRuleResult {
   const field =
-    'target' in inspection ? inspection.target
-    : 'targets' in inspection ? inspection.targets[0]
-    : undefined
+    'target' in inspection
+      ? inspection.target
+      : 'targets' in inspection
+        ? inspection.targets[0]
+        : undefined
 
   return {
     rules: [],
-    excluded: [createExcluded(inspection.kind, description, field, key, signature)],
+    excluded: [
+      createExcluded(inspection.kind, description, field, key, signature),
+    ],
     coverageKeys: [],
   }
 }
@@ -336,7 +393,10 @@ function serializeInspection(
       }
 
       if (inspection.predicate?.field && inspection.predicate.namedCheck) {
-        const when = createCheckExprFromMetadata(inspection.predicate.field, inspection.predicate.namedCheck)
+        const when = createCheckExprFromMetadata(
+          inspection.predicate.field,
+          inspection.predicate.namedCheck,
+        )
 
         if (when) {
           const rule: Extract<JsonRule, { type: 'enabledWhen' }> = {
@@ -380,14 +440,20 @@ function serializeInspection(
       }
 
       if (inspection.source.kind !== 'field') {
-        if (inspection.source.predicate?.field && inspection.source.predicate.namedCheck) {
+        if (
+          inspection.source.predicate?.field &&
+          inspection.source.predicate.namedCheck
+        ) {
           const when = createCheckExprFromMetadata(
             inspection.source.predicate.field,
             inspection.source.predicate.namedCheck,
           )
 
           if (when) {
-            const rule: Extract<JsonRule, { type: 'disables'; when: JsonExpr }> = {
+            const rule: Extract<
+              JsonRule,
+              { type: 'disables'; when: JsonExpr }
+            > = {
               type: 'disables',
               when,
               targets: [...inspection.targets],
@@ -409,21 +475,25 @@ function serializeInspection(
       }
 
       return {
-        rules: [{
-          type: 'disables',
-          source: inspection.source.field,
-          targets: [...inspection.targets],
-          ...(inspection.reason ? { reason: inspection.reason } : {}),
-        }],
+        rules: [
+          {
+            type: 'disables',
+            source: inspection.source.field,
+            targets: [...inspection.targets],
+            ...(inspection.reason ? { reason: inspection.reason } : {}),
+          },
+        ],
         excluded: [],
-        coverageKeys: [createKey(
-          'rule',
-          'disables',
-          'source',
-          inspection.source.field,
-          'targets',
-          createTargetsKeyPart(inspection.targets),
-        )],
+        coverageKeys: [
+          createKey(
+            'rule',
+            'disables',
+            'source',
+            inspection.source.field,
+            'targets',
+            createTargetsKeyPart(inspection.targets),
+          ),
+        ],
       }
     case 'fairWhen': {
       if (inspection.hasDynamicReason) {
@@ -436,7 +506,8 @@ function serializeInspection(
       }
 
       const namedCheckRule =
-        inspection.predicate?.field === inspection.target && inspection.predicate.namedCheck
+        inspection.predicate?.field === inspection.target &&
+        inspection.predicate.namedCheck
           ? createCheckRuleFromMetadata(
               inspection.target,
               inspection.predicate.namedCheck,
@@ -453,7 +524,10 @@ function serializeInspection(
       }
 
       if (inspection.predicate?.field && inspection.predicate.namedCheck) {
-        const when = createCheckExprFromMetadata(inspection.predicate.field, inspection.predicate.namedCheck)
+        const when = createCheckExprFromMetadata(
+          inspection.predicate.field,
+          inspection.predicate.namedCheck,
+        )
 
         if (when) {
           const rule: Extract<JsonRule, { type: 'fairWhen' }> = {
@@ -491,26 +565,32 @@ function serializeInspection(
       const fieldDependencies = inspection.dependencies.filter(
         (
           dependency,
-        ): dependency is Extract<(typeof inspection.dependencies)[number], { kind: 'field' }> =>
-          dependency.kind === 'field',
+        ): dependency is Extract<
+          (typeof inspection.dependencies)[number],
+          { kind: 'field' }
+        > => dependency.kind === 'field',
       )
 
-      const serializedDependencies = inspection.dependencies.map((dependency) => {
-        if (dependency.kind === 'field') {
-          return dependency.field
-        }
+      const serializedDependencies = inspection.dependencies.map(
+        (dependency) => {
+          if (dependency.kind === 'field') {
+            return dependency.field
+          }
 
-        if (dependency.predicate?.field && dependency.predicate.namedCheck) {
-          return createCheckExprFromMetadata(
-            dependency.predicate.field,
-            dependency.predicate.namedCheck,
-          )
-        }
+          if (dependency.predicate?.field && dependency.predicate.namedCheck) {
+            return createCheckExprFromMetadata(
+              dependency.predicate.field,
+              dependency.predicate.namedCheck,
+            )
+          }
 
-        return undefined
-      })
+          return undefined
+        },
+      )
 
-      if (serializedDependencies.some((dependency) => dependency === undefined)) {
+      if (
+        serializedDependencies.some((dependency) => dependency === undefined)
+      ) {
         return excludeInspection(
           inspection,
           'requires() with predicate dependencies cannot be serialized unless hydrated from JSON or when those predicates map to portable validators',
@@ -537,28 +617,37 @@ function serializeInspection(
         }
       }
 
-      const [firstDependency] = serializedDependencies as Array<string | JsonExpr>
+      const [firstDependency] = serializedDependencies as Array<
+        string | JsonExpr
+      >
 
-      const rules = serializedDependencies.length === 1
-        ? [typeof firstDependency === 'string'
-            ? {
+      const rules =
+        serializedDependencies.length === 1
+          ? [
+              typeof firstDependency === 'string'
+                ? {
+                    type: 'requires' as const,
+                    field: inspection.target,
+                    dependency: firstDependency,
+                    ...(inspection.reason ? { reason: inspection.reason } : {}),
+                  }
+                : {
+                    type: 'requires' as const,
+                    field: inspection.target,
+                    when: firstDependency,
+                    ...(inspection.reason ? { reason: inspection.reason } : {}),
+                  },
+            ]
+          : [
+              {
                 type: 'requires' as const,
                 field: inspection.target,
-                dependency: firstDependency,
+                dependencies: serializedDependencies as Array<
+                  string | JsonExpr
+                >,
                 ...(inspection.reason ? { reason: inspection.reason } : {}),
-              }
-            : {
-                type: 'requires' as const,
-                field: inspection.target,
-                when: firstDependency,
-                ...(inspection.reason ? { reason: inspection.reason } : {}),
-              }]
-        : [{
-            type: 'requires' as const,
-            field: inspection.target,
-            dependencies: serializedDependencies as Array<string | JsonExpr>,
-            ...(inspection.reason ? { reason: inspection.reason } : {}),
-          }]
+              },
+            ]
 
       return {
         rules,
@@ -567,7 +656,10 @@ function serializeInspection(
       }
     }
     case 'oneOf':
-      if (inspection.hasDynamicActiveBranch || inspection.activeBranch !== undefined) {
+      if (
+        inspection.hasDynamicActiveBranch ||
+        inspection.activeBranch !== undefined
+      ) {
         return excludeInspection(
           inspection,
           'oneOf() activeBranch overrides are not part of the JSON spec',
@@ -586,11 +678,13 @@ function serializeInspection(
       }
 
       return {
-        rules: [{
-          type: 'oneOf',
-          group: inspection.groupName,
-          branches: deepClone(inspection.branches),
-        }],
+        rules: [
+          {
+            type: 'oneOf',
+            group: inspection.groupName,
+            branches: deepClone(inspection.branches),
+          },
+        ],
         excluded: [],
         coverageKeys: [createKey('rule', 'oneOf', inspection.groupName)],
       }
@@ -599,7 +693,10 @@ function serializeInspection(
 
       for (const innerInspection of inspection.rules) {
         const inner = serializeInspection(
-          innerInspection as RuleInspection<Record<string, FieldDef>, Record<string, unknown>>,
+          innerInspection as RuleInspection<
+            Record<string, FieldDef>,
+            Record<string, unknown>
+          >,
           true,
         )
 
@@ -622,10 +719,12 @@ function serializeInspection(
       }
 
       return {
-        rules: [{
-          type: 'anyOf',
-          rules: innerRules,
-        }],
+        rules: [
+          {
+            type: 'anyOf',
+            rules: innerRules,
+          },
+        ],
         excluded: [],
         coverageKeys: createRuleKey({ type: 'anyOf', rules: innerRules })
           ? [createRuleKey({ type: 'anyOf', rules: innerRules }) as string]
@@ -635,12 +734,17 @@ function serializeInspection(
     case 'eitherOf': {
       const jsonBranches: Record<string, JsonRule[]> = {}
 
-      for (const [branchName, branchRules] of Object.entries(inspection.branches)) {
+      for (const [branchName, branchRules] of Object.entries(
+        inspection.branches,
+      )) {
         const serializedBranch: JsonRule[] = []
 
         for (const branchRule of branchRules) {
           const inner = serializeInspection(
-            branchRule as RuleInspection<Record<string, FieldDef>, Record<string, unknown>>,
+            branchRule as RuleInspection<
+              Record<string, FieldDef>,
+              Record<string, unknown>
+            >,
             true,
           )
 
@@ -666,11 +770,13 @@ function serializeInspection(
       }
 
       return {
-        rules: [{
-          type: 'eitherOf',
-          group: inspection.groupName,
-          branches: jsonBranches,
-        }],
+        rules: [
+          {
+            type: 'eitherOf',
+            group: inspection.groupName,
+            branches: jsonBranches,
+          },
+        ],
         excluded: [],
         coverageKeys: [createKey('rule', 'eitherOf', inspection.groupName)],
       }
@@ -694,9 +800,7 @@ function serializeInspection(
 function serializeRule<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  rule: Rule<F, C>,
-): SerializeRuleResult {
+>(rule: Rule<F, C>): SerializeRuleResult {
   const jsonDef = getJsonDef<JsonRule>(rule)
   if (jsonDef) {
     return {
@@ -723,7 +827,10 @@ function serializeRule<
   }
 
   return serializeInspection(
-    inspection as RuleInspection<Record<string, FieldDef>, Record<string, unknown>>,
+    inspection as RuleInspection<
+      Record<string, FieldDef>,
+      Record<string, unknown>
+    >,
     false,
   )
 }
@@ -731,10 +838,10 @@ function serializeRule<
 export function toJson<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
->(
-  config: ToJsonConfig<F, C>,
-): UmpireJsonSchema {
-  const meta = getJsonDef<SerializeMeta>(config.fields) ?? getJsonDef<SerializeMeta>(config.rules)
+>(config: ToJsonConfig<F, C>): UmpireJsonSchema {
+  const meta =
+    getJsonDef<SerializeMeta>(config.fields) ??
+    getJsonDef<SerializeMeta>(config.rules)
   const fields = {} as Record<string, JsonFieldDef>
   const rules: JsonRule[] = []
   const validators = {} as Record<string, JsonValidatorDef>

--- a/packages/json/src/strategies.ts
+++ b/packages/json/src/strategies.ts
@@ -1,4 +1,10 @@
-import { isEmptyArray, isEmptyObject, isEmptyPresent, isEmptyString, type FieldDef } from '@umpire/core'
+import {
+  isEmptyArray,
+  isEmptyObject,
+  isEmptyPresent,
+  isEmptyString,
+  type FieldDef,
+} from '@umpire/core'
 
 import type { JsonIsEmptyStrategy } from './schema.js'
 
@@ -14,7 +20,9 @@ const IS_EMPTY_STRATEGIES: Record<
   present: isEmptyPresent,
 }
 
-export function isJsonIsEmptyStrategy(value: unknown): value is JsonIsEmptyStrategy {
+export function isJsonIsEmptyStrategy(
+  value: unknown,
+): value is JsonIsEmptyStrategy {
   return typeof value === 'string' && value in IS_EMPTY_STRATEGIES
 }
 
@@ -26,7 +34,9 @@ export function hydrateIsEmptyStrategy(
   }
 
   if (!isJsonIsEmptyStrategy(strategy)) {
-    throw new Error(`[@umpire/json] Unknown isEmpty strategy "${String(strategy)}"`)
+    throw new Error(
+      `[@umpire/json] Unknown isEmpty strategy "${String(strategy)}"`,
+    )
   }
 
   return IS_EMPTY_STRATEGIES[strategy]
@@ -39,6 +49,7 @@ export function getJsonIsEmptyStrategy(
     return undefined
   }
 
-  return (Object.entries(IS_EMPTY_STRATEGIES).find(([, candidate]) => candidate === strategy)?.[0] ??
-    undefined) as JsonIsEmptyStrategy | undefined
+  return (Object.entries(IS_EMPTY_STRATEGIES).find(
+    ([, candidate]) => candidate === strategy,
+  )?.[0] ?? undefined) as JsonIsEmptyStrategy | undefined
 }

--- a/packages/json/src/validate.ts
+++ b/packages/json/src/validate.ts
@@ -15,62 +15,93 @@ type JsonRuleConstraint = 'enabled' | 'fair'
 
 function validateFieldDef(field: string, definition: JsonFieldDef) {
   if (!isPlainRecord(definition)) {
-    throw new Error(`[@umpire/json] Field "${field}" definition must be an object`)
+    throw new Error(
+      `[@umpire/json] Field "${field}" definition must be an object`,
+    )
   }
 
-  if (definition.default !== undefined && !isJsonPrimitive(definition.default)) {
-    throw new Error(`[@umpire/json] Field "${field}" has a non-serializable default value`)
+  if (
+    definition.default !== undefined &&
+    !isJsonPrimitive(definition.default)
+  ) {
+    throw new Error(
+      `[@umpire/json] Field "${field}" has a non-serializable default value`,
+    )
   }
 
   if (
     definition.isEmpty !== undefined &&
     !isJsonIsEmptyStrategy(definition.isEmpty)
   ) {
-    throw new Error(`[@umpire/json] Unknown isEmpty strategy "${String(definition.isEmpty)}"`)
+    throw new Error(
+      `[@umpire/json] Unknown isEmpty strategy "${String(definition.isEmpty)}"`,
+    )
   }
 }
 
 function validateExcludedRule(rule: ExcludedRule) {
   if (typeof rule.type !== 'string' || rule.type.length === 0) {
-    throw new Error('[@umpire/json] Excluded rules must include a non-empty string type')
+    throw new Error(
+      '[@umpire/json] Excluded rules must include a non-empty string type',
+    )
   }
 
   if (rule.field !== undefined && typeof rule.field !== 'string') {
-    throw new Error('[@umpire/json] Excluded rule field must be a string when provided')
+    throw new Error(
+      '[@umpire/json] Excluded rule field must be a string when provided',
+    )
   }
 
   if (typeof rule.description !== 'string' || rule.description.length === 0) {
-    throw new Error('[@umpire/json] Excluded rules must include a non-empty string description')
+    throw new Error(
+      '[@umpire/json] Excluded rules must include a non-empty string description',
+    )
   }
 
   if (rule.key !== undefined && typeof rule.key !== 'string') {
-    throw new Error('[@umpire/json] Excluded rule key must be a string when provided')
+    throw new Error(
+      '[@umpire/json] Excluded rule key must be a string when provided',
+    )
   }
 
   if (rule.signature !== undefined && typeof rule.signature !== 'string') {
-    throw new Error('[@umpire/json] Excluded rule signature must be a string when provided')
+    throw new Error(
+      '[@umpire/json] Excluded rule signature must be a string when provided',
+    )
   }
 }
 
 function assertField(field: string, fieldNames: Set<string>, context: string) {
   if (!fieldNames.has(field)) {
-    throw new Error(`[@umpire/json] Rule ${context} references unknown field "${field}"`)
+    throw new Error(
+      `[@umpire/json] Rule ${context} references unknown field "${field}"`,
+    )
   }
 }
 
-function validateValidator(field: string, validator: JsonValidatorDef, fieldNames: Set<string>) {
+function validateValidator(
+  field: string,
+  validator: JsonValidatorDef,
+  fieldNames: Set<string>,
+) {
   if (!fieldNames.has(field)) {
-    throw new Error(`[@umpire/json] Validator references unknown field "${field}"`)
+    throw new Error(
+      `[@umpire/json] Validator references unknown field "${field}"`,
+    )
   }
 
   if (!isPlainRecord(validator)) {
-    throw new Error(`[@umpire/json] Validator for field "${field}" must be an object`)
+    throw new Error(
+      `[@umpire/json] Validator for field "${field}" must be an object`,
+    )
   }
 
   assertValidValidatorSpec(validator)
 
   if (validator.error !== undefined && typeof validator.error !== 'string') {
-    throw new Error(`[@umpire/json] Validator for field "${field}" must use a string error when provided`)
+    throw new Error(
+      `[@umpire/json] Validator for field "${field}" must use a string error when provided`,
+    )
   }
 }
 
@@ -102,7 +133,9 @@ function getRuleTargets(rule: JsonRule): string[] {
     case 'disables':
       return [...rule.targets]
     case 'oneOf':
-      return uniqueFields(Object.values(rule.branches).flatMap((branchFields) => branchFields))
+      return uniqueFields(
+        Object.values(rule.branches).flatMap((branchFields) => branchFields),
+      )
     case 'anyOf':
       return resolveCompositeShape('anyOf()', rule.rules).targets
     case 'eitherOf':
@@ -130,7 +163,9 @@ function resolveCompositeShape(
       currentTargets.length !== expectedTargets.length ||
       currentTargets.some((target, index) => target !== expectedTargets[index])
     ) {
-      throw new Error(`[@umpire/json] ${label} rules must target the same fields`)
+      throw new Error(
+        `[@umpire/json] ${label} rules must target the same fields`,
+      )
     }
   }
 
@@ -138,7 +173,9 @@ function resolveCompositeShape(
 
   for (const innerRule of rules.slice(1)) {
     if (getRuleConstraint(innerRule) !== constraint) {
-      throw new Error(`[@umpire/json] ${label} cannot mix fairWhen rules with availability rules`)
+      throw new Error(
+        `[@umpire/json] ${label} cannot mix fairWhen rules with availability rules`,
+      )
     }
   }
 
@@ -148,25 +185,30 @@ function resolveCompositeShape(
   }
 }
 
-function resolveEitherOfShape(
-  rule: Extract<JsonRule, { type: 'eitherOf' }>,
-): {
+function resolveEitherOfShape(rule: Extract<JsonRule, { type: 'eitherOf' }>): {
   targets: string[]
   constraint: JsonRuleConstraint
 } {
   const branchNames = Object.keys(rule.branches)
 
   if (branchNames.length === 0) {
-    throw new Error(`[@umpire/json] eitherOf("${rule.group}") must include at least one branch`)
+    throw new Error(
+      `[@umpire/json] eitherOf("${rule.group}") must include at least one branch`,
+    )
   }
 
   for (const branchName of branchNames) {
     if (rule.branches[branchName].length === 0) {
-      throw new Error(`[@umpire/json] eitherOf("${rule.group}") branch "${branchName}" must not be empty`)
+      throw new Error(
+        `[@umpire/json] eitherOf("${rule.group}") branch "${branchName}" must not be empty`,
+      )
     }
   }
 
-  return resolveCompositeShape(`eitherOf("${rule.group}")`, Object.values(rule.branches).flat())
+  return resolveCompositeShape(
+    `eitherOf("${rule.group}")`,
+    Object.values(rule.branches).flat(),
+  )
 }
 
 function validateRule(
@@ -183,8 +225,13 @@ function validateRule(
       }
 
       if ('dependencies' in rule) {
-        if (!Array.isArray(rule.dependencies) || rule.dependencies.length === 0) {
-          throw new Error('[@umpire/json] "requires" rules with dependencies must include at least one entry')
+        if (
+          !Array.isArray(rule.dependencies) ||
+          rule.dependencies.length === 0
+        ) {
+          throw new Error(
+            '[@umpire/json] "requires" rules with dependencies must include at least one entry',
+          )
         }
 
         for (const dependency of rule.dependencies) {
@@ -247,11 +294,15 @@ function validateRule(
       assertValidCheckRule(rule)
       return
     default:
-      throw new Error(`[@umpire/json] Unknown rule type "${String((rule as { type?: unknown }).type)}"`)
+      throw new Error(
+        `[@umpire/json] Unknown rule type "${String((rule as { type?: unknown }).type)}"`,
+      )
   }
 }
 
-export function validateSchema(schema: unknown): asserts schema is UmpireJsonSchema {
+export function validateSchema(
+  schema: unknown,
+): asserts schema is UmpireJsonSchema {
   if (!isPlainRecord(schema)) {
     throw new Error('[@umpire/json] Schema must be an object')
   }
@@ -261,7 +312,9 @@ export function validateSchema(schema: unknown): asserts schema is UmpireJsonSch
   }
 
   if (schema.version !== 1) {
-    throw new Error(`[@umpire/json] Unsupported schema version "${String(schema.version)}"`)
+    throw new Error(
+      `[@umpire/json] Unsupported schema version "${String(schema.version)}"`,
+    )
   }
 
   if (!isPlainRecord(schema.fields)) {
@@ -273,15 +326,21 @@ export function validateSchema(schema: unknown): asserts schema is UmpireJsonSch
   }
 
   if (schema.validators !== undefined && !isPlainRecord(schema.validators)) {
-    throw new Error('[@umpire/json] Schema "validators" must be an object when provided')
+    throw new Error(
+      '[@umpire/json] Schema "validators" must be an object when provided',
+    )
   }
 
   if (schema.conditions !== undefined && !isPlainRecord(schema.conditions)) {
-    throw new Error('[@umpire/json] Schema "conditions" must be an object when provided')
+    throw new Error(
+      '[@umpire/json] Schema "conditions" must be an object when provided',
+    )
   }
 
   if (schema.excluded !== undefined && !Array.isArray(schema.excluded)) {
-    throw new Error('[@umpire/json] Schema "excluded" must be an array when provided')
+    throw new Error(
+      '[@umpire/json] Schema "excluded" must be an array when provided',
+    )
   }
 
   const typedSchema = schema as unknown as UmpireJsonSchema
@@ -296,7 +355,9 @@ export function validateSchema(schema: unknown): asserts schema is UmpireJsonSch
     validateRule(rule, fieldNames, typedSchema.conditions)
   }
 
-  for (const [field, validator] of Object.entries(typedSchema.validators ?? {})) {
+  for (const [field, validator] of Object.entries(
+    typedSchema.validators ?? {},
+  )) {
     validateValidator(field, validator, fieldNames)
   }
 

--- a/packages/pinia/__tests__/fromPiniaStore.test.ts
+++ b/packages/pinia/__tests__/fromPiniaStore.test.ts
@@ -4,7 +4,9 @@ import { enabledWhen, requires, umpire } from '@umpire/core'
 import { fromPiniaStore } from '../src/index.js'
 
 const fields = {
-  username: { isEmpty: (v: unknown) => v === '' || v === undefined || v === null },
+  username: {
+    isEmpty: (v: unknown) => v === '' || v === undefined || v === null,
+  },
   password: {},
   confirmPassword: { default: '' },
   inviteCode: { default: '' },
@@ -103,9 +105,12 @@ describe('fromPiniaStore', () => {
     type ConditionFields = typeof conditionFields
 
     const conditionRules = [
-      enabledWhen<ConditionFields, Conditions>('inviteCode', (_values, conditions) => {
-        return conditions.requireInvite
-      }),
+      enabledWhen<ConditionFields, Conditions>(
+        'inviteCode',
+        (_values, conditions) => {
+          return conditions.requireInvite
+        },
+      ),
     ]
 
     const store = createFormStore()
@@ -155,7 +160,10 @@ describe('fromPiniaStore', () => {
       fields: nestedFields,
       rules: [
         enabledWhen('note', (values) => {
-          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+          return (
+            (values.settings as { allowNote: boolean } | undefined)
+              ?.allowNote === true
+          )
         }),
       ],
     })

--- a/packages/pinia/src/index.ts
+++ b/packages/pinia/src/index.ts
@@ -22,17 +22,18 @@ export function fromPiniaStore<
 ): UmpireStore<F> {
   const previousState = trackPreviousState(store.$state)
 
-  return fromStore(ump, {
-    getState: () => store.$state,
-    subscribe(listener) {
-      return store.$subscribe((_mutation, nextState) => {
-        listener(nextState, previousState.next(nextState))
-      })
+  return fromStore(
+    ump,
+    {
+      getState: () => store.$state,
+      subscribe(listener) {
+        return store.$subscribe((_mutation, nextState) => {
+          listener(nextState, previousState.next(nextState))
+        })
+      },
     },
-  }, options)
+    options,
+  )
 }
 
-export type {
-  FromStoreOptions,
-  UmpireStore,
-} from '@umpire/store'
+export type { FromStoreOptions, UmpireStore } from '@umpire/store'

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,7 +7,6 @@
 - e570cac: Add browser/CDN builds via tsdown
 
   Both `@umpire/core` and `@umpire/react` now ship bundled browser artifacts alongside the existing ESM build:
-
   - `dist/index.browser.js` — minified ESM for `<script type="module">` and esm.sh
   - `dist/index.iife.js` — IIFE with `window.Umpire` / `window.UmpireReact` globals
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -20,11 +20,11 @@ import { useUmpire } from '@umpire/react'
 
 const signupUmp = umpire({
   fields: {
-    email:           { required: true, isEmpty: (v) => !v },
-    password:        { required: true, isEmpty: (v) => !v },
+    email: { required: true, isEmpty: (v) => !v },
+    password: { required: true, isEmpty: (v) => !v },
     confirmPassword: { required: true, isEmpty: (v) => !v },
-    companyName:     {},
-    companySize:     {},
+    companyName: {},
+    companySize: {},
   },
   rules: [
     requires('confirmPassword', 'password'),

--- a/packages/react/__tests__/useUmpire.test.ts
+++ b/packages/react/__tests__/useUmpire.test.ts
@@ -13,9 +13,7 @@ describe('useUmpire', () => {
   it('returns check with correct availability', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { result } = renderHook(() =>
@@ -30,9 +28,7 @@ describe('useUmpire', () => {
   it('returns disabled when predicate fails', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { result } = renderHook(() =>
@@ -45,9 +41,7 @@ describe('useUmpire', () => {
   it('recomputes check when values change', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { result, rerender } = renderHook(
@@ -65,9 +59,7 @@ describe('useUmpire', () => {
   it('returns empty fouls on first render', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { result } = renderHook(() =>
@@ -80,14 +72,16 @@ describe('useUmpire', () => {
   it('returns fouls when field transitions from enabled to disabled', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { result, rerender } = renderHook(
       ({ values }) => useUmpire(ump, values),
-      { initialProps: { values: { name: 'Alice', email: '', phone: '555-1234' } } },
+      {
+        initialProps: {
+          values: { name: 'Alice', email: '', phone: '555-1234' },
+        },
+      },
     )
 
     expect(result.current.fouls).toEqual([])
@@ -102,14 +96,16 @@ describe('useUmpire', () => {
   it('tracks prev correctly across rerenders', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { result, rerender } = renderHook(
       ({ values }) => useUmpire(ump, values),
-      { initialProps: { values: { name: 'Alice', email: '', phone: '555-1234' } } },
+      {
+        initialProps: {
+          values: { name: 'Alice', email: '', phone: '555-1234' },
+        },
+      },
     )
 
     // Second render: still enabled, no foul
@@ -135,21 +131,28 @@ describe('useUmpire', () => {
       fields: nestedFields,
       rules: [
         enabledWhen('note', (values) => {
-          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+          return (
+            (values.settings as { allowNote: boolean } | undefined)
+              ?.allowNote === true
+          )
         }),
       ],
     })
 
     const { result, rerender } = renderHook(
       ({ values }) => useUmpire(ump, values),
-      { initialProps: { values: { settings: sharedSettings, note: 'keep me' } } },
+      {
+        initialProps: { values: { settings: sharedSettings, note: 'keep me' } },
+      },
     )
 
     sharedSettings.allowNote = false
     rerender({ values: { settings: sharedSettings, note: 'keep me' } })
 
     expect(result.current.check.note.enabled).toBe(false)
-    expect(result.current.fouls.some((foul) => foul.field === 'note')).toBe(true)
+    expect(result.current.fouls.some((foul) => foul.field === 'note')).toBe(
+      true,
+    )
   })
 
   it('passes conditions to check', () => {
@@ -162,13 +165,12 @@ describe('useUmpire', () => {
 
     const ump = umpire<typeof ctxFields, Ctx>({
       fields: ctxFields,
-      rules: [
-        enabledWhen('advanced', (_values, ctx) => ctx.premium),
-      ],
+      rules: [enabledWhen('advanced', (_values, ctx) => ctx.premium)],
     })
 
     const { result, rerender } = renderHook(
-      ({ conditions }) => useUmpire(ump, { advanced: '', basic: '' }, conditions),
+      ({ conditions }) =>
+        useUmpire(ump, { advanced: '', basic: '' }, conditions),
       { initialProps: { conditions: { premium: false } as Ctx } },
     )
 

--- a/packages/react/src/debugValue.ts
+++ b/packages/react/src/debugValue.ts
@@ -2,10 +2,7 @@ import type { AvailabilityMap, FieldDef, Foul } from '@umpire/core'
 
 export function formatUmpireDebugValue<
   F extends Record<string, FieldDef>,
->(value: {
-  check: AvailabilityMap<F>
-  fouls: Foul<F>[]
-}) {
+>(value: { check: AvailabilityMap<F>; fouls: Foul<F>[] }) {
   const { check, fouls } = value
 
   return {

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -18,7 +18,7 @@ export default defineConfig([
   },
   // Externalized IIFE — user provides React + core via script tags
   {
-    entry: { 'index': 'src/index.ts' },
+    entry: { index: 'src/index.ts' },
     format: ['iife'],
     globalName: 'UmpireReact',
     platform: 'browser',

--- a/packages/reads/README.md
+++ b/packages/reads/README.md
@@ -16,12 +16,15 @@ npm install @umpire/core @umpire/reads
 import { umpire } from '@umpire/core'
 import { createReads, fairWhenRead } from '@umpire/reads'
 
-const reads = createReads<{
-  cpu?: string
-  motherboard?: string
-}, {
-  motherboardFair: boolean
-}>({
+const reads = createReads<
+  {
+    cpu?: string
+    motherboard?: string
+  },
+  {
+    motherboardFair: boolean
+  }
+>({
   motherboardFair: ({ input }) => {
     if (!input.motherboard) {
       return true

--- a/packages/reads/__tests__/reads.test.ts
+++ b/packages/reads/__tests__/reads.test.ts
@@ -62,12 +62,10 @@ function createFixtureReads(options: { onIdsResolve?: () => void } = {}) {
 
       return Boolean(input.cpu && motherboard === input.cpu)
     },
-    boardSummary: ({ input, read }) => `${input.cpu ?? ''}:${read('selections').motherboard ?? ''}`,
-    activeMotherboard: ({ read }) => (
-      read('motherboardFair')
-        ? read('selections').motherboard
-        : undefined
-    ),
+    boardSummary: ({ input, read }) =>
+      `${input.cpu ?? ''}:${read('selections').motherboard ?? ''}`,
+    activeMotherboard: ({ read }) =>
+      read('motherboardFair') ? read('selections').motherboard : undefined,
   })
 }
 
@@ -92,8 +90,12 @@ describe('@umpire/reads', () => {
       const input = { cpu: 'am5', motherboard: 'lga1700' }
       const predicate = fromRead(reads, 'motherboardFair')
 
-      expect(reads.motherboardFair(input)).toBe(reads.resolve(input).motherboardFair)
-      expect(predicate(undefined, input)).toBe(reads.resolve(input).motherboardFair)
+      expect(reads.motherboardFair(input)).toBe(
+        reads.resolve(input).motherboardFair,
+      )
+      expect(predicate(undefined, input)).toBe(
+        reads.resolve(input).motherboardFair,
+      )
     })
 
     test('fromRead supports selecting the input from arbitrary arguments', () => {
@@ -122,7 +124,9 @@ describe('@umpire/reads', () => {
         }),
       )
 
-      expect(predicate(undefined, { cpu: 'am5', motherboard: 'am5' })).toBe(true)
+      expect(predicate(undefined, { cpu: 'am5', motherboard: 'am5' })).toBe(
+        true,
+      )
       expect(selectedPredicate('lga1700', 'am5')).toBe(false)
     })
   })
@@ -136,7 +140,9 @@ describe('@umpire/reads', () => {
         },
       })
 
-      expect(reads.resolve({ cpu: 'am5', motherboard: 'am5', ram: '32gb' })).toMatchObject({
+      expect(
+        reads.resolve({ cpu: 'am5', motherboard: 'am5', ram: '32gb' }),
+      ).toMatchObject({
         ids: {
           cpu: 'am5',
           motherboard: 'am5',
@@ -166,21 +172,30 @@ describe('@umpire/reads', () => {
       expect(inspected.nodes.cpuPresent.dependsOnFields).toEqual(['cpu'])
       expect(inspected.nodes.cpuPresent.dependsOnReads).toEqual([])
 
-      expect(inspected.nodes.cpuAndRamPresent.dependsOnFields).toEqual(['cpu', 'ram'])
+      expect(inspected.nodes.cpuAndRamPresent.dependsOnFields).toEqual([
+        'cpu',
+        'ram',
+      ])
       expect(inspected.nodes.cpuAndRamPresent.dependsOnReads).toEqual([])
 
       expect(inspected.nodes.selectionPresent.dependsOnFields).toEqual([])
-      expect(inspected.nodes.selectionPresent.dependsOnReads).toEqual(['selections'])
+      expect(inspected.nodes.selectionPresent.dependsOnReads).toEqual([
+        'selections',
+      ])
 
       expect(inspected.nodes.motherboardFair.dependsOnFields).toEqual(['cpu'])
-      expect(inspected.nodes.motherboardFair.dependsOnReads).toEqual(['selections'])
+      expect(inspected.nodes.motherboardFair.dependsOnReads).toEqual([
+        'selections',
+      ])
 
       expect(inspected.nodes.activeMotherboard.dependsOnFields).toEqual([])
       expect(inspected.nodes.activeMotherboard.dependsOnReads).toEqual([
         'motherboardFair',
         'selections',
       ])
-      expect(inspected.nodes.activeMotherboard.dependsOnReads).not.toContain('ids')
+      expect(inspected.nodes.activeMotherboard.dependsOnReads).not.toContain(
+        'ids',
+      )
     })
   })
 
@@ -224,78 +239,80 @@ describe('@umpire/reads', () => {
         ram: '32gb',
       }).graph.edges
 
-      expect(edges).toEqual(expect.arrayContaining([
-        {
-          from: 'cpu',
-          to: 'ids',
-          type: 'field',
-        },
-        {
-          from: 'motherboard',
-          to: 'ids',
-          type: 'field',
-        },
-        {
-          from: 'ram',
-          to: 'ids',
-          type: 'field',
-        },
-        {
-          from: 'cpu',
-          to: 'cpuPresent',
-          type: 'field',
-        },
-        {
-          from: 'cpu',
-          to: 'cpuAndRamPresent',
-          type: 'field',
-        },
-        {
-          from: 'ram',
-          to: 'cpuAndRamPresent',
-          type: 'field',
-        },
-        {
-          from: 'cpu',
-          to: 'motherboardFair',
-          type: 'field',
-        },
-        {
-          from: 'cpu',
-          to: 'boardSummary',
-          type: 'field',
-        },
-        {
-          from: 'ids',
-          to: 'selections',
-          type: 'read',
-        },
-        {
-          from: 'selections',
-          to: 'selectionPresent',
-          type: 'read',
-        },
-        {
-          from: 'selections',
-          to: 'motherboardFair',
-          type: 'read',
-        },
-        {
-          from: 'selections',
-          to: 'boardSummary',
-          type: 'read',
-        },
-        {
-          from: 'motherboardFair',
-          to: 'activeMotherboard',
-          type: 'read',
-        },
-        {
-          from: 'selections',
-          to: 'activeMotherboard',
-          type: 'read',
-        },
-      ]))
+      expect(edges).toEqual(
+        expect.arrayContaining([
+          {
+            from: 'cpu',
+            to: 'ids',
+            type: 'field',
+          },
+          {
+            from: 'motherboard',
+            to: 'ids',
+            type: 'field',
+          },
+          {
+            from: 'ram',
+            to: 'ids',
+            type: 'field',
+          },
+          {
+            from: 'cpu',
+            to: 'cpuPresent',
+            type: 'field',
+          },
+          {
+            from: 'cpu',
+            to: 'cpuAndRamPresent',
+            type: 'field',
+          },
+          {
+            from: 'ram',
+            to: 'cpuAndRamPresent',
+            type: 'field',
+          },
+          {
+            from: 'cpu',
+            to: 'motherboardFair',
+            type: 'field',
+          },
+          {
+            from: 'cpu',
+            to: 'boardSummary',
+            type: 'field',
+          },
+          {
+            from: 'ids',
+            to: 'selections',
+            type: 'read',
+          },
+          {
+            from: 'selections',
+            to: 'selectionPresent',
+            type: 'read',
+          },
+          {
+            from: 'selections',
+            to: 'motherboardFair',
+            type: 'read',
+          },
+          {
+            from: 'selections',
+            to: 'boardSummary',
+            type: 'read',
+          },
+          {
+            from: 'motherboardFair',
+            to: 'activeMotherboard',
+            type: 'read',
+          },
+          {
+            from: 'selections',
+            to: 'activeMotherboard',
+            type: 'read',
+          },
+        ]),
+      )
     })
 
     test('inspect graph includes bridge edges after read-backed rules register', () => {
@@ -303,7 +320,9 @@ describe('@umpire/reads', () => {
 
       fairWhenRead('motherboard', 'motherboardFair', reads)
 
-      expect(reads.inspect({ cpu: 'am5', motherboard: 'am5' }).graph.edges).toEqual(
+      expect(
+        reads.inspect({ cpu: 'am5', motherboard: 'am5' }).graph.edges,
+      ).toEqual(
         expect.arrayContaining([
           {
             from: 'motherboardFair',
@@ -322,7 +341,9 @@ describe('@umpire/reads', () => {
         beta: ({ read }) => read('alpha'),
       })
 
-      expect(() => reads.resolve({})).toThrow('createReads circular dependency: alpha -> beta -> alpha')
+      expect(() => reads.resolve({})).toThrow(
+        'createReads circular dependency: alpha -> beta -> alpha',
+      )
     })
   })
 
@@ -333,13 +354,15 @@ describe('@umpire/reads', () => {
       fairWhenRead('motherboard', 'motherboardFair', reads)
       fairWhenRead('motherboard', 'motherboardFair', reads)
 
-      expect(reads.inspect({ cpu: 'am5', motherboard: 'am5' }).bridges).toEqual([
-        {
-          type: 'fairWhen',
-          read: 'motherboardFair',
-          field: 'motherboard',
-        },
-      ])
+      expect(reads.inspect({ cpu: 'am5', motherboard: 'am5' }).bridges).toEqual(
+        [
+          {
+            type: 'fairWhen',
+            read: 'motherboardFair',
+            field: 'motherboard',
+          },
+        ],
+      )
     })
 
     test('registers enabledWhen bridges with the correct type', () => {
@@ -361,13 +384,15 @@ describe('@umpire/reads', () => {
 
       fairWhenRead(field<string>('motherboard'), 'motherboardFair', reads)
 
-      expect(reads.inspect({ cpu: 'am5', motherboard: 'am5' }).bridges).toEqual([
-        {
-          type: 'fairWhen',
-          read: 'motherboardFair',
-          field: 'motherboard',
-        },
-      ])
+      expect(reads.inspect({ cpu: 'am5', motherboard: 'am5' }).bridges).toEqual(
+        [
+          {
+            type: 'fairWhen',
+            read: 'motherboardFair',
+            field: 'motherboard',
+          },
+        ],
+      )
     })
 
     test('throws when an unnamed field builder is used with a read-backed rule', () => {
@@ -396,14 +421,16 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(ump.check({ cpu: 'am5', motherboard: 'am5' }).motherboard).toEqual({
-        enabled: true,
-        satisfied: true,
-        fair: true,
-        required: false,
-        reason: null,
-        reasons: [],
-      })
+      expect(ump.check({ cpu: 'am5', motherboard: 'am5' }).motherboard).toEqual(
+        {
+          enabled: true,
+          satisfied: true,
+          fair: true,
+          required: false,
+          reason: null,
+          reasons: [],
+        },
+      )
     })
 
     test('fairWhenRead fails with the configured reason when the read returns false', () => {
@@ -422,7 +449,9 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(ump.check({ cpu: 'am5', motherboard: 'lga1700' }).motherboard).toEqual({
+      expect(
+        ump.check({ cpu: 'am5', motherboard: 'lga1700' }).motherboard,
+      ).toEqual({
         enabled: true,
         satisfied: true,
         fair: false,
@@ -451,14 +480,16 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(ump.check({ cpu: 'am5', motherboard: 'am5' }).motherboard).toEqual({
-        enabled: true,
-        satisfied: true,
-        fair: true,
-        required: false,
-        reason: null,
-        reasons: [],
-      })
+      expect(ump.check({ cpu: 'am5', motherboard: 'am5' }).motherboard).toEqual(
+        {
+          enabled: true,
+          satisfied: true,
+          fair: true,
+          required: false,
+          reason: null,
+          reasons: [],
+        },
+      )
       expect(ump.check({ motherboard: 'am5' }).motherboard).toEqual({
         enabled: false,
         satisfied: true,
@@ -516,9 +547,8 @@ describe('@umpire/reads', () => {
         { cpu?: string; motherboard?: string },
         { motherboardFair: boolean }
       >({
-        motherboardFair: ({ input }) => (
-          !input.motherboard || input.cpu === input.motherboard
-        ),
+        motherboardFair: ({ input }) =>
+          !input.motherboard || input.cpu === input.motherboard,
       })
       const ump = umpire<
         {
@@ -538,10 +568,8 @@ describe('@umpire/reads', () => {
       })
 
       expect(
-        ump.check(
-          { motherboard: 'am5' },
-          { cpu: 'am5', motherboard: 'am5' },
-        ).motherboard,
+        ump.check({ motherboard: 'am5' }, { cpu: 'am5', motherboard: 'am5' })
+          .motherboard,
       ).toEqual({
         enabled: true,
         satisfied: true,
@@ -591,7 +619,9 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(ump.check({ motherboard: 'am5' }, { cpu: 'am5' }).motherboard).toEqual({
+      expect(
+        ump.check({ motherboard: 'am5' }, { cpu: 'am5' }).motherboard,
+      ).toEqual({
         enabled: true,
         satisfied: true,
         fair: true,
@@ -599,7 +629,9 @@ describe('@umpire/reads', () => {
         reason: null,
         reasons: [],
       })
-      expect(ump.check({ motherboard: 'lga1700' }, { cpu: 'am5' }).motherboard).toEqual({
+      expect(
+        ump.check({ motherboard: 'lga1700' }, { cpu: 'am5' }).motherboard,
+      ).toEqual({
         enabled: true,
         satisfied: true,
         fair: false,

--- a/packages/reads/src/index.ts
+++ b/packages/reads/src/index.ts
@@ -6,4 +6,10 @@ export type {
   ReadTableInspection,
   ReadTableNode,
 } from './reads.js'
-export { ReadInputType, createReads, enabledWhenRead, fairWhenRead, fromRead } from './reads.js'
+export {
+  ReadInputType,
+  createReads,
+  enabledWhenRead,
+  fairWhenRead,
+  fromRead,
+} from './reads.js'

--- a/packages/reads/src/reads.ts
+++ b/packages/reads/src/reads.ts
@@ -13,7 +13,8 @@ export const ReadInputType = {
   CONDITIONS: 'conditions',
 } as const
 
-export type ReadInputTypeValue = typeof ReadInputType[keyof typeof ReadInputType]
+export type ReadInputTypeValue =
+  (typeof ReadInputType)[keyof typeof ReadInputType]
 
 type ReadContext<
   Input extends Record<string, unknown>,
@@ -32,7 +33,8 @@ type ReadResolvers<
 
 export type PredicateReadKey<Reads extends Record<string, unknown>> = {
   [K in keyof Reads]-?: Reads[K] extends boolean ? K : never
-}[keyof Reads] & string
+}[keyof Reads] &
+  string
 
 export type ReadBridge<ReadId extends string = string> = {
   type: 'enabledWhen' | 'fairWhen'
@@ -88,18 +90,17 @@ export type ReadTable<
 > = {
   from<K extends PredicateReadKey<Reads>>(
     key: K,
-  ): (
-    value: unknown,
-    values: Input,
-    conditions?: unknown,
-  ) => Reads[K]
+  ): (value: unknown, values: Input, conditions?: unknown) => Reads[K]
   from<K extends PredicateReadKey<Reads>, Args extends unknown[]>(
     key: K,
     selectInput: (...args: Args) => Input,
   ): (...args: Args) => Reads[K]
   inspect(input: Input): ReadTableInspection<Input, Reads>
   resolve(input: Input): Reads
-  trace<K extends keyof Reads & string, C extends Record<string, unknown> = Record<string, unknown>>(
+  trace<
+    K extends keyof Reads & string,
+    C extends Record<string, unknown> = Record<string, unknown>,
+  >(
     key: K,
   ): RuleTraceAttachment<Input, C>
   trace<
@@ -189,16 +190,17 @@ function getReadBridgeStore<
 function registerReadBridge<
   Input extends Record<string, unknown>,
   Reads extends Record<string, unknown>,
->(
-  table: ReadTable<Input, Reads>,
-  bridge: ReadBridge<keyof Reads & string>,
-) {
+>(table: ReadTable<Input, Reads>, bridge: ReadBridge<keyof Reads & string>) {
   const bridges = getReadBridgeStore(table)
 
-  if (bridges.some((entry) =>
-    entry.type === bridge.type &&
-    entry.read === bridge.read &&
-    entry.field === bridge.field)) {
+  if (
+    bridges.some(
+      (entry) =>
+        entry.type === bridge.type &&
+        entry.read === bridge.read &&
+        entry.field === bridge.field,
+    )
+  ) {
     return
   }
 
@@ -214,13 +216,12 @@ function getReadRuleFieldName(field: unknown) {
     return String(field.__umpfield)
   }
 
-  throw new Error('[@umpire/reads] Named field required when using a read-backed rule')
+  throw new Error(
+    '[@umpire/reads] Named field required when using a read-backed rule',
+  )
 }
 
-function mergeReadTrace<T>(
-  trace: T,
-  existing: T | T[] | undefined,
-) {
+function mergeReadTrace<T>(trace: T, existing: T | T[] | undefined) {
   return existing
     ? [...(Array.isArray(existing) ? existing : [existing]), trace]
     : trace
@@ -233,11 +234,7 @@ export function fromRead<
 >(
   table: ReadTable<Input, Reads>,
   key: K,
-): (
-  value: unknown,
-  values: Input,
-  conditions?: unknown,
-) => Reads[K]
+): (value: unknown, values: Input, conditions?: unknown) => Reads[K]
 export function fromRead<
   Input extends Record<string, unknown>,
   Reads extends Record<string, unknown>,
@@ -261,11 +258,8 @@ export function fromRead<
     return (...args: unknown[]) => table[key](selectInput(...args)) as Reads[K]
   }
 
-  return (
-    _value: unknown,
-    values: Input,
-    _conditions?: unknown,
-  ) => table[key](values) as Reads[K]
+  return (_value: unknown, values: Input, _conditions?: unknown) =>
+    table[key](values) as Reads[K]
 }
 
 export function fairWhenRead<
@@ -321,10 +315,11 @@ export function fairWhenRead<
     | FairWhenReadConfig<F, C, Input>,
 ): Rule<F, C> {
   const fieldName = getReadRuleFieldName(field)
-  const inputType = (
-    options as { inputType?: ReadInputTypeValue } | undefined
-  )?.inputType ?? ReadInputType.VALUES
-  const selectInput = options && 'selectInput' in options ? options.selectInput : undefined
+  const inputType =
+    (options as { inputType?: ReadInputTypeValue } | undefined)?.inputType ??
+    ReadInputType.VALUES
+  const selectInput =
+    options && 'selectInput' in options ? options.selectInput : undefined
   const resolveInput = (
     values: FieldValues<F>,
     conditions: C,
@@ -347,9 +342,11 @@ export function fairWhenRead<
     field: fieldName,
   })
 
-  const trace = ((selectInput || inputType === ReadInputType.CONDITIONS)
-    ? table.trace<K, FieldValues<F>, C>(key, resolveInput)
-    : table.trace<K, C>(key)) as RuleTraceAttachment<FieldValues<F>, C>
+  const trace = (
+    selectInput || inputType === ReadInputType.CONDITIONS
+      ? table.trace<K, FieldValues<F>, C>(key, resolveInput)
+      : table.trace<K, C>(key)
+  ) as RuleTraceAttachment<FieldValues<F>, C>
   const mergedTrace = mergeReadTrace(trace, options?.trace)
   const {
     inputType: _inputType,
@@ -361,7 +358,9 @@ export function fairWhenRead<
   }
 
   const predicate = ((_value: unknown, values: FieldValues<F>, conditions: C) =>
-    table[key](resolveInput(values, conditions))) as Parameters<typeof fairWhen<F, C, unknown>>[1]
+    table[key](resolveInput(values, conditions))) as Parameters<
+    typeof fairWhen<F, C, unknown>
+  >[1]
 
   return fairWhen(field, predicate, {
     ...ruleOptions,
@@ -422,10 +421,11 @@ export function enabledWhenRead<
     | EnabledWhenReadConfig<F, C, Input>,
 ): Rule<F, C> {
   const fieldName = getReadRuleFieldName(field)
-  const inputType = (
-    options as { inputType?: ReadInputTypeValue } | undefined
-  )?.inputType ?? ReadInputType.VALUES
-  const selectInput = options && 'selectInput' in options ? options.selectInput : undefined
+  const inputType =
+    (options as { inputType?: ReadInputTypeValue } | undefined)?.inputType ??
+    ReadInputType.VALUES
+  const selectInput =
+    options && 'selectInput' in options ? options.selectInput : undefined
   const resolveInput = (
     values: FieldValues<F>,
     conditions: C,
@@ -448,9 +448,11 @@ export function enabledWhenRead<
     field: fieldName,
   })
 
-  const trace = ((selectInput || inputType === ReadInputType.CONDITIONS)
-    ? table.trace<K, FieldValues<F>, C>(key, resolveInput)
-    : table.trace<K, C>(key)) as RuleTraceAttachment<FieldValues<F>, C>
+  const trace = (
+    selectInput || inputType === ReadInputType.CONDITIONS
+      ? table.trace<K, FieldValues<F>, C>(key, resolveInput)
+      : table.trace<K, C>(key)
+  ) as RuleTraceAttachment<FieldValues<F>, C>
   const mergedTrace = mergeReadTrace(trace, options?.trace)
   const {
     inputType: _inputType,
@@ -461,8 +463,13 @@ export function enabledWhenRead<
     selectInput?: ReadRuleInputSelector<F, C, Input>
   }
 
-  const predicate = ((values: FieldValues<F>, conditions: C, prev?: FieldValues<F>) =>
-    table[key](resolveInput(values, conditions, prev))) as Parameters<typeof enabledWhen<F, C>>[1]
+  const predicate = ((
+    values: FieldValues<F>,
+    conditions: C,
+    prev?: FieldValues<F>,
+  ) => table[key](resolveInput(values, conditions, prev))) as Parameters<
+    typeof enabledWhen<F, C>
+  >[1]
 
   return enabledWhen(field, predicate, {
     ...ruleOptions,
@@ -473,21 +480,21 @@ export function enabledWhenRead<
 export function createReads<
   Input extends Record<string, unknown>,
   Reads extends Record<string, unknown>,
->(
-  resolvers: ReadResolvers<Input, Reads>,
-): ReadTable<Input, Reads> {
+>(resolvers: ReadResolvers<Input, Reads>): ReadTable<Input, Reads> {
   const keys = Object.keys(resolvers) as Array<keyof Reads & string>
   const bridgeStore: ReadBridge<keyof Reads & string>[] = []
 
   function createSession(input: Input) {
     const cache = new Map<keyof Reads & string, Reads[keyof Reads & string]>()
     const stack: Array<keyof Reads & string> = []
-    const readDependencies = new Map<keyof Reads & string, Set<keyof Reads & string>>(
-      keys.map((key) => [key, new Set<keyof Reads & string>()]),
-    )
-    const fieldDependencies = new Map<keyof Reads & string, Set<keyof Input & string>>(
-      keys.map((key) => [key, new Set<keyof Input & string>()]),
-    )
+    const readDependencies = new Map<
+      keyof Reads & string,
+      Set<keyof Reads & string>
+    >(keys.map((key) => [key, new Set<keyof Reads & string>()]))
+    const fieldDependencies = new Map<
+      keyof Reads & string,
+      Set<keyof Input & string>
+    >(keys.map((key) => [key, new Set<keyof Input & string>()]))
 
     const trackedInput = new Proxy(input, {
       get(target, property, receiver) {
@@ -514,7 +521,9 @@ export function createReads<
 
       if (stack.includes(key)) {
         const cycle = [...stack, key].map(String).join(' -> ')
-        throw new Error(`[@umpire/reads] createReads circular dependency: ${cycle}`)
+        throw new Error(
+          `[@umpire/reads] createReads circular dependency: ${cycle}`,
+        )
       }
 
       stack.push(key)
@@ -560,7 +569,7 @@ export function createReads<
       graph: {
         nodes: [...keys],
         edges: [
-          ...keys.flatMap((key) => ([
+          ...keys.flatMap((key) => [
             ...session.getReadDependencies(key).map((from) => ({
               from,
               to: key,
@@ -571,7 +580,7 @@ export function createReads<
               to: key,
               type: 'field' as const,
             })),
-          ])),
+          ]),
           ...bridgeStore.map((bridge) => ({
             from: bridge.read,
             to: bridge.field,
@@ -602,11 +611,8 @@ export function createReads<
       return (...args: unknown[]) => resolveRead(key, selectInput(...args))
     }
 
-    return (
-      _value: unknown,
-      values: Input,
-      _conditions?: unknown,
-    ) => resolveRead(key, values)
+    return (_value: unknown, values: Input, _conditions?: unknown) =>
+      resolveRead(key, values)
   }
 
   function buildTrace<
@@ -635,7 +641,7 @@ export function createReads<
       inspect(values: Values | Input, conditions?: C, prev?: Values) {
         const input = selectInput
           ? selectInput(values as Values, conditions as C, prev)
-          : values as Input
+          : (values as Input)
         const inspected = inspectInput(input)
         const node = inspected.nodes[key]
 
@@ -664,7 +670,10 @@ export function createReads<
   })
 
   for (const key of keys) {
-    table[key] = ((input: Input) => resolveRead(key, input)) as ReadTable<Input, Reads>[typeof key]
+    table[key] = ((input: Input) => resolveRead(key, input)) as ReadTable<
+      Input,
+      Reads
+    >[typeof key]
   }
 
   return table

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -29,13 +29,15 @@ const ump = umpire({
   ],
 })
 
-const store = legacy_createStore((state = { password: '', confirmPassword: '' }, action) => {
-  if (action.type === 'patch') {
-    return { ...state, ...action.payload }
-  }
+const store = legacy_createStore(
+  (state = { password: '', confirmPassword: '' }, action) => {
+    if (action.type === 'patch') {
+      return { ...state, ...action.payload }
+    }
 
-  return state
-})
+    return state
+  },
+)
 
 const umpStore = fromReduxStore(ump, store, {
   select: (state) => ({

--- a/packages/redux/__tests__/fromReduxStore.test.ts
+++ b/packages/redux/__tests__/fromReduxStore.test.ts
@@ -4,7 +4,9 @@ import { enabledWhen, requires, umpire } from '@umpire/core'
 import { fromReduxStore } from '../src/index.js'
 
 const fields = {
-  username: { isEmpty: (v: unknown) => v === '' || v === undefined || v === null },
+  username: {
+    isEmpty: (v: unknown) => v === '' || v === undefined || v === null,
+  },
   password: {},
   confirmPassword: { default: '' },
   inviteCode: { default: '' },
@@ -146,9 +148,12 @@ describe('fromReduxStore', () => {
     type ConditionFields = typeof conditionFields
 
     const conditionRules = [
-      enabledWhen<ConditionFields, Conditions>('inviteCode', (_values, conditions) => {
-        return conditions.requireInvite
-      }),
+      enabledWhen<ConditionFields, Conditions>(
+        'inviteCode',
+        (_values, conditions) => {
+          return conditions.requireInvite
+        },
+      ),
     ]
 
     const store = createFormStore()
@@ -237,7 +242,10 @@ describe('fromReduxStore', () => {
       fields: nestedFields,
       rules: [
         enabledWhen('note', (values) => {
-          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+          return (
+            (values.settings as { allowNote: boolean } | undefined)
+              ?.allowNote === true
+          )
         }),
       ],
     })

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -22,19 +22,20 @@ export function fromReduxStore<
 ): UmpireStore<F> {
   const previousState = trackPreviousState(store.getState())
 
-  return fromStore(ump, {
-    getState: () => store.getState(),
-    subscribe(listener) {
-      return store.subscribe(() => {
-        const nextState = store.getState()
+  return fromStore(
+    ump,
+    {
+      getState: () => store.getState(),
+      subscribe(listener) {
+        return store.subscribe(() => {
+          const nextState = store.getState()
 
-        listener(nextState, previousState.next(nextState))
-      })
+          listener(nextState, previousState.next(nextState))
+        })
+      },
     },
-  }, options)
+    options,
+  )
 }
 
-export type {
-  FromStoreOptions,
-  UmpireStore,
-} from '@umpire/store'
+export type { FromStoreOptions, UmpireStore } from '@umpire/store'

--- a/packages/signals/README.md
+++ b/packages/signals/README.md
@@ -34,11 +34,11 @@ import { alienAdapter } from '@umpire/signals/alien'
 
 const signupUmp = umpire({
   fields: {
-    email:           { required: true, isEmpty: (v) => !v },
-    password:        { required: true, isEmpty: (v) => !v },
+    email: { required: true, isEmpty: (v) => !v },
+    password: { required: true, isEmpty: (v) => !v },
     confirmPassword: { required: true, isEmpty: (v) => !v },
-    companyName:     {},
-    companySize:     {},
+    companyName: {},
+    companySize: {},
   },
   rules: [
     requires('confirmPassword', 'password'),

--- a/packages/signals/__tests__/reactive.test.ts
+++ b/packages/signals/__tests__/reactive.test.ts
@@ -213,7 +213,9 @@ describe('reactiveUmp', () => {
     const ump = createTestUmpire()
     const reactive = reactiveUmp(ump, adapter)
 
-    expect(() => reactive.field('nonexistent' as never)).toThrow('Unknown field')
+    expect(() => reactive.field('nonexistent' as never)).toThrow(
+      'Unknown field',
+    )
   })
 
   test('set(name, value) updates the field signal and recomputes availability', () => {
@@ -344,8 +346,10 @@ describe('reactiveUmp', () => {
             Object.keys(conditions).includes('plan') &&
             valueDescriptor?.enumerable === true &&
             conditionDescriptor?.enumerable === true &&
-            Object.getOwnPropertyDescriptor(values as object, Symbol.iterator) ===
-              undefined &&
+            Object.getOwnPropertyDescriptor(
+              values as object,
+              Symbol.iterator,
+            ) === undefined &&
             Object.getOwnPropertyDescriptor(
               conditions as object,
               Symbol.iterator,
@@ -476,11 +480,9 @@ describe('reactiveUmp with disables rules', () => {
         endTime: { default: undefined, isEmpty: (v) => !v },
       },
       rules: [
-        disables(
-          'isAllDay',
-          ['startTime', 'endTime'],
-          { reason: 'All-day events do not have specific times' },
-        ),
+        disables('isAllDay', ['startTime', 'endTime'], {
+          reason: 'All-day events do not have specific times',
+        }),
       ],
     })
 
@@ -518,11 +520,9 @@ describe('reactiveUmp with disables rules', () => {
         startTime: { default: undefined, isEmpty: (v) => !v },
       },
       rules: [
-        disables(
-          'isAllDay',
-          ['startTime'],
-          { reason: 'All-day events do not have specific times' },
-        ),
+        disables('isAllDay', ['startTime'], {
+          reason: 'All-day events do not have specific times',
+        }),
       ],
     })
 
@@ -557,7 +557,10 @@ describe('reactiveUmp with disables rules', () => {
       },
       rules: [
         enabledWhen('note', (values) => {
-          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+          return (
+            (values.settings as { allowNote: boolean } | undefined)
+              ?.allowNote === true
+          )
         }),
       ],
     })

--- a/packages/signals/__tests__/reactive.test.ts
+++ b/packages/signals/__tests__/reactive.test.ts
@@ -37,7 +37,7 @@ function createMockAdapter(): SignalProtocol & {
   }> = []
 
   // Track which signal is being read during computed/effect evaluation
-  let activeSubscribers: Set<Subscriber> | null = null
+  const activeSubscribers: Set<Subscriber> | null = null
 
   function recompute() {
     // Re-evaluate all computeds

--- a/packages/signals/__tests__/solid-adapter.test.ts
+++ b/packages/signals/__tests__/solid-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { enabledWhen, umpire } from '@umpire/core'
+import { enabledWhen, umpire, type Foul } from '@umpire/core'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — solid-js types are available at runtime in this workspace
 import { createRoot } from 'solid-js'
@@ -8,12 +8,14 @@ import { reactiveUmp } from '../src/reactive.js'
 
 describe('solid adapter', () => {
   test('tracks fouls inside a root and stays safe after dispose', async () => {
+    const fields = {
+      useSso: { default: false },
+      password: { default: '' },
+      confirmPassword: { default: '' },
+    }
+
     const ump = umpire({
-      fields: {
-        useSso: { default: false },
-        password: { default: '' },
-        confirmPassword: { default: '' },
-      },
+      fields,
       rules: [
         enabledWhen('password', (values) => values.useSso !== true),
         enabledWhen('confirmPassword', (values) => values.useSso !== true),
@@ -23,7 +25,7 @@ describe('solid adapter', () => {
       ],
     })
 
-    let reactive: any
+    let reactive
     let disposeRoot = () => {}
 
     createRoot((dispose) => {
@@ -37,7 +39,14 @@ describe('solid adapter', () => {
 
     expect(reactive!.field('password').enabled).toBe(false)
     expect(reactive!.field('confirmPassword').enabled).toBe(false)
-    expect(reactive!.fouls.map((foul) => foul.field).sort()).toEqual(['password'])
+    expect(reactive!.foul('password')).toEqual({
+      field: 'password',
+      reason: 'condition not met',
+      suggestedValue: '',
+    })
+    expect(reactive!.fouls.map((foul: Foul<typeof fields>) => foul.field).sort()).toEqual([
+      'password',
+    ])
 
     reactive!.dispose()
     disposeRoot()

--- a/packages/signals/__tests__/solid-adapter.test.ts
+++ b/packages/signals/__tests__/solid-adapter.test.ts
@@ -44,9 +44,9 @@ describe('solid adapter', () => {
       reason: 'condition not met',
       suggestedValue: '',
     })
-    expect(reactive!.fouls.map((foul: Foul<typeof fields>) => foul.field).sort()).toEqual([
-      'password',
-    ])
+    expect(
+      reactive!.fouls.map((foul: Foul<typeof fields>) => foul.field).sort(),
+    ).toEqual(['password'])
 
     reactive!.dispose()
     disposeRoot()

--- a/packages/signals/src/adapters/alien.ts
+++ b/packages/signals/src/adapters/alien.ts
@@ -6,7 +6,13 @@ import type { SignalProtocol } from '../protocol.js'
 // the explicit /esm entry keeps adapter tests stable in this repo.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — types unavailable unless alien-signals is installed
-import { signal, computed, effect, startBatch, endBatch } from 'alien-signals/esm'
+import {
+  signal,
+  computed,
+  effect,
+  startBatch,
+  endBatch,
+} from 'alien-signals/esm'
 
 export const alienAdapter: SignalProtocol = {
   signal(initial) {

--- a/packages/signals/src/adapters/solid.ts
+++ b/packages/signals/src/adapters/solid.ts
@@ -2,10 +2,17 @@ import type { SignalProtocol } from '../protocol.js'
 
 // solid-js is an optional peer dependency.
 // This file only compiles/runs when the consumer has it installed.
-// Bun test resolution in this repo needs the explicit runtime entry.
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore — types unavailable unless solid-js is installed
-import { createSignal, createMemo, createEffect, createRoot, onCleanup, batch } from 'solid-js/dist/solid.js'
+import {
+  createSignal,
+  createMemo,
+  createEffect,
+  createRoot,
+  onCleanup,
+  batch,
+  // Bun test resolution in this repo needs the explicit runtime entry.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — types unavailable unless solid-js is installed
+} from 'solid-js/dist/solid.js'
 
 export const solidAdapter: SignalProtocol = {
   signal<T>(initial: T) {

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -1,3 +1,7 @@
 export type { SignalProtocol } from './protocol.js'
 export { reactiveUmp } from './reactive.js'
-export type { ReactiveUmpire, ReactiveUmpOptions, ReactiveField } from './reactive.js'
+export type {
+  ReactiveUmpire,
+  ReactiveUmpOptions,
+  ReactiveField,
+} from './reactive.js'

--- a/packages/signals/src/reactive.ts
+++ b/packages/signals/src/reactive.ts
@@ -78,17 +78,23 @@ export function reactiveUmp<
   for (const name of fieldNames) {
     const external = options?.signals?.[name]
     if (external) {
-      fieldSignals.set(name, external as ReactiveSignal<FieldValues<F>[typeof name]>)
+      fieldSignals.set(
+        name,
+        external as ReactiveSignal<FieldValues<F>[typeof name]>,
+      )
     } else {
       fieldSignals.set(
         name,
-        adapter.signal(initValues[name]) as ReactiveSignal<FieldValues<F>[typeof name]>,
+        adapter.signal(initValues[name]) as ReactiveSignal<
+          FieldValues<F>[typeof name]
+        >,
       )
     }
   }
 
   // --- 2. Conditions signals ---
-  const conditionSignals: ReactiveConditionSignals<C> = options?.conditions ?? {}
+  const conditionSignals: ReactiveConditionSignals<C> =
+    options?.conditions ?? {}
 
   // --- 3. Lazy proxy for fine-grained predicate tracking ---
   function createSignalMapProxy<T extends object>(
@@ -158,24 +164,28 @@ export function reactiveUmp<
   for (const name of fieldNames) {
     fieldComputeds.set(name, {
       enabled: adapter.computed(() => availabilityComputed.get()[name].enabled),
-      satisfied: adapter.computed(() => availabilityComputed.get()[name].satisfied),
+      satisfied: adapter.computed(
+        () => availabilityComputed.get()[name].satisfied,
+      ),
       fair: adapter.computed(() => availabilityComputed.get()[name].fair),
-      required: adapter.computed(() => availabilityComputed.get()[name].required),
+      required: adapter.computed(
+        () => availabilityComputed.get()[name].required,
+      ),
       reason: adapter.computed(() => availabilityComputed.get()[name].reason),
       reasons: adapter.computed(() => availabilityComputed.get()[name].reasons),
     })
   }
 
   // --- 5. Aggregate values computed ---
-  const valuesComputed = adapter.computed<ReactiveValues<F>>(
-    () => {
-      const result = {} as ReactiveValues<F>
-      for (const name of fieldNames) {
-        result[name] = fieldSignals.get(name)!.get() as ReactiveValues<F>[typeof name]
-      }
-      return result
-    },
-  )
+  const valuesComputed = adapter.computed<ReactiveValues<F>>(() => {
+    const result = {} as ReactiveValues<F>
+    for (const name of fieldNames) {
+      result[name] = fieldSignals
+        .get(name)!
+        .get() as ReactiveValues<F>[typeof name]
+    }
+    return result
+  })
 
   // --- 6. Fouls tracking (requires effect) ---
   const disposeFns: Array<() => void> = []
@@ -197,18 +207,22 @@ export function reactiveUmp<
     // change — no version counter needed.
 
     function readSnapshotValues() {
-      return snapshotValue(Object.fromEntries(
-        fieldNames.map((name) => [name, fieldSignals.get(name)!.get()]),
-      ) as InputValues)
+      return snapshotValue(
+        Object.fromEntries(
+          fieldNames.map((name) => [name, fieldSignals.get(name)!.get()]),
+        ) as InputValues,
+      )
     }
 
     function readSnapshotConditions() {
-      return snapshotValue(Object.fromEntries(
-        Object.keys(conditionSignals).map((name) => [
-          name,
-          conditionSignals[name as keyof C & string]!.get(),
-        ]),
-      ) as C)
+      return snapshotValue(
+        Object.fromEntries(
+          Object.keys(conditionSignals).map((name) => [
+            name,
+            conditionSignals[name as keyof C & string]!.get(),
+          ]),
+        ) as C,
+      )
     }
 
     let beforeValues: InputValues = readSnapshotValues()

--- a/packages/signals/tsconfig.typecheck.json
+++ b/packages/signals/tsconfig.typecheck.json
@@ -5,8 +5,5 @@
     "composite": false,
     "rootDir": ".."
   },
-  "include": [
-    "src",
-    "type-tests/**/*.ts"
-  ]
+  "include": ["src", "type-tests/**/*.ts"]
 }

--- a/packages/signals/type-tests/reactive-writes.type-test.ts
+++ b/packages/signals/type-tests/reactive-writes.type-test.ts
@@ -23,14 +23,17 @@ const adapter: SignalProtocol = {
   },
 }
 
-const form = reactiveUmp(umpire({
-  fields: {
-    count: { default: 0 },
-    label: { default: '' },
-    enabled: { default: true },
-  },
-  rules: [],
-}), adapter)
+const form = reactiveUmp(
+  umpire({
+    fields: {
+      count: { default: 0 },
+      label: { default: '' },
+      enabled: { default: true },
+    },
+    rules: [],
+  }),
+  adapter,
+)
 
 const conditionedUmp = umpire<
   {
@@ -46,32 +49,32 @@ const conditionedUmp = umpire<
     enabled: { default: true },
   },
   rules: [
-    enabledWhen('enabled', (_values, conditions) => conditions.plan === 'pro' && conditions.stage > 0),
+    enabledWhen(
+      'enabled',
+      (_values, conditions) =>
+        conditions.plan === 'pro' && conditions.stage > 0,
+    ),
   ],
 })
 
-const optionsForm = reactiveUmp(
-  conditionedUmp,
-  adapter,
-  {
-    signals: {
-      count: {
-        get: () => 1,
-        set: (_next) => {},
-      },
-      label: {
-        get: () => 'label',
-        // @ts-expect-error label signal set must accept string
-        set: (_next: number) => {},
-      },
+const optionsForm = reactiveUmp(conditionedUmp, adapter, {
+  signals: {
+    count: {
+      get: () => 1,
+      set: (_next) => {},
     },
-    conditions: {
-      plan: { get: () => 'free' },
-      // @ts-expect-error stage condition must return number
-      stage: { get: () => '1' },
+    label: {
+      get: () => 'label',
+      // @ts-expect-error label signal set must accept string
+      set: (_next: number) => {},
     },
   },
-)
+  conditions: {
+    plan: { get: () => 'free' },
+    // @ts-expect-error stage condition must return number
+    stage: { get: () => '1' },
+  },
+})
 
 void optionsForm
 

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -19,20 +19,28 @@ import { useUmpire } from '@umpire/solid'
 
 const signupUmp = umpire({
   fields: {
-    email:           { required: true, isEmpty: (v) => !v },
-    password:        { required: true, isEmpty: (v) => !v },
+    email: { required: true, isEmpty: (v) => !v },
+    password: { required: true, isEmpty: (v) => !v },
     confirmPassword: { required: true, isEmpty: (v) => !v },
-    companyName:     {},
-    companySize:     {},
+    companyName: {},
+    companySize: {},
   },
   rules: [
     requires('confirmPassword', 'password'),
-    enabledWhen('companyName', (_values, conditions) => conditions.plan === 'business', {
-      reason: 'business plan required',
-    }),
-    enabledWhen('companySize', (_values, conditions) => conditions.plan === 'business', {
-      reason: 'business plan required',
-    }),
+    enabledWhen(
+      'companyName',
+      (_values, conditions) => conditions.plan === 'business',
+      {
+        reason: 'business plan required',
+      },
+    ),
+    enabledWhen(
+      'companySize',
+      (_values, conditions) => conditions.plan === 'business',
+      {
+        reason: 'business plan required',
+      },
+    ),
     requires('companySize', 'companyName'),
   ],
 })
@@ -46,7 +54,11 @@ function SignupForm() {
     companySize: '',
   })
 
-  const { check, fouls } = useUmpire(signupUmp, () => values, () => ({ plan: 'business' as const }))
+  const { check, fouls } = useUmpire(
+    signupUmp,
+    () => values,
+    () => ({ plan: 'business' as const }),
+  )
 
   check().companyName.enabled
   check().companyName.reason

--- a/packages/solid/__tests__/fromSolidStore.test.ts
+++ b/packages/solid/__tests__/fromSolidStore.test.ts
@@ -26,9 +26,7 @@ describe('fromSolidStore', () => {
   it('derives field availability from shared reactive values', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { value, dispose } = withRoot(() => {
@@ -83,9 +81,7 @@ describe('fromSolidStore', () => {
   it('tracks foul transitions from shared reactive values', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { value, dispose } = withRoot(() => {
@@ -149,9 +145,7 @@ describe('fromSolidStore', () => {
   it('writes back through set() and update()', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { value, dispose } = withRoot(() => {
@@ -305,7 +299,10 @@ describe('fromSolidStore', () => {
         },
       }
 
-      const set = (field: keyof typeof premiumFields & string, next: unknown) => {
+      const set = (
+        field: keyof typeof premiumFields & string,
+        next: unknown,
+      ) => {
         switch (field) {
           case 'advanced':
             setAdvanced(String(next))
@@ -343,9 +340,7 @@ describe('fromSolidStore', () => {
   it('dispose() cleans up Solid effect tracking once', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const originalEffect = solidAdapter.effect

--- a/packages/solid/__tests__/useUmpire.test.ts
+++ b/packages/solid/__tests__/useUmpire.test.ts
@@ -29,9 +29,7 @@ describe('useUmpire', () => {
   it('returns check with correct availability', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { value, dispose } = withRoot(() => {
@@ -51,13 +49,15 @@ describe('useUmpire', () => {
   it('recomputes check when values change', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { value, dispose } = withRoot(() => {
-      const [values, setValues] = createSignal({ name: '', email: '', phone: '' })
+      const [values, setValues] = createSignal({
+        name: '',
+        email: '',
+        phone: '',
+      })
       return {
         setValues,
         ...useUmpire(ump, values),
@@ -78,13 +78,15 @@ describe('useUmpire', () => {
   it('returns empty fouls on first read', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { value, dispose } = withRoot(() => {
-      const [values] = createSignal({ name: 'Alice', email: '', phone: '555-1234' })
+      const [values] = createSignal({
+        name: 'Alice',
+        email: '',
+        phone: '555-1234',
+      })
       return useUmpire(ump, values)
     })
 
@@ -98,9 +100,7 @@ describe('useUmpire', () => {
   it('computes check once on mount', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
     const checkSpy = spyOn(ump, 'check')
 
@@ -121,13 +121,15 @@ describe('useUmpire', () => {
   it('returns fouls when a field transitions from enabled to disabled', () => {
     const ump = umpire({
       fields,
-      rules: [
-        enabledWhen('phone', (values) => !!values.name),
-      ],
+      rules: [enabledWhen('phone', (values) => !!values.name)],
     })
 
     const { value, dispose } = withRoot(() => {
-      const [values, setValues] = createSignal({ name: 'Alice', email: '', phone: '555-1234' })
+      const [values, setValues] = createSignal({
+        name: 'Alice',
+        email: '',
+        phone: '555-1234',
+      })
       return {
         setValues,
         ...useUmpire(ump, values),
@@ -163,7 +165,9 @@ describe('useUmpire', () => {
 
     const { value, dispose } = withRoot(() => {
       const [values] = createSignal({ advanced: '', basic: '' })
-      const [conditions, setConditions] = createSignal<Conditions>({ premium: false })
+      const [conditions, setConditions] = createSignal<Conditions>({
+        premium: false,
+      })
       return {
         setConditions,
         ...useUmpire(ump, values, conditions),
@@ -182,7 +186,8 @@ describe('useUmpire', () => {
   })
 
   it('passes previous values to check for oneOf resolution', () => {
-    const isEmpty = (value: unknown) => value === '' || value === undefined || value === null
+    const isEmpty = (value: unknown) =>
+      value === '' || value === undefined || value === null
     const oneOfFields = {
       date: { default: '', isEmpty },
       time: { default: '', isEmpty },
@@ -200,7 +205,11 @@ describe('useUmpire', () => {
     })
 
     const { value, dispose } = withRoot(() => {
-      const [values, setValues] = createSignal({ date: '', time: '', weekday: '' })
+      const [values, setValues] = createSignal({
+        date: '',
+        time: '',
+        weekday: '',
+      })
       return {
         setValues,
         ...useUmpire(ump, values),

--- a/packages/solid/src/fromSolidStore.ts
+++ b/packages/solid/src/fromSolidStore.ts
@@ -16,7 +16,8 @@ export type FromSolidStoreOptions<
   conditions?: Partial<{ [K in keyof C & string]: Accessor<C[K]> }>
 }
 
-export type SolidStoreUmpire<F extends Record<string, FieldDef>> = ReactiveUmpire<F>
+export type SolidStoreUmpire<F extends Record<string, FieldDef>> =
+  ReactiveUmpire<F>
 
 export function fromSolidStore<
   F extends Record<string, FieldDef>,
@@ -36,7 +37,9 @@ export function fromSolidStore<
     }
   }
 
-  let conditions: NonNullable<ReactiveUmpOptions<F, C>['conditions']> | undefined
+  let conditions:
+    | NonNullable<ReactiveUmpOptions<F, C>['conditions']>
+    | undefined
   if (options.conditions) {
     conditions = {}
     for (const [name, accessor] of Object.entries(options.conditions)) {

--- a/packages/solid/src/useUmpire.ts
+++ b/packages/solid/src/useUmpire.ts
@@ -27,9 +27,16 @@ export function useUmpire<
   createComputed(() => {
     const currentValues = snapshotValue(values())
     const currentConditions = snapshotValue(conditions?.())
-    const nextCheck = ump.check(currentValues, currentConditions, previousSnapshot?.values)
+    const nextCheck = ump.check(
+      currentValues,
+      currentConditions,
+      previousSnapshot?.values,
+    )
     const nextFouls = previousSnapshot
-      ? ump.play(previousSnapshot, { values: currentValues, conditions: currentConditions })
+      ? ump.play(previousSnapshot, {
+          values: currentValues,
+          conditions: currentConditions,
+        })
       : []
 
     batch(() => {

--- a/packages/solid/tsconfig.typecheck.json
+++ b/packages/solid/tsconfig.typecheck.json
@@ -5,8 +5,5 @@
     "composite": false,
     "rootDir": ".."
   },
-  "include": [
-    "src",
-    "type-tests/**/*.ts"
-  ]
+  "include": ["src", "type-tests/**/*.ts"]
 }

--- a/packages/solid/type-tests/from-solid-store.type-test.ts
+++ b/packages/solid/type-tests/from-solid-store.type-test.ts
@@ -20,7 +20,11 @@ const typedUmp = umpire<Fields, Conditions>({
     label: { default: '' },
   },
   rules: [
-    enabledWhen('label', (_values, conditions) => conditions.tier === 'pro' && conditions.stage > 0),
+    enabledWhen(
+      'label',
+      (_values, conditions) =>
+        conditions.tier === 'pro' && conditions.stage > 0,
+    ),
   ],
 })
 

--- a/packages/store/__tests__/fromStore.test.ts
+++ b/packages/store/__tests__/fromStore.test.ts
@@ -3,7 +3,9 @@ import { enabledWhen, requires, umpire } from '@umpire/core'
 import { fromStore } from '../src/fromStore.js'
 
 const fields = {
-  username: { isEmpty: (v: unknown) => v === '' || v === undefined || v === null },
+  username: {
+    isEmpty: (v: unknown) => v === '' || v === undefined || v === null,
+  },
   password: {},
   confirmPassword: { default: '' },
   inviteCode: { default: '' },
@@ -98,15 +100,20 @@ describe('fromStore', () => {
       }),
     ]
 
-    const store = createStore<{ username: string; inviteCode: string; requireInvite: boolean }>(
-      () => ({
-        username: '',
-        inviteCode: '',
-        requireInvite: false,
-      }),
-    )
+    const store = createStore<{
+      username: string
+      inviteCode: string
+      requireInvite: boolean
+    }>(() => ({
+      username: '',
+      inviteCode: '',
+      requireInvite: false,
+    }))
 
-    const ump = umpire<CFields, Ctx>({ fields: conditionsFields, rules: conditionsRules })
+    const ump = umpire<CFields, Ctx>({
+      fields: conditionsFields,
+      rules: conditionsRules,
+    })
     const us = fromStore(ump, store, {
       select: (state) => ({
         username: state.username,
@@ -145,7 +152,10 @@ describe('fromStore', () => {
       inviteCode: '',
     }))
 
-    const ump = umpire<CFields, Ctx>({ fields: conditionsFields, rules: conditionsRules })
+    const ump = umpire<CFields, Ctx>({
+      fields: conditionsFields,
+      rules: conditionsRules,
+    })
     const us = fromStore(ump, store, {
       select: (state) => ({
         username: state.username,
@@ -173,7 +183,10 @@ describe('fromStore', () => {
     store.setState({ password: 'secret' })
 
     expect(calls).toHaveLength(1)
-    expect((calls[0] as Record<string, { enabled: boolean }>).confirmPassword.enabled).toBe(true)
+    expect(
+      (calls[0] as Record<string, { enabled: boolean }>).confirmPassword
+        .enabled,
+    ).toBe(true)
 
     us.destroy()
   })
@@ -210,7 +223,12 @@ describe('fromStore', () => {
     expect(availability).toHaveProperty('confirmPassword')
     expect(availability).toHaveProperty('inviteCode')
 
-    for (const field of ['username', 'password', 'confirmPassword', 'inviteCode'] as const) {
+    for (const field of [
+      'username',
+      'password',
+      'confirmPassword',
+      'inviteCode',
+    ] as const) {
       expect(availability[field]).toHaveProperty('enabled')
       expect(availability[field]).toHaveProperty('required')
       expect(availability[field]).toHaveProperty('reason')

--- a/packages/store/src/fromStore.ts
+++ b/packages/store/src/fromStore.ts
@@ -82,7 +82,9 @@ export function fromStore<
       return currentAvailability
     },
 
-    subscribe(listener: (availability: AvailabilityMap<F>) => void): () => void {
+    subscribe(
+      listener: (availability: AvailabilityMap<F>) => void,
+    ): () => void {
       listeners.add(listener)
       return () => {
         listeners.delete(listener)

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,7 +1,3 @@
 export { fromStore } from './fromStore.js'
 export { trackPreviousState } from './trackPreviousState.js'
-export type {
-  FromStoreOptions,
-  StoreApi,
-  UmpireStore,
-} from './fromStore.js'
+export type { FromStoreOptions, StoreApi, UmpireStore } from './fromStore.js'

--- a/packages/tanstack-store/__tests__/fromTanStackStore.test.ts
+++ b/packages/tanstack-store/__tests__/fromTanStackStore.test.ts
@@ -3,7 +3,9 @@ import { enabledWhen, requires, umpire } from '@umpire/core'
 import { fromTanStackStore } from '../src/index.js'
 
 const fields = {
-  username: { isEmpty: (v: unknown) => v === '' || v === undefined || v === null },
+  username: {
+    isEmpty: (v: unknown) => v === '' || v === undefined || v === null,
+  },
   password: {},
   confirmPassword: { default: '' },
   inviteCode: { default: '' },
@@ -98,9 +100,12 @@ describe('fromTanStackStore', () => {
     type ConditionFields = typeof conditionFields
 
     const conditionRules = [
-      enabledWhen<ConditionFields, Conditions>('inviteCode', (_values, conditions) => {
-        return conditions.requireInvite
-      }),
+      enabledWhen<ConditionFields, Conditions>(
+        'inviteCode',
+        (_values, conditions) => {
+          return conditions.requireInvite
+        },
+      ),
     ]
 
     const store = createFormStore()
@@ -182,7 +187,10 @@ describe('fromTanStackStore', () => {
       fields: nestedFields,
       rules: [
         enabledWhen('note', (values) => {
-          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+          return (
+            (values.settings as { allowNote: boolean } | undefined)
+              ?.allowNote === true
+          )
         }),
       ],
     })

--- a/packages/tanstack-store/src/index.ts
+++ b/packages/tanstack-store/src/index.ts
@@ -6,16 +6,20 @@ import {
   type UmpireStore,
 } from '@umpire/store'
 
-export type TanStackStoreSubscription = {
-  unsubscribe(): void
-} | (() => void)
+export type TanStackStoreSubscription =
+  | {
+      unsubscribe(): void
+    }
+  | (() => void)
 
 export type TanStackStoreApi<S> = {
   state: S
   subscribe(listener: () => void): TanStackStoreSubscription
 }
 
-function normalizeSubscription(subscription: TanStackStoreSubscription): () => void {
+function normalizeSubscription(
+  subscription: TanStackStoreSubscription,
+): () => void {
   if (typeof subscription === 'function') {
     return subscription
   }
@@ -36,19 +40,22 @@ export function fromTanStackStore<
 ): UmpireStore<F> {
   const previousState = trackPreviousState(store.state)
 
-  return fromStore(ump, {
-    getState: () => store.state,
-    subscribe(listener) {
-      return normalizeSubscription(store.subscribe(() => {
-        const nextState = store.state
+  return fromStore(
+    ump,
+    {
+      getState: () => store.state,
+      subscribe(listener) {
+        return normalizeSubscription(
+          store.subscribe(() => {
+            const nextState = store.state
 
-        listener(nextState, previousState.next(nextState))
-      }))
+            listener(nextState, previousState.next(nextState))
+          }),
+        )
+      },
     },
-  }, options)
+    options,
+  )
 }
 
-export type {
-  FromStoreOptions,
-  UmpireStore,
-} from '@umpire/store'
+export type { FromStoreOptions, UmpireStore } from '@umpire/store'

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -30,14 +30,14 @@ expect(result.passed).toBe(true)
 
 ### What it checks
 
-| Invariant | Description |
-|-----------|-------------|
-| `determinism` | `check(values)` returns identical results on two consecutive calls. Catches impure predicates. |
-| `self-play` | `play(snapshot, snapshot)` always returns zero fouls. Flags rules that foul the current state against itself. |
-| `foul-convergence` | Applying foul suggestions repeatedly reaches zero fouls within the iteration limit. Catches foul cycles. |
-| `challenge-check-agreement` | `challenge(field)` and `check()` agree on `enabled` and `fair` for every field. |
-| `disabled-field-immunity` | Mutating a disabled field's value does not change the availability of any field that doesn't declare it as a dependency. Catches undeclared rule sources. |
-| `init-clean` | `play(init(), init())` returns zero fouls. The initial state must always be legal. |
+| Invariant                   | Description                                                                                                                                               |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `determinism`               | `check(values)` returns identical results on two consecutive calls. Catches impure predicates.                                                            |
+| `self-play`                 | `play(snapshot, snapshot)` always returns zero fouls. Flags rules that foul the current state against itself.                                             |
+| `foul-convergence`          | Applying foul suggestions repeatedly reaches zero fouls within the iteration limit. Catches foul cycles.                                                  |
+| `challenge-check-agreement` | `challenge(field)` and `check()` agree on `enabled` and `fair` for every field.                                                                           |
+| `disabled-field-immunity`   | Mutating a disabled field's value does not change the availability of any field that doesn't declare it as a dependency. Catches undeclared rule sources. |
+| `init-clean`                | `play(init(), init())` returns zero fouls. The initial state must always be legal.                                                                        |
 
 ### Input generation
 
@@ -50,9 +50,9 @@ The probe value set is `[null, undefined, '', 'a', 0, 1, true, false]`.
 
 ```typescript
 type MonkeyTestOptions = {
-  samples?: number           // random sample count for large forms (default: 1000)
-  seed?: number              // PRNG seed (default: 42)
-  conditions?: Record<string, unknown>[]  // condition snapshots to probe (default: [{}])
+  samples?: number // random sample count for large forms (default: 1000)
+  seed?: number // PRNG seed (default: 42)
+  conditions?: Record<string, unknown>[] // condition snapshots to probe (default: [{}])
   maxFoulIterations?: number // convergence limit (default: 10)
 }
 ```
@@ -67,7 +67,13 @@ type MonkeyTestResult = {
 }
 
 type MonkeyTestViolation = {
-  invariant: 'determinism' | 'self-play' | 'foul-convergence' | 'challenge-check-agreement' | 'disabled-field-immunity' | 'init-clean'
+  invariant:
+    | 'determinism'
+    | 'self-play'
+    | 'foul-convergence'
+    | 'challenge-check-agreement'
+    | 'disabled-field-immunity'
+    | 'init-clean'
   values: Record<string, unknown>
   conditions?: Record<string, unknown>
   description: string
@@ -82,10 +88,7 @@ If your umpire uses conditions, pass representative snapshots so they're include
 
 ```typescript
 monkeyTest(ump, {
-  conditions: [
-    { role: 'admin' },
-    { role: 'viewer' },
-  ],
+  conditions: [{ role: 'admin' }, { role: 'viewer' }],
 })
 ```
 

--- a/packages/testing/__tests__/baseball-examples.test.ts
+++ b/packages/testing/__tests__/baseball-examples.test.ts
@@ -62,9 +62,13 @@ describe('baseball-flavored monkeyTest examples', () => {
         infieldWork: { default: '' },
       },
       rules: [
-        enabledWhen('tarpOnField', (_values, conditions) => conditions.weather === 'rain', {
-          reason: 'The tarp only matters during a rain delay',
-        }),
+        enabledWhen(
+          'tarpOnField',
+          (_values, conditions) => conditions.weather === 'rain',
+          {
+            reason: 'The tarp only matters during a rain delay',
+          },
+        ),
         disables('tarpOnField', ['battingPractice', 'infieldWork'], {
           reason: 'Pregame field work stops while the tarp is out',
         }),
@@ -88,12 +92,11 @@ describe('baseball-flavored monkeyTest examples', () => {
     // hand-authored assertions. This version is intentionally small and keeps
     // `tarpOnField` as a direct override only, so the sample stays focused on
     // the condition sweep rather than on deeper dependency chains.
-    expect(monkeyTest(ump, {
-      conditions: [
-        { weather: 'clear' },
-        { weather: 'rain' },
-      ],
-    })).toEqual({
+    expect(
+      monkeyTest(ump, {
+        conditions: [{ weather: 'clear' }, { weather: 'rain' }],
+      }),
+    ).toEqual({
       passed: true,
       violations: [],
       samplesChecked: 1024,

--- a/packages/testing/__tests__/monkey.test.ts
+++ b/packages/testing/__tests__/monkey.test.ts
@@ -2,18 +2,23 @@ import { enabledWhen, requires, umpire } from '@umpire/core'
 import { createReads, enabledWhenRead, fairWhenRead } from '@umpire/reads'
 import { monkeyTest } from '../src/index.js'
 
-const createAvailability = (fieldNames: string[], resolve: (field: string) => { enabled: boolean; fair: boolean }) =>
-  Object.fromEntries(fieldNames.map((field) => {
-    const status = resolve(field)
+const createAvailability = (
+  fieldNames: string[],
+  resolve: (field: string) => { enabled: boolean; fair: boolean },
+) =>
+  Object.fromEntries(
+    fieldNames.map((field) => {
+      const status = resolve(field)
 
-    return [
-      field,
-      {
-        enabled: status.enabled,
-        fair: status.fair,
-      },
-    ]
-  }))
+      return [
+        field,
+        {
+          enabled: status.enabled,
+          fair: status.fair,
+        },
+      ]
+    }),
+  )
 
 const createChallenge = (field: string, enabled: boolean, fair: boolean) => ({
   field,
@@ -51,8 +56,10 @@ describe('monkeyTest', () => {
 
   test('passes a stable umpire with reads-backed rules', () => {
     const reads = createReads({
-      motherboardFair: ({ input }) => !input.motherboard || input.cpu === input.motherboard,
-      canSubmit: ({ input }) => Boolean(input.cpu) && Boolean(input.motherboard),
+      motherboardFair: ({ input }) =>
+        !input.motherboard || input.cpu === input.motherboard,
+      canSubmit: ({ input }) =>
+        Boolean(input.cpu) && Boolean(input.motherboard),
     })
 
     const ump = umpire({
@@ -86,19 +93,27 @@ describe('monkeyTest', () => {
         unstable: {},
       },
       rules: [
-        enabledWhen('unstable', () => {
-          flip = !flip
-          return flip
-        }, {
-          reason: 'Impure predicate',
-        }),
+        enabledWhen(
+          'unstable',
+          () => {
+            flip = !flip
+            return flip
+          },
+          {
+            reason: 'Impure predicate',
+          },
+        ),
       ],
     })
 
     const result = monkeyTest(ump)
 
     expect(result.passed).toBe(false)
-    expect(result.violations.some((violation) => violation.invariant === 'determinism')).toBe(true)
+    expect(
+      result.violations.some(
+        (violation) => violation.invariant === 'determinism',
+      ),
+    ).toBe(true)
   })
 
   test('returns the expected result shape and random-sampling count', () => {
@@ -157,17 +172,25 @@ describe('monkeyTest', () => {
     const result = monkeyTest(ump)
 
     expect(result.passed).toBe(false)
-    expect(result.violations.map((violation) => violation.invariant)).toEqual(expect.arrayContaining([
-      'init-clean',
-      'self-play',
-      'foul-convergence',
-      'challenge-check-agreement',
-      'disabled-field-immunity',
-    ]))
-    expect(result.violations.some((violation) =>
-      violation.description.includes('to null'))).toBe(true)
-    expect(result.violations.some((violation) =>
-      violation.description.includes('to undefined'))).toBe(true)
+    expect(result.violations.map((violation) => violation.invariant)).toEqual(
+      expect.arrayContaining([
+        'init-clean',
+        'self-play',
+        'foul-convergence',
+        'challenge-check-agreement',
+        'disabled-field-immunity',
+      ]),
+    )
+    expect(
+      result.violations.some((violation) =>
+        violation.description.includes('to null'),
+      ),
+    ).toBe(true)
+    expect(
+      result.violations.some((violation) =>
+        violation.description.includes('to undefined'),
+      ),
+    ).toBe(true)
   })
 
   test('stops after the first exhaustive sample once max violations are reached', () => {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -6,7 +6,10 @@ const DEFAULT_SAMPLE_COUNT = 1000
 const DEFAULT_SEED = 42
 const DEFAULT_MAX_FOUL_ITERATIONS = 10
 
-export type AnyUmpire = Umpire<Record<string, FieldDef>, Record<string, unknown>>
+export type AnyUmpire = Umpire<
+  Record<string, FieldDef>,
+  Record<string, unknown>
+>
 
 export type MonkeyTestViolation = {
   invariant:
@@ -77,7 +80,10 @@ function describeValue(value: unknown) {
   return JSON.stringify(value)
 }
 
-function buildUpstreamByField(fieldNames: string[], edges: Array<{ from: string; to: string }>) {
+function buildUpstreamByField(
+  fieldNames: string[],
+  edges: Array<{ from: string; to: string }>,
+) {
   const upstreamByField = new Map<string, Set<string>>(
     fieldNames.map((field) => [field, new Set<string>()]),
   )
@@ -117,7 +123,11 @@ function forEachSampleValueSet(
   if (fieldNames.length <= 6) {
     const totalCombinations = VALUE_PROBES.length ** fieldNames.length
 
-    for (let sampleIndex = 0; sampleIndex < totalCombinations; sampleIndex += 1) {
+    for (
+      let sampleIndex = 0;
+      sampleIndex < totalCombinations;
+      sampleIndex += 1
+    ) {
       let cursor = sampleIndex
       const values: Record<string, unknown> = {}
 
@@ -134,7 +144,10 @@ function forEachSampleValueSet(
     return
   }
 
-  const sampleCount = Math.max(0, Math.floor(options?.samples ?? DEFAULT_SAMPLE_COUNT))
+  const sampleCount = Math.max(
+    0,
+    Math.floor(options?.samples ?? DEFAULT_SAMPLE_COUNT),
+  )
   const random = mulberry32(options?.seed ?? DEFAULT_SEED)
 
   for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
@@ -160,15 +173,18 @@ function getConditionSets(options: MonkeyTestOptions | undefined) {
 export function monkeyTest<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(
-  ump: Umpire<F, C>,
-  options?: MonkeyTestOptions,
-): MonkeyTestResult
-export function monkeyTest(ump: AnyUmpire, options: MonkeyTestOptions = {}): MonkeyTestResult {
+>(ump: Umpire<F, C>, options?: MonkeyTestOptions): MonkeyTestResult
+export function monkeyTest(
+  ump: AnyUmpire,
+  options: MonkeyTestOptions = {},
+): MonkeyTestResult {
   const graph = ump.graph()
   const fieldNames = [...graph.nodes]
   const upstreamByField = buildUpstreamByField(fieldNames, graph.edges)
-  const maxFoulIterations = Math.max(1, Math.floor(options.maxFoulIterations ?? DEFAULT_MAX_FOUL_ITERATIONS))
+  const maxFoulIterations = Math.max(
+    1,
+    Math.floor(options.maxFoulIterations ?? DEFAULT_MAX_FOUL_ITERATIONS),
+  )
   const conditionsList = getConditionSets(options)
   const violations: MonkeyTestViolation[] = []
   let samplesChecked = 0
@@ -278,7 +294,10 @@ export function monkeyTest(ump: AnyUmpire, options: MonkeyTestOptions = {}): Mon
 
       for (const field of fieldNames) {
         const trace = ump.challenge(field, values, conditions)
-        if (trace.enabled !== firstCheck[field].enabled || trace.fair !== firstCheck[field].fair) {
+        if (
+          trace.enabled !== firstCheck[field].enabled ||
+          trace.fair !== firstCheck[field].fair
+        ) {
           if (
             recordViolation(
               'challenge-check-agreement',

--- a/packages/vuex/__tests__/fromVuexStore.test.ts
+++ b/packages/vuex/__tests__/fromVuexStore.test.ts
@@ -3,7 +3,9 @@ import { enabledWhen, requires, umpire } from '@umpire/core'
 import { fromVuexStore } from '../src/index.js'
 
 const fields = {
-  username: { isEmpty: (v: unknown) => v === '' || v === undefined || v === null },
+  username: {
+    isEmpty: (v: unknown) => v === '' || v === undefined || v === null,
+  },
   password: {},
   confirmPassword: { default: '' },
   inviteCode: { default: '' },
@@ -102,9 +104,12 @@ describe('fromVuexStore', () => {
     type ConditionFields = typeof conditionFields
 
     const conditionRules = [
-      enabledWhen<ConditionFields, Conditions>('inviteCode', (_values, conditions) => {
-        return conditions.requireInvite
-      }),
+      enabledWhen<ConditionFields, Conditions>(
+        'inviteCode',
+        (_values, conditions) => {
+          return conditions.requireInvite
+        },
+      ),
     ]
 
     const store = createFormStore()
@@ -155,7 +160,10 @@ describe('fromVuexStore', () => {
       fields: nestedFields,
       rules: [
         enabledWhen('note', (values) => {
-          return (values.settings as { allowNote: boolean } | undefined)?.allowNote === true
+          return (
+            (values.settings as { allowNote: boolean } | undefined)
+              ?.allowNote === true
+          )
         }),
       ],
     })

--- a/packages/vuex/src/index.ts
+++ b/packages/vuex/src/index.ts
@@ -22,17 +22,18 @@ export function fromVuexStore<
 ): UmpireStore<F> {
   const previousState = trackPreviousState(store.state)
 
-  return fromStore(ump, {
-    getState: () => store.state,
-    subscribe(listener) {
-      return store.subscribe((_mutation, nextState) => {
-        listener(nextState, previousState.next(nextState))
-      })
+  return fromStore(
+    ump,
+    {
+      getState: () => store.state,
+      subscribe(listener) {
+        return store.subscribe((_mutation, nextState) => {
+          listener(nextState, previousState.next(nextState))
+        })
+      },
     },
-  }, options)
+    options,
+  )
 }
 
-export type {
-  FromStoreOptions,
-  UmpireStore,
-} from '@umpire/store'
+export type { FromStoreOptions, UmpireStore } from '@umpire/store'

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -17,12 +17,17 @@ npm install @umpire/core @umpire/zod zod
 ```ts
 import { z } from 'zod'
 import { umpire, enabledWhen, requires } from '@umpire/core'
-import { createZodAdapter, deriveErrors, deriveSchema, zodErrors } from '@umpire/zod'
+import {
+  createZodAdapter,
+  deriveErrors,
+  deriveSchema,
+  zodErrors,
+} from '@umpire/zod'
 
 // 1. Define availability rules
 const ump = umpire({
   fields: {
-    email:       { required: true, isEmpty: (v) => !v },
+    email: { required: true, isEmpty: (v) => !v },
     companyName: { required: true, isEmpty: (v) => !v },
   },
   rules: [
@@ -56,7 +61,7 @@ const validation = createZodAdapter({
 
 const umpWithValidation = umpire({
   fields: {
-    email:       { required: true, isEmpty: (v) => !v },
+    email: { required: true, isEmpty: (v) => !v },
     companyName: { required: true, isEmpty: (v) => !v },
   },
   rules: [
@@ -73,6 +78,7 @@ const umpWithValidation = umpire({
 ### `deriveSchema(availability, schemas)`
 
 Builds a `z.object()` from the availability map:
+
 - **Disabled fields** are excluded entirely
 - **Enabled + required** fields use the base schema
 - **Enabled + optional** fields get `.optional()`
@@ -92,6 +98,7 @@ Normalizes a Zod error's `issues` array into `{ field, message }[]` pairs for us
 ### `createZodAdapter({ schemas, build? })`
 
 Creates a convenience adapter with:
+
 - `validators` for `umpire({ validators })`, surfacing the first field-level Zod issue as `error`
 - `run(availability, values)` for the full `deriveSchema() -> safeParse() -> deriveErrors()` flow
 
@@ -139,7 +146,10 @@ const validation = createZodAdapter({
   schemas: fieldSchemas,
   build(baseSchema) {
     return baseSchema.refine(
-      (data) => !data.confirmPassword || !data.password || data.confirmPassword === data.password,
+      (data) =>
+        !data.confirmPassword ||
+        !data.password ||
+        data.confirmPassword === data.password,
       { message: 'Passwords do not match', path: ['confirmPassword'] },
     )
   },
@@ -159,6 +169,7 @@ const { check } = useUmpireWithDevtools('signup', ump, values, conditions, {
 If you already have a precomputed parse result, the helper also accepts `availability`, `result`, and optional `schemaFields` directly.
 
 The first pass shows:
+
 - valid/invalid
 - surfaced error count
 - suppressed and unmapped issue counts
@@ -172,18 +183,20 @@ It does not currently detect skipped `refine()`/`superRefine()` execution on its
 The payoff — one loop renders every field regardless of availability, validation, or fouls:
 
 ```tsx
-{fields.map((field) => {
-  const av = availability[field]
-  const error = validationErrors[field]
+{
+  fields.map((field) => {
+    const av = availability[field]
+    const error = validationErrors[field]
 
-  return (
-    <div className={av.enabled ? '' : 'disabled'}>
-      <input disabled={!av.enabled} value={values[field]} />
-      {!av.enabled && <span>{av.reason}</span>}
-      {av.enabled && error && <span className="error">{error}</span>}
-    </div>
-  )
-})}
+    return (
+      <div className={av.enabled ? '' : 'disabled'}>
+        <input disabled={!av.enabled} value={values[field]} />
+        {!av.enabled && <span>{av.reason}</span>}
+        {av.enabled && error && <span className="error">{error}</span>}
+      </div>
+    )
+  })
+}
 ```
 
 No per-field branching. No `if (field === 'companyName' && plan === 'business')`. The rules and schemas declare everything upfront. The render loop just reads.

--- a/packages/zod/__tests__/adapter.test.ts
+++ b/packages/zod/__tests__/adapter.test.ts
@@ -53,9 +53,13 @@ describe('createZodAdapter', () => {
     const ump = umpire<typeof fields, { plan: 'personal' | 'business' }>({
       fields,
       rules: [
-        enabledWhen('companyName', (_values, conditions) => conditions.plan === 'business', {
-          reason: 'business plan required',
-        }),
+        enabledWhen(
+          'companyName',
+          (_values, conditions) => conditions.plan === 'business',
+          {
+            reason: 'business plan required',
+          },
+        ),
       ],
     })
 
@@ -68,7 +72,11 @@ describe('createZodAdapter', () => {
     const availability = ump.check(values, { plan: 'personal' })
     const result = validation.run(availability, values)
 
-    expect(result.schemaFields).toEqual(['email', 'password', 'confirmPassword'])
+    expect(result.schemaFields).toEqual([
+      'email',
+      'password',
+      'confirmPassword',
+    ])
     expect(result.errors).toEqual({
       confirmPassword: 'Passwords do not match',
     })
@@ -79,20 +87,24 @@ describe('createZodAdapter', () => {
   })
 
   test('throws if given a z.object instead of per-field schemas', () => {
-    expect(() => createZodAdapter({
-      schemas: z.object({
-        email: z.string().email(),
-      }) as never,
-    })).toThrow(
+    expect(() =>
+      createZodAdapter({
+        schemas: z.object({
+          email: z.string().email(),
+        }) as never,
+      }),
+    ).toThrow(
       'createZodAdapter() expects per-field schemas, not a z.object(). ' +
-      'Pass formSchema.shape instead of formSchema.',
+        'Pass formSchema.shape instead of formSchema.',
     )
   })
 
   test('throws if given a non-object instead of per-field schemas', () => {
-    expect(() => createZodAdapter({
-      schemas: undefined as never,
-    })).toThrow('createZodAdapter() expects a per-field schema map object.')
+    expect(() =>
+      createZodAdapter({
+        schemas: undefined as never,
+      }),
+    ).toThrow('createZodAdapter() expects a per-field schema map object.')
   })
 
   test('rejects foul field values when rejectFoul is true', () => {
@@ -114,20 +126,33 @@ describe('createZodAdapter', () => {
       rules: [
         fairWhen(
           'vehicleType',
-          (value, values) => value === values.spotType || values.spotType === 'standard',
+          (value, values) =>
+            value === values.spotType || values.spotType === 'standard',
           { reason: 'Vehicle type does not match the reserved spot' },
         ),
       ],
     })
 
     // Electric vehicle in an electric spot — fair, passes
-    const fairAvailability = ump.check({ spotType: 'electric', vehicleType: 'electric' })
-    const fairResult = validation.run(fairAvailability, { spotType: 'electric', vehicleType: 'electric' })
+    const fairAvailability = ump.check({
+      spotType: 'electric',
+      vehicleType: 'electric',
+    })
+    const fairResult = validation.run(fairAvailability, {
+      spotType: 'electric',
+      vehicleType: 'electric',
+    })
     expect(fairResult.result.success).toBe(true)
 
     // Gas vehicle in an electric spot — foul, rejected with reason as error
-    const foulAvailability = ump.check({ spotType: 'electric', vehicleType: 'gas' })
-    const foulResult = validation.run(foulAvailability, { spotType: 'electric', vehicleType: 'gas' })
+    const foulAvailability = ump.check({
+      spotType: 'electric',
+      vehicleType: 'gas',
+    })
+    const foulResult = validation.run(foulAvailability, {
+      spotType: 'electric',
+      vehicleType: 'gas',
+    })
     expect(foulResult.result.success).toBe(false)
     expect(foulResult.errors).toEqual({
       vehicleType: 'Vehicle type does not match the reserved spot',

--- a/packages/zod/__tests__/derive-schema.test.ts
+++ b/packages/zod/__tests__/derive-schema.test.ts
@@ -45,37 +45,28 @@ function createAvailability(
 
 describe('deriveSchema', () => {
   test('omits disabled fields from the schema', () => {
-    const schema = deriveSchema(
-      createAvailability(),
-      {
-        requiredName: z.string(),
-        disabledSecret: z.string(),
-      },
-    )
+    const schema = deriveSchema(createAvailability(), {
+      requiredName: z.string(),
+      disabledSecret: z.string(),
+    })
 
     expect(Object.keys(schema.shape)).toEqual(['requiredName'])
     expect(schema.shape.disabledSecret).toBeUndefined()
   })
 
   test('keeps enabled required fields required', () => {
-    const schema = deriveSchema(
-      createAvailability(),
-      {
-        requiredName: z.string(),
-      },
-    )
+    const schema = deriveSchema(createAvailability(), {
+      requiredName: z.string(),
+    })
 
     expect(schema.safeParse({}).success).toBe(false)
     expect(schema.safeParse({ requiredName: 'Douglas' }).success).toBe(true)
   })
 
   test('makes enabled non-required fields optional', () => {
-    const schema = deriveSchema(
-      createAvailability(),
-      {
-        optionalNickname: z.string(),
-      },
-    )
+    const schema = deriveSchema(createAvailability(), {
+      optionalNickname: z.string(),
+    })
 
     expect(schema.safeParse({}).success).toBe(true)
     expect(schema.safeParse({ optionalNickname: 'Doug' }).success).toBe(true)
@@ -89,26 +80,25 @@ describe('deriveSchema', () => {
   })
 
   test('skips enabled fields that do not have a matching schema', () => {
-    const schema = deriveSchema(
-      createAvailability(),
-      {
-        requiredName: z.string(),
-      },
-    )
+    const schema = deriveSchema(createAvailability(), {
+      requiredName: z.string(),
+    })
 
     expect(schema.shape.missingSchema).toBeUndefined()
     expect(Object.keys(schema.shape)).toEqual(['requiredName'])
   })
 
   test('throws if given a z.object instead of per-field schemas', () => {
-    expect(() => deriveSchema(
-      createAvailability(),
-      z.object({
-        requiredName: z.string(),
-      }) as never,
-    )).toThrow(
+    expect(() =>
+      deriveSchema(
+        createAvailability(),
+        z.object({
+          requiredName: z.string(),
+        }) as never,
+      ),
+    ).toThrow(
       'deriveSchema() expects per-field schemas, not a z.object(). ' +
-      'Pass formSchema.shape instead of formSchema.',
+        'Pass formSchema.shape instead of formSchema.',
     )
   })
 })

--- a/packages/zod/__tests__/devtools.test.ts
+++ b/packages/zod/__tests__/devtools.test.ts
@@ -47,15 +47,17 @@ const demoUmp = umpire({
 
 describe('zodValidationExtension', () => {
   test('summarizes surfaced, suppressed, and unmapped issues from a safeParse result', () => {
-    const result = z.object({
-      email: z.string().email('Enter a valid email'),
-      companyName: z.string().min(1, 'Company name is required'),
-      companySize: z.string().min(1, 'Company size is required'),
-    }).safeParse({
-      email: 'nope',
-      companyName: '',
-      companySize: '',
-    })
+    const result = z
+      .object({
+        email: z.string().email('Enter a valid email'),
+        companyName: z.string().min(1, 'Company name is required'),
+        companySize: z.string().min(1, 'Company size is required'),
+      })
+      .safeParse({
+        email: 'nope',
+        companyName: '',
+        companySize: '',
+      })
 
     if (result.success) {
       throw new Error('Expected parse to fail')
@@ -112,15 +114,18 @@ describe('zodValidationExtension', () => {
     expect(view?.sections).toContainEqual({
       kind: 'items',
       title: 'Suppressed Issues',
-      items: [{
-        id: 'companyName:0',
-        title: 'companyName',
-        badge: { tone: 'muted', value: 'disabled' },
-        body: 'Company name is required',
-        rows: [{ label: 'availability reason', value: 'business plan required' }],
-      }],
+      items: [
+        {
+          id: 'companyName:0',
+          title: 'companyName',
+          badge: { tone: 'muted', value: 'disabled' },
+          body: 'Company name is required',
+          rows: [
+            { label: 'availability reason', value: 'business plan required' },
+          ],
+        },
+      ],
     })
-
   })
 
   test('labels form-level issues as unmapped', () => {
@@ -129,10 +134,12 @@ describe('zodValidationExtension', () => {
       result: {
         success: false,
         error: {
-          issues: [{
-            path: [],
-            message: 'Passwords do not match',
-          }],
+          issues: [
+            {
+              path: [],
+              message: 'Passwords do not match',
+            },
+          ],
         },
       },
     })
@@ -158,12 +165,14 @@ describe('zodValidationExtension', () => {
     expect(view?.sections).toContainEqual({
       kind: 'items',
       title: 'Unmapped Issues',
-      items: [{
-        id: ':0',
-        title: '(form)',
-        badge: { tone: 'fair', value: 'unmapped' },
-        body: 'Passwords do not match',
-      }],
+      items: [
+        {
+          id: ':0',
+          title: '(form)',
+          badge: { tone: 'fair', value: 'unmapped' },
+          body: 'Passwords do not match',
+        },
+      ],
     })
   })
 
@@ -210,7 +219,9 @@ describe('zodValidationExtension', () => {
       ]),
     })
 
-    expect(view?.sections.find((section) => section.title === 'Derived Error Map')).toBeUndefined()
+    expect(
+      view?.sections.find((section) => section.title === 'Derived Error Map'),
+    ).toBeUndefined()
     expect(view?.sections).toContainEqual({
       kind: 'rows',
       title: 'Derived Schema',
@@ -228,9 +239,13 @@ describe('zodValidationExtension', () => {
         companyName: { default: '' },
       },
       rules: [
-        enabledWhen('companyName', (_v, c: { plan: 'personal' | 'business' }) => c.plan === 'business', {
-          reason: 'business plan required',
-        }),
+        enabledWhen(
+          'companyName',
+          (_v, c: { plan: 'personal' | 'business' }) => c.plan === 'business',
+          {
+            reason: 'business plan required',
+          },
+        ),
       ],
     })
 
@@ -279,9 +294,7 @@ describe('zodValidationExtension', () => {
     expect(view?.sections).toContainEqual({
       kind: 'rows',
       title: 'Derived Error Map',
-      rows: [
-        { label: 'email', value: 'Enter a valid email' },
-      ],
+      rows: [{ label: 'email', value: 'Enter a valid email' }],
     })
 
     expect(view?.sections).toContainEqual({
@@ -335,10 +348,12 @@ describe('zodValidationExtension', () => {
       result: {
         success: false,
         error: {
-          issues: [{
-            path: ['companyName'],
-            message: 'Company name is required',
-          }],
+          issues: [
+            {
+              path: ['companyName'],
+              message: 'Company name is required',
+            },
+          ],
         },
       },
     })
@@ -364,13 +379,15 @@ describe('zodValidationExtension', () => {
     expect(view?.sections).toContainEqual({
       kind: 'items',
       title: 'Suppressed Issues',
-      items: [{
-        id: 'companyName:0',
-        title: 'companyName',
-        badge: { tone: 'muted', value: 'disabled' },
-        body: 'Company name is required',
-        rows: undefined,
-      }],
+      items: [
+        {
+          id: 'companyName:0',
+          title: 'companyName',
+          badge: { tone: 'muted', value: 'disabled' },
+          body: 'Company name is required',
+          rows: undefined,
+        },
+      ],
     })
   })
 })

--- a/packages/zod/__tests__/discriminated.test.ts
+++ b/packages/zod/__tests__/discriminated.test.ts
@@ -79,7 +79,7 @@ describe('deriveDiscriminatedFields', () => {
     })
 
     expect(Object.keys(fields).sort()).toEqual(
-      ['accountNumber', 'cardNumber', 'cvv', 'method', 'routingNumber'].sort()
+      ['accountNumber', 'cardNumber', 'cvv', 'method', 'routingNumber'].sort(),
     )
     expect(fields.method.required).toBe(true)
   })
@@ -234,9 +234,9 @@ describe('deriveDiscriminatedFields', () => {
       }),
     ])
 
-    expect(() => deriveDiscriminatedFields(schema, { groupName: 'overlap' })).toThrow(
-      'field "shared" appears in multiple branches'
-    )
+    expect(() =>
+      deriveDiscriminatedFields(schema, { groupName: 'overlap' }),
+    ).toThrow('field "shared" appears in multiple branches')
   })
 })
 
@@ -251,13 +251,21 @@ describe('zod v4 compatibility', () => {
       options: [
         {
           shape: {
-            method: { _def: { values: ['card'] }, value: 'card', isOptional: () => false },
+            method: {
+              _def: { values: ['card'] },
+              value: 'card',
+              isOptional: () => false,
+            },
             cardNumber: { isOptional: () => false },
           },
         },
         {
           shape: {
-            method: { _def: { values: ['bank'] }, value: 'bank', isOptional: () => false },
+            method: {
+              _def: { values: ['bank'] },
+              value: 'bank',
+              isOptional: () => false,
+            },
             routingNumber: { isOptional: () => false },
           },
         },
@@ -274,7 +282,11 @@ describe('zod v4 compatibility', () => {
     expect(fields.method).toEqual({ required: true })
     expect(fields.cardNumber).toEqual({ required: true })
     expect(fields.routingNumber).toEqual({ required: true })
-    expect(Object.keys(fields).sort()).toEqual(['cardNumber', 'method', 'routingNumber'])
+    expect(Object.keys(fields).sort()).toEqual([
+      'cardNumber',
+      'method',
+      'routingNumber',
+    ])
 
     // Verify the rule works end-to-end with umpire
     const u = umpire({

--- a/packages/zod/__tests__/discriminated.test.ts
+++ b/packages/zod/__tests__/discriminated.test.ts
@@ -79,7 +79,7 @@ describe('deriveDiscriminatedFields', () => {
     })
 
     expect(Object.keys(fields).sort()).toEqual(
-      ['accountNumber', 'cardNumber', 'cvv', 'method', 'routingNumber'].sort(),
+      ['accountNumber', 'cardNumber', 'cvv', 'method', 'routingNumber'].sort()
     )
     expect(fields.method.required).toBe(true)
   })
@@ -234,9 +234,9 @@ describe('deriveDiscriminatedFields', () => {
       }),
     ])
 
-    expect(() =>
-      deriveDiscriminatedFields(schema, { groupName: 'overlap' }),
-    ).toThrow('field "shared" appears in multiple branches')
+    expect(() => deriveDiscriminatedFields(schema, { groupName: 'overlap' })).toThrow(
+      'field "shared" appears in multiple branches'
+    )
   })
 })
 
@@ -265,6 +265,8 @@ describe('zod v4 compatibility', () => {
     }
 
     // deriveDiscriminatedFields exercises extractBranches internally
+    // it's not worth the effort to fully type this mock, so using `any` escape hatch
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { fields, rule } = deriveDiscriminatedFields(v4LikeSchema as any, {
       groupName: 'v4test',
     })
@@ -313,6 +315,8 @@ describe('zod v4 compatibility', () => {
       ],
     }
 
+    // it's not worth the effort to fully type this mock, so using `any` escape hatch
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { fields } = deriveDiscriminatedFields(v3LikeSchema as any, {
       groupName: 'v3test',
     })

--- a/packages/zod/src/adapter.ts
+++ b/packages/zod/src/adapter.ts
@@ -6,10 +6,18 @@ import type {
 } from '@umpire/core'
 import { isRecord } from '@umpire/core/guards'
 import type { z } from 'zod'
-import { deriveErrors, zodErrors, type NormalizedFieldError } from './derive-errors.js'
+import {
+  deriveErrors,
+  zodErrors,
+  type NormalizedFieldError,
+} from './derive-errors.js'
 import { deriveSchema, type DeriveSchemaOptions } from './derive-schema.js'
 import { assertFieldSchemas } from './schema-guards.js'
-import type { ZodSafeParseResultLike, ZodSchemaLike, ZodErrorLike } from './zod-types.js'
+import type {
+  ZodSafeParseResultLike,
+  ZodSchemaLike,
+  ZodErrorLike,
+} from './zod-types.js'
 
 type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
   Record<keyof F & string, z.ZodTypeAny>
@@ -39,11 +47,15 @@ function firstIssueMessage(error: ZodErrorLike): string | undefined {
   return error.issues[0]?.message
 }
 
-function isFailedParseResult(result: unknown): result is Extract<ZodSafeParseResultLike, { success: false }> {
-  return isRecord(result) &&
+function isFailedParseResult(
+  result: unknown,
+): result is Extract<ZodSafeParseResultLike, { success: false }> {
+  return (
+    isRecord(result) &&
     result.success === false &&
     isRecord(result.error) &&
     Array.isArray(result.error.issues)
+  )
 }
 
 export function createZodAdapter<F extends Record<string, FieldDef>>(
@@ -51,14 +63,12 @@ export function createZodAdapter<F extends Record<string, FieldDef>>(
 ): ZodAdapter<F> {
   assertFieldSchemas(options.schemas, 'createZodAdapter')
 
-  const {
-    schemas,
-    build,
-    rejectFoul,
-  } = options
+  const { schemas, build, rejectFoul } = options
   const validators = {} as ValidationMap<F>
 
-  for (const [field, schema] of Object.entries(schemas) as Array<[keyof F & string, z.ZodTypeAny | undefined]>) {
+  for (const [field, schema] of Object.entries(schemas) as Array<
+    [keyof F & string, z.ZodTypeAny | undefined]
+  >) {
     if (!schema) {
       continue
     }
@@ -72,9 +82,7 @@ export function createZodAdapter<F extends Record<string, FieldDef>>(
 
       const error = firstIssueMessage(result.error)
 
-      return error === undefined
-        ? { valid: false }
-        : { valid: false, error }
+      return error === undefined ? { valid: false } : { valid: false, error }
     }
   }
 
@@ -84,7 +92,9 @@ export function createZodAdapter<F extends Record<string, FieldDef>>(
       const baseSchema = deriveSchema(availability, schemas, { rejectFoul })
       const schema = build ? build(baseSchema) : baseSchema
       const result = schema.safeParse(values)
-      const normalizedErrors = isFailedParseResult(result) ? zodErrors(result.error) : []
+      const normalizedErrors = isFailedParseResult(result)
+        ? zodErrors(result.error)
+        : []
 
       return {
         errors: deriveErrors(availability, normalizedErrors),

--- a/packages/zod/src/derive-schema.ts
+++ b/packages/zod/src/derive-schema.ts
@@ -59,7 +59,8 @@ export function deriveSchema<F extends Record<string, FieldDef>>(
     }
 
     if (rejectFoul && !status.fair) {
-      const message = status.reason ?? 'Value is not valid for the current context'
+      const message =
+        status.reason ?? 'Value is not valid for the current context'
       const refined = base.refine(() => false, { message })
       shape[field] = status.required ? refined : refined.optional()
       continue

--- a/packages/zod/src/devtools.ts
+++ b/packages/zod/src/devtools.ts
@@ -1,7 +1,4 @@
-import type {
-  AvailabilityMap,
-  FieldDef,
-} from '@umpire/core'
+import type { AvailabilityMap, FieldDef } from '@umpire/core'
 import type {
   DevtoolsExtension,
   DevtoolsExtensionInspectContext,
@@ -46,9 +43,7 @@ type ZodValidationStaticOptions<
 export type ZodValidationExtensionOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
-> =
-  | ZodValidationResolveOptions<F, C>
-  | ZodValidationStaticOptions<F, C>
+> = ZodValidationResolveOptions<F, C> | ZodValidationStaticOptions<F, C>
 
 function issueFieldLabel(field: string) {
   return field === '' ? '(form)' : field
@@ -62,7 +57,9 @@ function sectionRows<F extends Record<string, FieldDef>>(
     const state = availability[issue.field as keyof F & string]
     return state !== undefined && !state.enabled
   })
-  const unknownIssues = issues.filter((issue) => availability[issue.field as keyof F & string] === undefined)
+  const unknownIssues = issues.filter(
+    (issue) => availability[issue.field as keyof F & string] === undefined,
+  )
 
   return {
     suppressedIssues,
@@ -82,59 +79,60 @@ function hasResolve<
 export function zodValidationExtension<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
->(
-  options: ZodValidationExtensionOptions<F, C>,
-): DevtoolsExtension<F, C> {
-  const {
-    id = 'validation',
-    label = 'validation',
-  } = options
+>(options: ZodValidationExtensionOptions<F, C>): DevtoolsExtension<F, C> {
+  const { id = 'validation', label = 'validation' } = options
 
   return {
     id,
     label,
     inspect(context) {
-      const resolved = hasResolve(options)
-        ? options.resolve(context)
-        : options
+      const resolved = hasResolve(options) ? options.resolve(context) : options
 
       if (!resolved) {
         return null
       }
 
       const availability = resolved.availability ?? context.scorecard.check
-      const normalizedErrors = resolved.normalizedErrors ??
+      const normalizedErrors =
+        resolved.normalizedErrors ??
         (resolved.result.success ? [] : zodErrors(resolved.result.error))
       const derivedErrorMap = deriveErrors(availability, normalizedErrors)
-      const enabledFieldCount = Object.values(availability).filter((field) => field.enabled).length
+      const enabledFieldCount = Object.values(availability).filter(
+        (field) => field.enabled,
+      ).length
       const derivedErrorCount = Object.keys(derivedErrorMap).length
-      const { suppressedIssues, unknownIssues } = sectionRows(availability, normalizedErrors)
-      const sections: DevtoolsExtensionSection[] = [{
-        kind: 'badges',
-        title: 'Summary',
-        badges: [
-          {
-            tone: resolved.result.success ? 'enabled' : 'disabled',
-            value: resolved.result.success ? 'valid' : 'invalid',
-          },
-          {
-            tone: 'accent',
-            value: `errors ${derivedErrorCount}`,
-          },
-          {
-            tone: 'muted',
-            value: `suppressed ${suppressedIssues.length}`,
-          },
-          {
-            tone: 'fair',
-            value: `unmapped ${unknownIssues.length}`,
-          },
-          {
-            tone: 'fair',
-            value: `fields ${enabledFieldCount}`,
-          },
-        ],
-      }]
+      const { suppressedIssues, unknownIssues } = sectionRows(
+        availability,
+        normalizedErrors,
+      )
+      const sections: DevtoolsExtensionSection[] = [
+        {
+          kind: 'badges',
+          title: 'Summary',
+          badges: [
+            {
+              tone: resolved.result.success ? 'enabled' : 'disabled',
+              value: resolved.result.success ? 'valid' : 'invalid',
+            },
+            {
+              tone: 'accent',
+              value: `errors ${derivedErrorCount}`,
+            },
+            {
+              tone: 'muted',
+              value: `suppressed ${suppressedIssues.length}`,
+            },
+            {
+              tone: 'fair',
+              value: `unmapped ${unknownIssues.length}`,
+            },
+            {
+              tone: 'fair',
+              value: `fields ${enabledFieldCount}`,
+            },
+          ],
+        },
+      ]
 
       if (Object.keys(derivedErrorMap).length > 0) {
         sections.push({

--- a/packages/zod/src/discriminated.ts
+++ b/packages/zod/src/discriminated.ts
@@ -21,7 +21,7 @@ function extractBranches(
     exclude?: string[]
     branchNames?: Record<string, string>
     forceRequired?: boolean
-  } = {}
+  } = {},
 ): ExtractedBranches {
   const discriminator: string =
     'discriminator' in schema
@@ -46,7 +46,7 @@ function extractBranches(
     if (rawValue == null) {
       throw new Error(
         `[@umpire/zod] Could not extract literal value from discriminator field "${discriminator}". ` +
-          `Expected a ZodLiteral with ._def.value (v3) or .value (v4).`
+          `Expected a ZodLiteral with ._def.value (v3) or .value (v4).`,
       )
     }
     const branchName = options.branchNames?.[rawValue] ?? rawValue
@@ -78,7 +78,7 @@ export function deriveOneOf<
   C extends Record<string, unknown> = Record<string, unknown>,
 >(
   schema: z.ZodDiscriminatedUnion<string, DiscriminatedUnionOption[]>,
-  options: DeriveOptions
+  options: DeriveOptions,
 ): Rule<F, C> {
   const { discriminator, branches } = extractBranches(schema, options)
   const branchNames = options.branchNames
@@ -98,7 +98,7 @@ export function deriveDiscriminatedFields<
   T extends z.ZodDiscriminatedUnion<string, DiscriminatedUnionOption[]>,
 >(
   schema: T,
-  options: DeriveOptions & { required?: boolean }
+  options: DeriveOptions & { required?: boolean },
 ): {
   fields: Record<string, FieldDef>
   rule: Rule<Record<string, FieldDef>, Record<string, unknown>>
@@ -113,7 +113,10 @@ export function deriveDiscriminatedFields<
     fields: fieldDefs,
     rule: oneOf(options.groupName, branches, {
       activeBranch: (values) => {
-        const raw = values[discriminator as keyof typeof values] as string | null | undefined
+        const raw = values[discriminator as keyof typeof values] as
+          | string
+          | null
+          | undefined
         if (raw == null) return null
         return branchNames?.[raw] ?? raw
       },

--- a/packages/zod/src/discriminated.ts
+++ b/packages/zod/src/discriminated.ts
@@ -21,12 +21,14 @@ function extractBranches(
     exclude?: string[]
     branchNames?: Record<string, string>
     forceRequired?: boolean
-  } = {},
+  } = {}
 ): ExtractedBranches {
   const discriminator: string =
     'discriminator' in schema
-      ? (schema as any).discriminator
-      : (schema as any)._zod.def.discriminator
+      ? schema.discriminator
+      : // i've explored the alternative and it's a big mess, this is just a compat thing
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (schema as any)._zod.def.discriminator
   const excludeSet = new Set([discriminator, ...(options.exclude ?? [])])
 
   const branches: Record<string, string[]> = {}
@@ -37,12 +39,14 @@ function extractBranches(
 
   for (const variant of schema.options) {
     const shape = variant.shape
+    // zod uses `any` internally here so we're just cheating like them
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const literalField = shape[discriminator] as any
     const rawValue: string = literalField._def?.value ?? literalField.value
     if (rawValue == null) {
       throw new Error(
         `[@umpire/zod] Could not extract literal value from discriminator field "${discriminator}". ` +
-          `Expected a ZodLiteral with ._def.value (v3) or .value (v4).`,
+          `Expected a ZodLiteral with ._def.value (v3) or .value (v4).`
       )
     }
     const branchName = options.branchNames?.[rawValue] ?? rawValue
@@ -74,7 +78,7 @@ export function deriveOneOf<
   C extends Record<string, unknown> = Record<string, unknown>,
 >(
   schema: z.ZodDiscriminatedUnion<string, DiscriminatedUnionOption[]>,
-  options: DeriveOptions,
+  options: DeriveOptions
 ): Rule<F, C> {
   const { discriminator, branches } = extractBranches(schema, options)
   const branchNames = options.branchNames
@@ -94,7 +98,7 @@ export function deriveDiscriminatedFields<
   T extends z.ZodDiscriminatedUnion<string, DiscriminatedUnionOption[]>,
 >(
   schema: T,
-  options: DeriveOptions & { required?: boolean },
+  options: DeriveOptions & { required?: boolean }
 ): {
   fields: Record<string, FieldDef>
   rule: Rule<Record<string, FieldDef>, Record<string, unknown>>

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -8,4 +8,8 @@ export type {
   ZodAdapter,
   ZodAdapterRunResult,
 } from './adapter.js'
-export { deriveOneOf, deriveDiscriminatedFields, type DeriveOptions } from './discriminated.js'
+export {
+  deriveOneOf,
+  deriveDiscriminatedFields,
+  type DeriveOptions,
+} from './discriminated.js'

--- a/packages/zod/src/schema-guards.ts
+++ b/packages/zod/src/schema-guards.ts
@@ -11,7 +11,7 @@ export function assertFieldSchemas(
   if (isZodObjectSchema(schemas)) {
     throw new Error(
       `[umpire/zod] ${caller}() expects per-field schemas, not a z.object(). ` +
-      'Pass formSchema.shape instead of formSchema.',
+        'Pass formSchema.shape instead of formSchema.',
     )
   }
 

--- a/packages/zustand/__tests__/index.test.ts
+++ b/packages/zustand/__tests__/index.test.ts
@@ -42,7 +42,9 @@ describe('@umpire/zustand', () => {
     store.setState({ password: '', confirmPassword: 'secret' })
 
     expect(availability.field('confirmPassword').enabled).toBe(false)
-    expect(availability.fouls.some((foul) => foul.field === 'confirmPassword')).toBe(true)
+    expect(
+      availability.fouls.some((foul) => foul.field === 'confirmPassword'),
+    ).toBe(true)
 
     availability.destroy()
   })

--- a/packages/zustand/src/index.ts
+++ b/packages/zustand/src/index.ts
@@ -1,6 +1,2 @@
 export { fromStore } from '@umpire/store'
-export type {
-  FromStoreOptions,
-  StoreApi,
-  UmpireStore,
-} from '@umpire/store'
+export type { FromStoreOptions, StoreApi, UmpireStore } from '@umpire/store'

--- a/scripts/materialize-agent-compat.mjs
+++ b/scripts/materialize-agent-compat.mjs
@@ -5,113 +5,125 @@ import {
   readlinkSync,
   rmSync,
   symlinkSync,
-  writeFileSync
-} from 'node:fs';
-import { dirname, join } from 'node:path';
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
 
 // ── Config ───────────────────────────────────────────────────────────────────
 // Folders (relative to the package root) where the AGENTS.md compat file
 // should be materialized during `npm pack`. Add more paths here to distribute
 // rules to additional agent runtimes (e.g. '.codex/rules', '.cursor/rules').
-const compatPaths = ['.claude/rules'];
+const compatPaths = ['.claude/rules']
 // ─────────────────────────────────────────────────────────────────────────────
 
-const action = process.argv[2];
+const action = process.argv[2]
 
 if (action !== 'prepack' && action !== 'postpack') {
-  throw new Error('Expected `prepack` or `postpack`.');
+  throw new Error('Expected `prepack` or `postpack`.')
 }
 
-const packageDir = process.cwd();
-const packageJson = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'));
-const agentsPath = join(packageDir, 'AGENTS.md');
-const compatFilename = `${packageJson.name.slice(1).replaceAll('/', '-')}.md`;
-const statePath = join(packageDir, '.pack-agent-compat-state.json');
+const packageDir = process.cwd()
+const packageJson = JSON.parse(
+  readFileSync(join(packageDir, 'package.json'), 'utf8'),
+)
+const agentsPath = join(packageDir, 'AGENTS.md')
+const compatFilename = `${packageJson.name.slice(1).replaceAll('/', '-')}.md`
+const statePath = join(packageDir, '.pack-agent-compat-state.json')
 
 function resolvedCompatPaths() {
-  return compatPaths.map(folder => join(packageDir, folder, compatFilename));
+  return compatPaths.map((folder) => join(packageDir, folder, compatFilename))
 }
 
 function captureCompatState(compatPath) {
   try {
-    const stat = lstatSync(compatPath);
+    const stat = lstatSync(compatPath)
 
     if (stat.isSymbolicLink()) {
       return {
         existed: true,
         type: 'symlink',
-        linkname: readlinkSync(compatPath)
-      };
+        linkname: readlinkSync(compatPath),
+      }
     }
 
     if (stat.isFile()) {
       return {
         existed: true,
         type: 'file',
-        content: readFileSync(compatPath, 'utf8')
-      };
+        content: readFileSync(compatPath, 'utf8'),
+      }
     }
 
-    throw new Error(`Unsupported compatibility file entry at ${compatPath}`);
+    throw new Error(`Unsupported compatibility file entry at ${compatPath}`)
   } catch (error) {
-    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
-      return { existed: false };
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return { existed: false }
     }
 
-    throw error;
+    throw error
   }
 }
 
 function restoreCompatState(compatPath, state) {
-  rmSync(compatPath, { force: true, recursive: true });
+  rmSync(compatPath, { force: true, recursive: true })
 
   if (state.existed) {
-    mkdirSync(dirname(compatPath), { recursive: true });
+    mkdirSync(dirname(compatPath), { recursive: true })
 
     if (state.type === 'symlink') {
-      symlinkSync(state.linkname, compatPath);
+      symlinkSync(state.linkname, compatPath)
     } else if (state.type === 'file') {
-      writeFileSync(compatPath, state.content);
+      writeFileSync(compatPath, state.content)
     } else {
-      throw new Error(`Unsupported compatibility file state for ${compatPath}`);
+      throw new Error(`Unsupported compatibility file state for ${compatPath}`)
     }
   }
 }
 
 function restoreAllFromStateFile() {
   try {
-    const savedState = JSON.parse(readFileSync(statePath, 'utf8'));
+    const savedState = JSON.parse(readFileSync(statePath, 'utf8'))
     for (const [path, state] of Object.entries(savedState)) {
-      restoreCompatState(path, state);
+      restoreCompatState(path, state)
     }
-    rmSync(statePath, { force: true });
+    rmSync(statePath, { force: true })
   } catch (error) {
-    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
-      return;
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return
     }
-    throw error;
+    throw error
   }
 }
 
 if (action === 'prepack') {
   // Clean up any stale state from an interrupted previous pack
-  restoreAllFromStateFile();
+  restoreAllFromStateFile()
 
-  const agents = readFileSync(agentsPath, 'utf8');
-  const paths = resolvedCompatPaths();
-  const savedState = {};
+  const agents = readFileSync(agentsPath, 'utf8')
+  const paths = resolvedCompatPaths()
+  const savedState = {}
 
   for (const compatPath of paths) {
-    savedState[compatPath] = captureCompatState(compatPath);
+    savedState[compatPath] = captureCompatState(compatPath)
   }
 
-  writeFileSync(statePath, JSON.stringify(savedState));
+  writeFileSync(statePath, JSON.stringify(savedState))
 
   for (const compatPath of paths) {
-    mkdirSync(dirname(compatPath), { recursive: true });
-    rmSync(compatPath, { force: true, recursive: true });
-    writeFileSync(compatPath, agents);
+    mkdirSync(dirname(compatPath), { recursive: true })
+    rmSync(compatPath, { force: true, recursive: true })
+    writeFileSync(compatPath, agents)
   }
 } else {
-  restoreAllFromStateFile();
+  restoreAllFromStateFile()
 }

--- a/scripts/merge-lcov.mjs
+++ b/scripts/merge-lcov.mjs
@@ -49,7 +49,10 @@ for (const entry of packageEntries) {
     if (rawLine.startsWith('SF:')) {
       const sourcePath = rawLine.slice(3)
       const resolvedPath = path.resolve(packageDir, sourcePath)
-      currentFile = path.relative(rootDir, resolvedPath).split(path.sep).join('/')
+      currentFile = path
+        .relative(rootDir, resolvedPath)
+        .split(path.sep)
+        .join('/')
 
       if (!shouldIncludeFile(currentFile)) {
         currentFile = null

--- a/scripts/test-coverage-istanbul.ts
+++ b/scripts/test-coverage-istanbul.ts
@@ -28,10 +28,11 @@ function matchesFilter(pkg: WorkspacePackage) {
     return true
   }
 
-  return filters.some((filter) =>
-    filter === pkg.name ||
-    filter === pkg.dirName ||
-    filter === `packages/${pkg.dirName}`,
+  return filters.some(
+    (filter) =>
+      filter === pkg.name ||
+      filter === pkg.dirName ||
+      filter === `packages/${pkg.dirName}`,
   )
 }
 
@@ -64,7 +65,9 @@ async function listPackages() {
     })
   }
 
-  return packages.filter(matchesFilter).sort((a, b) => a.name.localeCompare(b.name))
+  return packages
+    .filter(matchesFilter)
+    .sort((a, b) => a.name.localeCompare(b.name))
 }
 
 async function cleanCoverageDirectories(packages: WorkspacePackage[]) {
@@ -72,7 +75,10 @@ async function cleanCoverageDirectories(packages: WorkspacePackage[]) {
 
   await Promise.all(
     packages.map((pkg) =>
-      rm(path.join(pkg.dir, 'coverage-istanbul'), { recursive: true, force: true }),
+      rm(path.join(pkg.dir, 'coverage-istanbul'), {
+        recursive: true,
+        force: true,
+      }),
     ),
   )
 }
@@ -85,7 +91,11 @@ function runPackageTests(pkg: WorkspacePackage) {
       {
         env: {
           ...process.env,
-          UMPIRE_ISTANBUL_COVERAGE_DIR: path.join(pkg.dir, 'coverage-istanbul', 'raw'),
+          UMPIRE_ISTANBUL_COVERAGE_DIR: path.join(
+            pkg.dir,
+            'coverage-istanbul',
+            'raw',
+          ),
         },
         stdio: 'inherit',
       },
@@ -98,7 +108,11 @@ function runPackageTests(pkg: WorkspacePackage) {
         return
       }
 
-      reject(new Error(`Coverage experiment failed for ${pkg.name} with exit code ${code ?? 'unknown'}.`))
+      reject(
+        new Error(
+          `Coverage experiment failed for ${pkg.name} with exit code ${code ?? 'unknown'}.`,
+        ),
+      )
     })
   })
 }
@@ -171,7 +185,9 @@ for (const pkg of packages) {
 const { coverageMap, rawFileCount } = await readCoverageMaps(packages)
 const summary = await writeReports(coverageMap)
 
-console.log(`\n[istanbul] Merged ${rawFileCount} raw coverage file(s) into ${path.relative(rootDir, outputDir)}/lcov.info`)
+console.log(
+  `\n[istanbul] Merged ${rawFileCount} raw coverage file(s) into ${path.relative(rootDir, outputDir)}/lcov.info`,
+)
 console.log(
   `[istanbul] Statements ${summary.statements.pct}% | Branches ${summary.branches.pct}% | Functions ${summary.functions.pct}% | Lines ${summary.lines.pct}%`,
 )

--- a/test/istanbul-coverage-preload.ts
+++ b/test/istanbul-coverage-preload.ts
@@ -9,7 +9,8 @@ const { createInstrumenter } = require('istanbul-lib-instrument')
 const { defaults } = require('@istanbuljs/schema')
 
 const rootDir = path.resolve(import.meta.dir, '..')
-const coverageDir = process.env.UMPIRE_ISTANBUL_COVERAGE_DIR ??
+const coverageDir =
+  process.env.UMPIRE_ISTANBUL_COVERAGE_DIR ??
   path.join(process.cwd(), 'coverage-istanbul', 'raw')
 
 const instrumenter = createInstrumenter({
@@ -60,7 +61,11 @@ function loaderForPath(filePath: string) {
     return 'tsx'
   }
 
-  if (filePath.endsWith('.ts') || filePath.endsWith('.mts') || filePath.endsWith('.cts')) {
+  if (
+    filePath.endsWith('.ts') ||
+    filePath.endsWith('.mts') ||
+    filePath.endsWith('.cts')
+  ) {
     return 'ts'
   }
 
@@ -74,16 +79,19 @@ function loaderForPath(filePath: string) {
 plugin({
   name: 'umpire-istanbul-coverage',
   setup(build) {
-    build.onLoad({ filter: /\/packages\/.*\.[cm]?[jt]sx?$/u, namespace: 'file' }, ({ path: filePath }) => {
-      const source = readFileSync(filePath, 'utf8')
+    build.onLoad(
+      { filter: /\/packages\/.*\.[cm]?[jt]sx?$/u, namespace: 'file' },
+      ({ path: filePath }) => {
+        const source = readFileSync(filePath, 'utf8')
 
-      return {
-        contents: shouldInstrument(filePath)
-          ? instrumenter.instrumentSync(source, filePath)
-          : source,
-        loader: loaderForPath(filePath),
-      }
-    })
+        return {
+          contents: shouldInstrument(filePath)
+            ? instrumenter.instrumentSync(source, filePath)
+            : source,
+          loader: loaderForPath(filePath),
+        }
+      },
+    )
   },
 })
 

--- a/test/preload-workspace-aliases.ts
+++ b/test/preload-workspace-aliases.ts
@@ -17,19 +17,27 @@ if (process.env.BUN_DISABLE_WORKSPACE_MOCKS !== 'true') {
   mock.module('@umpire/reads', () => require('../packages/reads/src/index.js'))
   mock.module('@umpire/react', () => require('../packages/react/src/index.js'))
   mock.module('@umpire/solid', () => require('../packages/solid/src/index.js'))
-  mock.module('@umpire/signals', () => require('../packages/signals/src/index.js'))
+  mock.module('@umpire/signals', () =>
+    require('../packages/signals/src/index.js'),
+  )
   mock.module('@umpire/signals/solid', () =>
     require('../packages/signals/src/adapters/solid.js'),
   )
-  mock.module('@umpire/testing', () => require('../packages/testing/src/index.js'))
+  mock.module('@umpire/testing', () =>
+    require('../packages/testing/src/index.js'),
+  )
   mock.module('@umpire/zod', () => require('../packages/zod/src/index.js'))
   mock.module('@umpire/dsl', () => require('../packages/dsl/src/index.js'))
   mock.module('@umpire/dsl/clone', () => ({
     ...require('../packages/dsl/src/clone.js'),
   }))
   mock.module('@umpire/json', () => require('../packages/json/src/index.js'))
-  mock.module('@umpire/devtools', () => require('../packages/devtools/src/index.js'))
-  mock.module('@umpire/devtools/slim', () => require('../packages/devtools/src/slim.js'))
+  mock.module('@umpire/devtools', () =>
+    require('../packages/devtools/src/index.js'),
+  )
+  mock.module('@umpire/devtools/slim', () =>
+    require('../packages/devtools/src/slim.js'),
+  )
   mock.module('@umpire/devtools/react', () =>
     require('../packages/devtools/entrypoints/react.js'),
   )
@@ -39,5 +47,7 @@ if (process.env.BUN_DISABLE_WORKSPACE_MOCKS !== 'true') {
     require('../packages/tanstack-store/src/index.js'),
   )
   mock.module('@umpire/vuex', () => require('../packages/vuex/src/index.js'))
-  mock.module('@umpire/zustand', () => require('../packages/zustand/src/index.js'))
+  mock.module('@umpire/zustand', () =>
+    require('../packages/zustand/src/index.js'),
+  )
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["bun"],
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "packages/*/src/**/*",
+    "packages/*/__tests__/**/*",
+    "packages/*/type-tests/**/*",
+    "test/**/*",
+    "scripts/**/*"
+  ]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -11,10 +11,21 @@
     },
     "//#lint": {
       "dependsOn": ["@umpire/eslint-plugin#build"],
-      "inputs": ["packages/**/*.{ts,tsx,js}", "docs/src/**/*.{ts,js}", "eslint.config.js"]
+      "inputs": [
+        "packages/**/*.{ts,tsx,js}",
+        "docs/src/**/*.{ts,js}",
+        "eslint.config.js"
+      ]
     },
     "//#format:check": {
-      "inputs": ["packages/**/*.{ts,tsx,js}", "scripts/**/*.{ts,mjs}", "test/**/*.ts", ".prettierrc", ".prettierignore", "README.md"]
+      "inputs": [
+        "packages/**/*.{ts,tsx,js}",
+        "scripts/**/*.{ts,mjs}",
+        "test/**/*.ts",
+        ".prettierrc",
+        ".prettierignore",
+        "README.md"
+      ]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,7 @@
       "inputs": ["packages/**/*.{ts,tsx,js}", "docs/src/**/*.{ts,js}", "eslint.config.js"]
     },
     "//#format:check": {
-      "inputs": ["packages/**/*.{ts,tsx,js}", "scripts/**/*.{ts,mjs}", "test/**/*.ts", ".prettierrc", ".prettierignore"]
+      "inputs": ["packages/**/*.{ts,tsx,js}", "scripts/**/*.{ts,mjs}", "test/**/*.ts", ".prettierrc", ".prettierignore", "README.md"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,13 @@
     "test": {},
     "typecheck": {
       "dependsOn": ["^build"]
+    },
+    "//#lint": {
+      "dependsOn": ["@umpire/eslint-plugin#build"],
+      "inputs": ["packages/**/*.{ts,tsx,js}", "docs/src/**/*.{ts,js}", "eslint.config.js"]
+    },
+    "//#format:check": {
+      "inputs": ["packages/**/*.{ts,tsx,js}", "scripts/**/*.{ts,mjs}", "test/**/*.ts", ".prettierrc", ".prettierignore"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,7 +469,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.8.0":
+"@eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -480,7 +480,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.12.1":
+"@eslint-community/regexpp@npm:^4.12.1, @eslint-community/regexpp@npm:^4.12.2":
   version: 4.12.2
   resolution: "@eslint-community/regexpp@npm:4.12.2"
   checksum: 10c0/fddcbc66851b308478d04e302a4d771d6917a0b3740dc351513c0da9ca2eab8a1adf99f5e0aa7ab8b13fa0df005c81adeee7e63a92f3effd7d367a163b721c2d
@@ -498,6 +498,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/config-array@npm:^0.23.5":
+  version: 0.23.5
+  resolution: "@eslint/config-array@npm:0.23.5"
+  dependencies:
+    "@eslint/object-schema": "npm:^3.0.5"
+    debug: "npm:^4.3.1"
+    minimatch: "npm:^10.2.4"
+  checksum: 10c0/b24833c4c76e78ee075d306cd3f095db46b2db0f90cc13a6ee6e4275f9889731c05bf5403ab5fefb79c756e07ac9184ed0e04570341382f9eccbccc80e6d1a0c
+  languageName: node
+  linkType: hard
+
 "@eslint/config-helpers@npm:^0.4.2":
   version: 0.4.2
   resolution: "@eslint/config-helpers@npm:0.4.2"
@@ -507,12 +518,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/config-helpers@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@eslint/config-helpers@npm:0.5.5"
+  dependencies:
+    "@eslint/core": "npm:^1.2.1"
+  checksum: 10c0/18889c062cd6bdbd4cd92fe57318c44465ea66184aa0ba204a4420712c66764c64093a7905b6c2ffde23e51b268ca2cec1a39c605d336bebf17ee1ba4f0fc0bb
+  languageName: node
+  linkType: hard
+
 "@eslint/core@npm:^0.17.0":
   version: 0.17.0
   resolution: "@eslint/core@npm:0.17.0"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
   checksum: 10c0/9a580f2246633bc752298e7440dd942ec421860d1946d0801f0423830e67887e4aeba10ab9a23d281727a978eb93d053d1922a587d502942a713607f40ed704e
+  languageName: node
+  linkType: hard
+
+"@eslint/core@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@eslint/core@npm:1.2.1"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/10979b40588ecfef771fcb5013a542a35fb30692cc95a65f3481b0b36fbd89f5679efeb30d57f4eed35203d859aabace2a620177d6c536f71b299a1af2f3398f
   languageName: node
   linkType: hard
 
@@ -547,6 +576,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/object-schema@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@eslint/object-schema@npm:3.0.5"
+  checksum: 10c0/1db337431f520b99e9edda64ef5fafd7ec6a029843eeb608753025125b6649d861d843cffafafd3c4e37926d7d5f9ec0c6a8e3665c13c3da2144e8132892e92e
+  languageName: node
+  linkType: hard
+
 "@eslint/plugin-kit@npm:^0.4.1":
   version: 0.4.1
   resolution: "@eslint/plugin-kit@npm:0.4.1"
@@ -554,6 +590,16 @@ __metadata:
     "@eslint/core": "npm:^0.17.0"
     levn: "npm:^0.4.1"
   checksum: 10c0/51600f78b798f172a9915dffb295e2ffb44840d583427bc732baf12ecb963eb841b253300e657da91d890f4b323d10a1bd12934bf293e3018d8bb66fdce5217b
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "@eslint/plugin-kit@npm:0.7.1"
+  dependencies:
+    "@eslint/core": "npm:^1.2.1"
+    levn: "npm:^0.4.1"
+  checksum: 10c0/335b0c1c46fd906cb50bd5ce442b9cee18dc44342ce35c718ba4a63d1aa51d2797f16a517b2f4fe371ccd777b6862fafb2dc8195e00e69197ef4cb17ab32c01b
   languageName: node
   linkType: hard
 
@@ -1030,7 +1076,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.7":
+"@types/esrecurse@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@types/esrecurse@npm:4.3.1"
+  checksum: 10c0/90dad74d5da3ad27606d8e8e757322f33171cfeaa15ad558b615cf71bb2a516492d18f55f4816384685a3eb2412142e732bbae9a4a7cd2cf3deb7572aa4ebe03
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.7, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -1110,6 +1163,141 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.58.2"
+  dependencies:
+    "@eslint-community/regexpp": "npm:^4.12.2"
+    "@typescript-eslint/scope-manager": "npm:8.58.2"
+    "@typescript-eslint/type-utils": "npm:8.58.2"
+    "@typescript-eslint/utils": "npm:8.58.2"
+    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+    ignore: "npm:^7.0.5"
+    natural-compare: "npm:^1.4.0"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    "@typescript-eslint/parser": ^8.58.2
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/87dd29c7a87461c586e3025cde2a6e35c7cc99e69c3a93ee8254f1523ab6d4d5d322cacd476e42a3aa87581fbcf9039ef528a638a80a5c9beb1c5ebb4cc557e2
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/parser@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:8.58.2"
+    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/typescript-estree": "npm:8.58.2"
+    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/7ce3e5086b5376a91f2932fda6e0d6777ff457535eff9c133852b21c895dc56933dcda173430352850e77c2437f81c5699fac9c70207abbbd087882766b88758
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/project-service@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/project-service@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.58.2"
+    "@typescript-eslint/types": "npm:^8.58.2"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/57fa2a54452f9d9058781feb8d99d7a25096d55db15783a552b242d144992ccf893548672d3bc554c1bc0768cd8c80dbb467e9aff0db471ebcc876d4409cf75e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/scope-manager@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+  checksum: 10c0/9bf17c32d99db840500dfa4f0504635f6422fa435e0d2f3c58c36a88434d7af7ffe7ba9a6b13bd105dfa0f36a74307955ef2837ec5f1855e34c3af1843c11d36
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.58.2, @typescript-eslint/tsconfig-utils@npm:^8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.58.2"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/d3dc874ab43af39245ee8383bb6d39c985e64c43b81a7bbf18b7982047473366c252e19a9fbfe38df30c677b42133aa43a1c0a75e92b8de5d2e64defd4b3a05e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/type-utils@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/typescript-estree": "npm:8.58.2"
+    "@typescript-eslint/utils": "npm:8.58.2"
+    debug: "npm:^4.4.3"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/1e7248694c15b5e78aeb573aef755513910f6a7ec1842223ec0c8429b6abd7342996de215aefab78520e64d2e8600c9829bdf56132476cb86703fd54f2492467
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.58.2, @typescript-eslint/types@npm:^8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/types@npm:8.58.2"
+  checksum: 10c0/6707c1a2ec921b9ae441b35d9cb4e0af11673a67e332a366e3033f1d558ff5db4f39021872c207fb361841670e9ffcc4981f19eb21e4495a3a031d02015637a7
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/typescript-estree@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.58.2"
+    "@typescript-eslint/tsconfig-utils": "npm:8.58.2"
+    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/60a323f60eff9b4bb6eb3121c5f6292e7962517a329a8a9f828e8f07516de78e6a7c1b1b1cfd732f39edf184fe57828ca557fbc63b74c61b54bcb679a69e249c
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/utils@npm:8.58.2"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.58.2"
+    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/typescript-estree": "npm:8.58.2"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/d83e6c7c1b01236d255cabe2a5dc5384eedebc9f9af6aa19cc2ab7d8b280f86912f2b1a87659b2754919afd2606820b4e53862ac91970794e2980bc97487537c
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/visitor-keys@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.58.2"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10c0/6775a63dbafe7a305f0cf3f0c5eb077e30dba8a60022e4ce3220669c7f1e742c6ea2ebff8c6c0288dc17eeef8f4015089a23abbdc82a6a9382abe4a77950b695
+  languageName: node
+  linkType: hard
+
 "@umpire/core@workspace:^, @umpire/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@umpire/core@workspace:packages/core"
@@ -1149,7 +1337,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@umpire/eslint-plugin@workspace:packages/eslint-plugin":
+"@umpire/eslint-plugin@workspace:^, @umpire/eslint-plugin@workspace:packages/eslint-plugin":
   version: 0.0.0-use.local
   resolution: "@umpire/eslint-plugin@workspace:packages/eslint-plugin"
   dependencies:
@@ -1501,7 +1689,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.15.0":
+"acorn@npm:^8.15.0, acorn@npm:^8.16.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -1658,6 +1846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
+  languageName: node
+  linkType: hard
+
 "baseline-browser-mapping@npm:^2.10.12":
   version: 2.10.17
   resolution: "baseline-browser-mapping@npm:2.10.17"
@@ -1697,6 +1892,15 @@ __metadata:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
   checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "brace-expansion@npm:5.0.5"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
   languageName: node
   linkType: hard
 
@@ -1860,7 +2064,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2":
+"debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -2072,6 +2276,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-config-prettier@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "eslint-config-prettier@npm:10.1.8"
+  peerDependencies:
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: 10c0/e1bcfadc9eccd526c240056b1e59c5cd26544fe59feb85f38f4f1f116caed96aea0b3b87868e68b3099e55caaac3f2e5b9f58110f85db893e83a332751192682
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^8.4.0":
   version: 8.4.0
   resolution: "eslint-scope@npm:8.4.0"
@@ -2079,6 +2294,18 @@ __metadata:
     esrecurse: "npm:^4.3.0"
     estraverse: "npm:^5.2.0"
   checksum: 10c0/407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "eslint-scope@npm:9.1.2"
+  dependencies:
+    "@types/esrecurse": "npm:^4.3.1"
+    "@types/estree": "npm:^1.0.8"
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/9fb8bca5a73e5741efb6cec84467027b6cb6f4203ff9b43a938e272c5cd30800bde46a5c20dfd1609f840225f0b62b7673be391b20acadf8658ca9fa4729b3dd
   languageName: node
   linkType: hard
 
@@ -2093,6 +2320,58 @@ __metadata:
   version: 4.2.1
   resolution: "eslint-visitor-keys@npm:4.2.1"
   checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^5.0.0, eslint-visitor-keys@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eslint-visitor-keys@npm:5.0.1"
+  checksum: 10c0/16190bdf2cbae40a1109384c94450c526a79b0b9c3cb21e544256ed85ac48a4b84db66b74a6561d20fe6ab77447f150d711c2ad5ad74df4fcc133736bce99678
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^10.2.1":
+  version: 10.2.1
+  resolution: "eslint@npm:10.2.1"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.8.0"
+    "@eslint-community/regexpp": "npm:^4.12.2"
+    "@eslint/config-array": "npm:^0.23.5"
+    "@eslint/config-helpers": "npm:^0.5.5"
+    "@eslint/core": "npm:^1.2.1"
+    "@eslint/plugin-kit": "npm:^0.7.1"
+    "@humanfs/node": "npm:^0.16.6"
+    "@humanwhocodes/module-importer": "npm:^1.0.1"
+    "@humanwhocodes/retry": "npm:^0.4.2"
+    "@types/estree": "npm:^1.0.6"
+    ajv: "npm:^6.14.0"
+    cross-spawn: "npm:^7.0.6"
+    debug: "npm:^4.3.2"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^9.1.2"
+    eslint-visitor-keys: "npm:^5.0.1"
+    espree: "npm:^11.2.0"
+    esquery: "npm:^1.7.0"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^8.0.0"
+    find-up: "npm:^5.0.0"
+    glob-parent: "npm:^6.0.2"
+    ignore: "npm:^5.2.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    minimatch: "npm:^10.2.4"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.3"
+  peerDependencies:
+    jiti: "*"
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+  bin:
+    eslint: bin/eslint.js
+  checksum: 10c0/176795a3794a785502fa5cd14a9609264c2be5405552d20fed3e499bd465c29639c91ac44619ae66787b0fb7494e72d112550a2136a735d92a26bc6a7af4915c
   languageName: node
   linkType: hard
 
@@ -2156,6 +2435,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"espree@npm:^11.2.0":
+  version: 11.2.0
+  resolution: "espree@npm:11.2.0"
+  dependencies:
+    acorn: "npm:^8.16.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^5.0.1"
+  checksum: 10c0/cf87e18ffd9dc113eb8d16588e7757701bc10c9934a71cce8b89c2611d51672681a918307bd6b19ac3ccd0e7ba1cbccc2f815b36b52fa7e73097b251014c3d81
+  languageName: node
+  linkType: hard
+
 "esprima@npm:^4.0.0":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
@@ -2166,7 +2456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.5.0":
+"esquery@npm:^1.5.0, esquery@npm:^1.7.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
   dependencies:
@@ -2588,6 +2878,13 @@ __metadata:
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "ignore@npm:7.0.5"
+  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
   languageName: node
   linkType: hard
 
@@ -3066,6 +3363,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.2.2, minimatch@npm:^10.2.4":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
+  dependencies:
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.1.5":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
@@ -3381,6 +3687,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "prettier@npm:3.8.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/754816fd7593eb80f6376d7476d463e832c38a12f32775a82683adb6e35b772b1f484d65f19401507b983a8c8a7cd5a4a9f12006bd56491e8f35503473f77473
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^27.0.2":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
@@ -3663,7 +3978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.4":
+"semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.3, semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -3934,6 +4249,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-api-utils@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "ts-api-utils@npm:2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
+  languageName: node
+  linkType: hard
+
 "tsdown@npm:^0.21.7":
   version: 0.21.7
   resolution: "tsdown@npm:0.21.7"
@@ -4028,6 +4352,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript-eslint@npm:^8.58.2":
+  version: 8.58.2
+  resolution: "typescript-eslint@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.58.2"
+    "@typescript-eslint/parser": "npm:8.58.2"
+    "@typescript-eslint/typescript-estree": "npm:8.58.2"
+    "@typescript-eslint/utils": "npm:8.58.2"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/6065fe90674e89100b3192716fc641d80de4b586fe244c00e2c97d47923166ab3286f895685bf9570919c8606724f1196486f09e7841ca73bdf05d5df0752945
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.8.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
@@ -4054,12 +4393,17 @@ __metadata:
   dependencies:
     "@changesets/cli": "npm:^2.30.0"
     "@happy-dom/global-registrator": "npm:^20.0.10"
+    "@umpire/eslint-plugin": "workspace:^"
+    eslint: "npm:^10.2.1"
+    eslint-config-prettier: "npm:^10.1.8"
     istanbul-lib-coverage: "npm:^3.2.2"
     istanbul-lib-instrument: "npm:^6.0.3"
     istanbul-lib-report: "npm:^3.0.1"
     istanbul-reports: "npm:^3.2.0"
+    prettier: "npm:^3.8.3"
     turbo: "npm:^2.5.0"
     typescript: "npm:^5.8.3"
+    typescript-eslint: "npm:^8.58.2"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2874,6 +2874,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.7.0":
   version: 0.7.2
   resolution: "iconv-lite@npm:0.7.2"
@@ -4406,6 +4415,7 @@ __metadata:
     "@umpire/eslint-plugin": "workspace:^"
     eslint: "npm:^10.2.1"
     eslint-config-prettier: "npm:^10.1.8"
+    husky: "npm:^9.1.7"
     istanbul-lib-coverage: "npm:^3.2.2"
     istanbul-lib-instrument: "npm:^6.0.3"
     istanbul-lib-report: "npm:^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/bun@npm:^1.3.12":
+  version: 1.3.12
+  resolution: "@types/bun@npm:1.3.12"
+  dependencies:
+    bun-types: "npm:1.3.12"
+  checksum: 10c0/dacc8c77819f1d851657c5d80b1b2928dd7752016c53ae6a406f4f9a8291a5fea0799e77da99a511f4d9080e31bb97106be57f9b1a5f2a35dd235f5854953e4e
+  languageName: node
+  linkType: hard
+
 "@types/esrecurse@npm:^4.3.1":
   version: 4.3.1
   resolution: "@types/esrecurse@npm:4.3.1"
@@ -1928,7 +1937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bun-types@npm:^1.3.12":
+"bun-types@npm:1.3.12, bun-types@npm:^1.3.12":
   version: 1.3.12
   resolution: "bun-types@npm:1.3.12"
   dependencies:
@@ -4393,6 +4402,7 @@ __metadata:
   dependencies:
     "@changesets/cli": "npm:^2.30.0"
     "@happy-dom/global-registrator": "npm:^20.0.10"
+    "@types/bun": "npm:^1.3.12"
     "@umpire/eslint-plugin": "workspace:^"
     eslint: "npm:^10.2.1"
     eslint-config-prettier: "npm:^10.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,21 +480,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.12.1, @eslint-community/regexpp@npm:^4.12.2":
+"@eslint-community/regexpp@npm:^4.12.2":
   version: 4.12.2
   resolution: "@eslint-community/regexpp@npm:4.12.2"
   checksum: 10c0/fddcbc66851b308478d04e302a4d771d6917a0b3740dc351513c0da9ca2eab8a1adf99f5e0aa7ab8b13fa0df005c81adeee7e63a92f3effd7d367a163b721c2d
-  languageName: node
-  linkType: hard
-
-"@eslint/config-array@npm:^0.21.2":
-  version: 0.21.2
-  resolution: "@eslint/config-array@npm:0.21.2"
-  dependencies:
-    "@eslint/object-schema": "npm:^2.1.7"
-    debug: "npm:^4.3.1"
-    minimatch: "npm:^3.1.5"
-  checksum: 10c0/89dfe815d18456177c0a1f238daf4593107fd20298b3598e0103054360d3b8d09d967defd8318f031185d68df1f95cfa68becf1390a9c5c6887665f1475142e3
   languageName: node
   linkType: hard
 
@@ -509,30 +498,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "@eslint/config-helpers@npm:0.4.2"
-  dependencies:
-    "@eslint/core": "npm:^0.17.0"
-  checksum: 10c0/92efd7a527b2d17eb1a148409d71d80f9ac160b565ac73ee092252e8bf08ecd08670699f46b306b94f13d22e88ac88a612120e7847570dd7cdc72f234d50dcb4
-  languageName: node
-  linkType: hard
-
 "@eslint/config-helpers@npm:^0.5.5":
   version: 0.5.5
   resolution: "@eslint/config-helpers@npm:0.5.5"
   dependencies:
     "@eslint/core": "npm:^1.2.1"
   checksum: 10c0/18889c062cd6bdbd4cd92fe57318c44465ea66184aa0ba204a4420712c66764c64093a7905b6c2ffde23e51b268ca2cec1a39c605d336bebf17ee1ba4f0fc0bb
-  languageName: node
-  linkType: hard
-
-"@eslint/core@npm:^0.17.0":
-  version: 0.17.0
-  resolution: "@eslint/core@npm:0.17.0"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/9a580f2246633bc752298e7440dd942ec421860d1946d0801f0423830e67887e4aeba10ab9a23d281727a978eb93d053d1922a587d502942a713607f40ed704e
   languageName: node
   linkType: hard
 
@@ -545,51 +516,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^3.3.5":
-  version: 3.3.5
-  resolution: "@eslint/eslintrc@npm:3.3.5"
-  dependencies:
-    ajv: "npm:^6.14.0"
-    debug: "npm:^4.3.2"
-    espree: "npm:^10.0.1"
-    globals: "npm:^14.0.0"
-    ignore: "npm:^5.2.0"
-    import-fresh: "npm:^3.2.1"
-    js-yaml: "npm:^4.1.1"
-    minimatch: "npm:^3.1.5"
-    strip-json-comments: "npm:^3.1.1"
-  checksum: 10c0/9fb9f1ca65e46d6173966e3aaa5bd353e3a65d7f1f582bebf77f578fab7d7960a399fac1ecfb1e7d52bd61f5cefd6531087ca52a3a3c388f2e1b4f1ebd3da8b7
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.39.4":
-  version: 9.39.4
-  resolution: "@eslint/js@npm:9.39.4"
-  checksum: 10c0/5aa7dea2cbc5decf7f5e3b0c6f86a084ccee0f792d288ca8e839f8bc1b64e03e227068968e49b26096e6f71fd857ab6e42691d1b993826b9a3883f1bdd7a0e46
-  languageName: node
-  linkType: hard
-
-"@eslint/object-schema@npm:^2.1.7":
-  version: 2.1.7
-  resolution: "@eslint/object-schema@npm:2.1.7"
-  checksum: 10c0/936b6e499853d1335803f556d526c86f5fe2259ed241bc665000e1d6353828edd913feed43120d150adb75570cae162cf000b5b0dfc9596726761c36b82f4e87
-  languageName: node
-  linkType: hard
-
 "@eslint/object-schema@npm:^3.0.5":
   version: 3.0.5
   resolution: "@eslint/object-schema@npm:3.0.5"
   checksum: 10c0/1db337431f520b99e9edda64ef5fafd7ec6a029843eeb608753025125b6649d861d843cffafafd3c4e37926d7d5f9ec0c6a8e3665c13c3da2144e8132892e92e
-  languageName: node
-  linkType: hard
-
-"@eslint/plugin-kit@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@eslint/plugin-kit@npm:0.4.1"
-  dependencies:
-    "@eslint/core": "npm:^0.17.0"
-    levn: "npm:^0.4.1"
-  checksum: 10c0/51600f78b798f172a9915dffb295e2ffb44840d583427bc732baf12ecb963eb841b253300e657da91d890f4b323d10a1bd12934bf293e3018d8bb66fdce5217b
   languageName: node
   linkType: hard
 
@@ -1351,7 +1281,7 @@ __metadata:
   resolution: "@umpire/eslint-plugin@workspace:packages/eslint-plugin"
   dependencies:
     "@types/estree": "npm:^1.0.7"
-    eslint: "npm:^9.0.0"
+    eslint: "npm:^10.0.0"
   peerDependencies:
     eslint: ">=9.0.0"
   languageName: unknown
@@ -1698,7 +1628,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.15.0, acorn@npm:^8.16.0":
+"acorn@npm:^8.16.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -1848,13 +1778,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "balanced-match@npm:1.0.2"
-  checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -1891,16 +1814,6 @@ __metadata:
   version: 4.0.0
   resolution: "birpc@npm:4.0.0"
   checksum: 10c0/61f4e893ff4c5948b2c587c971c04883af0d8b2658d4632c8e77073db9f9e8b040402f985d56308021890b2ad32ef8392e36a8335cab1e3771d99e1b025d1af6
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.14
-  resolution: "brace-expansion@npm:1.1.14"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-    concat-map: "npm:0.0.1"
-  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
   languageName: node
   linkType: hard
 
@@ -1985,13 +1898,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"callsites@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "callsites@npm:3.1.0"
-  checksum: 10c0/fff92277400eb06c3079f9e74f3af120db9f8ea03bad0e84d9aede54bbe2d44a56cccb5f6cf12211f93f52306df87077ecec5b712794c5a9b5dac6d615a3f301
-  languageName: node
-  linkType: hard
-
 "caniuse-lite@npm:^1.0.30001782":
   version: 1.0.30001787
   resolution: "caniuse-lite@npm:1.0.30001787"
@@ -1999,7 +1905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+"chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -2029,13 +1935,6 @@ __metadata:
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
-  languageName: node
-  linkType: hard
-
-"concat-map@npm:0.0.1":
-  version: 0.0.1
-  resolution: "concat-map@npm:0.0.1"
-  checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
   languageName: node
   linkType: hard
 
@@ -2296,16 +2195,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^8.4.0":
-  version: 8.4.0
-  resolution: "eslint-scope@npm:8.4.0"
-  dependencies:
-    esrecurse: "npm:^4.3.0"
-    estraverse: "npm:^5.2.0"
-  checksum: 10c0/407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
-  languageName: node
-  linkType: hard
-
 "eslint-scope@npm:^9.1.2":
   version: 9.1.2
   resolution: "eslint-scope@npm:9.1.2"
@@ -2325,13 +2214,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "eslint-visitor-keys@npm:4.2.1"
-  checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
-  languageName: node
-  linkType: hard
-
 "eslint-visitor-keys@npm:^5.0.0, eslint-visitor-keys@npm:^5.0.1":
   version: 5.0.1
   resolution: "eslint-visitor-keys@npm:5.0.1"
@@ -2339,7 +2221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^10.2.1":
+"eslint@npm:^10.0.0, eslint@npm:^10.2.1":
   version: 10.2.1
   resolution: "eslint@npm:10.2.1"
   dependencies:
@@ -2384,66 +2266,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.0.0":
-  version: 9.39.4
-  resolution: "eslint@npm:9.39.4"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.8.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.21.2"
-    "@eslint/config-helpers": "npm:^0.4.2"
-    "@eslint/core": "npm:^0.17.0"
-    "@eslint/eslintrc": "npm:^3.3.5"
-    "@eslint/js": "npm:9.39.4"
-    "@eslint/plugin-kit": "npm:^0.4.1"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    ajv: "npm:^6.14.0"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.4.0"
-    eslint-visitor-keys: "npm:^4.2.1"
-    espree: "npm:^10.4.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.5"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/1955067c2d991f0c84f4c4abfafe31bb47fa3b717a7fd3e43fe1e511c6f859d7700cbca969f85661dc4c130f7aeced5e5444884314198a54428f5e5141db9337
-  languageName: node
-  linkType: hard
-
-"espree@npm:^10.0.1, espree@npm:^10.4.0":
-  version: 10.4.0
-  resolution: "espree@npm:10.4.0"
-  dependencies:
-    acorn: "npm:^8.15.0"
-    acorn-jsx: "npm:^5.3.2"
-    eslint-visitor-keys: "npm:^4.2.1"
-  checksum: 10c0/c63fe06131c26c8157b4083313cb02a9a54720a08e21543300e55288c40e06c3fc284bdecf108d3a1372c5934a0a88644c98714f38b6ae8ed272b40d9ea08d6b
-  languageName: node
-  linkType: hard
-
 "espree@npm:^11.2.0":
   version: 11.2.0
   resolution: "espree@npm:11.2.0"
@@ -2465,7 +2287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.5.0, esquery@npm:^1.7.0":
+"esquery@npm:^1.7.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
   dependencies:
@@ -2747,13 +2569,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "globals@npm:14.0.0"
-  checksum: 10c0/b96ff42620c9231ad468d4c58ff42afee7777ee1c963013ff8aabe095a451d0ceeb8dcd8ef4cbd64d2538cef45f787a78ba3a9574f4a634438963e334471302d
-  languageName: node
-  linkType: hard
-
 "globby@npm:^11.0.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
@@ -2910,16 +2725,6 @@ __metadata:
   version: 11.1.4
   resolution: "immer@npm:11.1.4"
   checksum: 10c0/77beca6b0a4e361b30414189d63c64beb7df40ac1d8cbf524308fcbabe755e9aa49db3c6e95a6e412911416fec621f2c8470be5ec79feedc6abd6e4f7f18a9ce
-  languageName: node
-  linkType: hard
-
-"import-fresh@npm:^3.2.1":
-  version: 3.3.1
-  resolution: "import-fresh@npm:3.3.1"
-  dependencies:
-    parent-module: "npm:^1.0.0"
-    resolve-from: "npm:^4.0.0"
-  checksum: 10c0/bf8cc494872fef783249709385ae883b447e3eb09db0ebd15dcead7d9afe7224dad7bd7591c6b73b0b19b3c0f9640eb8ee884f01cfaf2887ab995b0b36a0cbec
   languageName: node
   linkType: hard
 
@@ -3307,13 +3112,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.merge@npm:^4.6.2":
-  version: 4.6.2
-  resolution: "lodash.merge@npm:4.6.2"
-  checksum: 10c0/402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
-  languageName: node
-  linkType: hard
-
 "lodash.startcase@npm:^4.4.0":
   version: 4.4.0
   resolution: "lodash.startcase@npm:4.4.0"
@@ -3387,15 +3185,6 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^5.0.5"
   checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "minimatch@npm:3.1.5"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
@@ -3574,15 +3363,6 @@ __metadata:
   dependencies:
     quansync: "npm:^0.2.7"
   checksum: 10c0/247991de461b9e731f3463b7dae9ce187e53095b7b94d7d96eec039abf418b61ccf74464bec1d0c11d97311f33472e77baccd4c5898f77358da4b5b33395e0b1
-  languageName: node
-  linkType: hard
-
-"parent-module@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "parent-module@npm:1.0.1"
-  dependencies:
-    callsites: "npm:^3.0.0"
-  checksum: 10c0/c63d6e80000d4babd11978e0d3fee386ca7752a02b035fd2435960ffaa7219dc42146f07069fb65e6e8bf1caef89daf9af7535a39bddf354d78bf50d8294f556
   languageName: node
   linkType: hard
 
@@ -3824,13 +3604,6 @@ __metadata:
   version: 5.1.1
   resolution: "reselect@npm:5.1.1"
   checksum: 10c0/219c30da122980f61853db3aebd173524a2accd4b3baec770e3d51941426c87648a125ca08d8c57daa6b8b086f2fdd2703cb035dd6231db98cdbe1176a71f489
-  languageName: node
-  linkType: hard
-
-"resolve-from@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "resolve-from@npm:4.0.0"
-  checksum: 10c0/8408eec31a3112ef96e3746c37be7d64020cda07c03a920f5024e77290a218ea758b26ca9529fd7b1ad283947f34b2291c1c0f6aa0ed34acfdda9c6014c8d190
   languageName: node
   linkType: hard
 
@@ -4197,13 +3970,6 @@ __metadata:
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
   checksum: 10c0/51201f50e021ef16672593d7434ca239441b7b760e905d9f33df6e4f3954ff54ec0e0a06f100d028af0982d6f25c35cd5cda2ce34eaebccd0250b8befb90d8f1
-  languageName: node
-  linkType: hard
-
-"strip-json-comments@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "strip-json-comments@npm:3.1.1"
-  checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Adds ESLint (TypeScript-ESLint + complexity rule at warn/15) across all `packages/*`, with `@umpire/eslint-plugin` applied to packages and docs source. Prettier configured repo-wide, excluding `docs/` and `.changeset/`.
- Wires `lint` and `format:check` as Turbo root tasks with scoped inputs for caching; `lint` depends only on `@umpire/eslint-plugin#build` rather than a full `^build`.
- Adds parallel `lint` and `format` jobs to CI.
- Pre-commit hook runs `lint → format:check → typecheck → test` in order (cheapest/most substantive failures first).
- Adds root `tsconfig.json` so tsserver resolves `__tests__/**` through the workspace rather than falling back to inferred mode; adds `@types/bun` and `types: ['bun']` to `tsconfig.base.json`.

## Notes

- `@typescript-eslint/no-empty-object-type` is disabled — `{}` is used intentionally as a generic type throughout umpire's type system.
- `@typescript-eslint/no-unused-vars` is downgraded to warn. 9 real errors remain (7 `no-explicit-any`, 1 `prefer-const`, 1 legitimate `@umpire/no-contradicting-rules` hit in a test). Complexity warnings are surfaced but not enforced — follow-up PR will drive the threshold down.

## Test plan

- [ ] `yarn turbo run lint` exits 1 on the known errors, no spurious parse errors
- [ ] `yarn format:check` covers packages/scripts, skips `docs/` and `.changeset/`
- [x] CI lint and format jobs appear as independent checks on the PR
- [x] Pre-commit hook fires on `git commit`