### PR TITLE
🧹 Lint Sweep

### DIFF
--- a/.changeset/remove-fieldselector-phantom-v.md
+++ b/.changeset/remove-fieldselector-phantom-v.md
@@ -1,0 +1,5 @@
+---
+"@umpire/core": minor
+---
+
+Remove unused `V` type parameter from `FieldSelector<F>` and the function signatures that accepted it (`enabledWhen`, `requires`, `disables`). The parameter was never referenced in the type body and had no effect on type checking. `fairWhen` retains its `V` parameter for use with `FairPredicate<V, F, C>`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,17 @@ export default tseslint.config(
       // {} is used intentionally as a generic type throughout umpire's type system
       '@typescript-eslint/no-empty-object-type': 'off',
       // Real issues but numerous; tracked as warnings to drive gradual cleanup
-      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+  // type-tests declare values solely to assert types — unused vars are expected
+  {
+    files: ['packages/*/type-tests/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
     },
   },
   // TypeScript parser for docs source — enables umpire plugin without full TS-ESLint rules

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,13 @@ export default tseslint.config(
       ],
     },
   },
+  // complexity doesn't map well to component render functions
+  {
+    files: ['packages/**/*.tsx'],
+    rules: {
+      complexity: 'off',
+    },
+  },
   // type-tests declare values solely to assert types — unused vars are expected
   {
     files: ['packages/*/type-tests/**/*.ts'],

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -2,12 +2,7 @@ import {
   appendCompositeFailureReasons,
   combineCompositeResults,
 } from './composite.js'
-import {
-  getInternalRuleMetadata,
-  isFairRule,
-  isGateRule,
-  resolveReason,
-} from './rules.js'
+import { getInternalRuleMetadata, isFairRule, isGateRule } from './rules.js'
 import { isSatisfied } from './satisfaction.js'
 import type {
   AvailabilityMap,

--- a/packages/core/src/field.ts
+++ b/packages/core/src/field.ts
@@ -29,7 +29,7 @@ type FairPredicate<
   C extends Record<string, unknown>,
 > = (value: NonNullable<V>, values: FieldValues<F>, conditions: C) => boolean
 
-type FieldSelector<F extends Record<string, FieldDef>, V = unknown> =
+export type FieldSelector<F extends Record<string, FieldDef>> =
   | (keyof F & string)
   | { readonly __umpfield: keyof F & string }
   | { readonly __umpfield: string }
@@ -204,8 +204,8 @@ export function getFieldBuilderName(value: unknown): string | undefined {
   return typeof name === 'string' ? name : undefined
 }
 
-export function getFieldNameOrThrow<F extends Record<string, FieldDef>, V>(
-  field: FieldSelector<F, V>,
+export function getFieldNameOrThrow<F extends Record<string, FieldDef>>(
+  field: FieldSelector<F>,
 ): keyof F & string {
   if (typeof field === 'string') {
     return field

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -3,7 +3,7 @@ import {
   getCompositeTargetEvaluation,
 } from './composite.js'
 import { shouldWarnInDev } from './dev.js'
-import { getFieldBuilderName, getFieldNameOrThrow } from './field.js'
+import { getFieldNameOrThrow, type FieldSelector } from './field.js'
 import { isSatisfied } from './satisfaction.js'
 import {
   isNamedCheck as isNamedCheckValidator,
@@ -132,11 +132,6 @@ type RuleOptions<
     | RuleTraceAttachment<FieldValues<F>, C>[]
 }
 
-type FieldSelector<F extends Record<string, FieldDef>, V = unknown> =
-  | (keyof F & string)
-  | { readonly __umpfield: keyof F & string }
-  | { readonly __umpfield: string }
-
 type Source<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -145,8 +140,7 @@ type Source<
 type SourceInput<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-  V = unknown,
-> = FieldSelector<F, V> | Predicate<F, C>
+> = FieldSelector<F> | Predicate<F, C>
 
 type FairPredicate<
   V,
@@ -375,8 +369,7 @@ export function getSourceField<
 function normalizeSource<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-  V = unknown,
->(source: SourceInput<F, C, V>): Source<F, C> {
+>(source: SourceInput<F, C>): Source<F, C> {
   if (typeof source === 'function') {
     return source
   }
@@ -1076,9 +1069,8 @@ export function resolveOneOfState<
 export function enabledWhen<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
-  V = unknown,
 >(
-  field: FieldSelector<F, V>,
+  field: FieldSelector<F>,
   predicate: Predicate<F, C>,
   options?: RuleOptions<F, C>,
 ): Rule<F, C> {
@@ -1119,7 +1111,7 @@ export function fairWhen<
   C extends Record<string, unknown> = Record<string, unknown>,
   V = unknown,
 >(
-  field: FieldSelector<F, V>,
+  field: FieldSelector<F>,
   predicate: FairPredicate<V, F, C>,
   options?: RuleOptions<F, C>,
 ): Rule<F, C> {
@@ -1169,9 +1161,8 @@ export function fairWhen<
 export function disables<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
-  V = unknown,
 >(
-  source: SourceInput<F, C, V>,
+  source: SourceInput<F, C>,
   targets: Array<FieldSelector<F>>,
   options?: RuleOptions<F, C>,
 ): Rule<F, C> {
@@ -1210,9 +1201,8 @@ export function disables<
 export function requires<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
-  V = unknown,
 >(
-  field: FieldSelector<F, V>,
+  field: FieldSelector<F>,
   ...deps: Array<SourceInput<F, C> | RuleOptions<F, C>>
 ): Rule<F, C> {
   const target = getFieldNameOrThrow(field)
@@ -1496,7 +1486,7 @@ export function check<
   C extends Record<string, unknown> = Record<string, unknown>,
   V = unknown,
 >(
-  field: FieldSelector<F, V>,
+  field: FieldSelector<F>,
   validator: FieldValidator<NonNullable<V>>,
 ): Predicate<F, C> {
   const target = getFieldNameOrThrow(field)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -204,10 +204,7 @@ export type ScorecardTransition<
   cascadingFields: Array<keyof F & string>
 }
 
-export type ScorecardOptions<
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown>,
-> = {
+export type ScorecardOptions<C extends Record<string, unknown>> = {
   before?: Snapshot<C>
   includeChallenge?: boolean
 }
@@ -258,7 +255,7 @@ export interface Umpire<
   init(overrides?: InputValues): FieldValues<F>
   scorecard(
     snapshot: Snapshot<C>,
-    options?: ScorecardOptions<F, C>,
+    options?: ScorecardOptions<C>,
   ): ScorecardResult<F, C>
   challenge(
     field: keyof F & string,

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -68,10 +68,7 @@ type NormalizedValidationMap<F extends Record<string, FieldDef>> = Partial<{
   [K in keyof F & string]: NormalizedValidationEntry
 }>
 
-function getChangedFields<
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown>,
->(
+function getChangedFields<F extends Record<string, FieldDef>>(
   fieldNames: Array<keyof F & string>,
   before: { values: FieldValues<F> } | undefined,
   after: { values: FieldValues<F> },
@@ -1241,7 +1238,7 @@ export function umpire<
       values: InputValues
       conditions?: C
     },
-    options: ScorecardOptions<NormalizeFields<FInput>, C> = {},
+    options: ScorecardOptions<C> = {},
   ): ScorecardResult<NormalizeFields<FInput>, C> {
     const { before, includeChallenge = false } = options
     const typedValues = snapshot.values as FieldValues<NormalizeFields<FInput>>

--- a/packages/devtools/__tests__/mount.test.tsx
+++ b/packages/devtools/__tests__/mount.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock, spyOn, test } from 'bun:test'
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
 import { mount, unmount } from '../src/index.js'
 import { resetRegistry } from '../src/registry.js'
 

--- a/packages/devtools/__tests__/registry.test.ts
+++ b/packages/devtools/__tests__/registry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock, test } from 'bun:test'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { enabledWhen, umpire } from '@umpire/core'
 import { createReads, enabledWhenRead } from '@umpire/reads'
 import type { ReadTableInspection } from '@umpire/reads'

--- a/packages/devtools/src/panel/Panel.tsx
+++ b/packages/devtools/src/panel/Panel.tsx
@@ -4,7 +4,6 @@ import type {
   AnyScorecard,
   DevtoolsTab,
   MountOptions,
-  ResolvedDevtoolsExtension,
   RegistryEntry,
 } from '../types.js'
 import { ChallengeDrawer } from './ChallengeDrawer.js'

--- a/packages/json/__tests__/builders.test.ts
+++ b/packages/json/__tests__/builders.test.ts
@@ -281,7 +281,7 @@ describe('portable JSON builders', () => {
   })
 
   test('anyOfJson requires JSON-backed inner rules', () => {
-    const fields = {
+    const _fields = {
       warmupNotice: {},
       pitchType: {},
     }
@@ -289,14 +289,14 @@ describe('portable JSON builders', () => {
     type Conditions = Record<string, unknown>
 
     const { expr, enabledWhenExpr } = createJsonRules<
-      typeof fields,
+      typeof _fields,
       Conditions
     >()
 
     expect(() =>
       anyOfJson(
         enabledWhenExpr('warmupNotice', expr.eq('pitchType', 'slider')),
-        enabledWhen<typeof fields>('warmupNotice', () => true),
+        enabledWhen<typeof _fields>('warmupNotice', () => true),
       ),
     ).toThrow('anyOfJson() requires every inner rule to carry JSON metadata')
   })
@@ -681,18 +681,18 @@ describe('portable JSON builders', () => {
   })
 
   test('eitherOfJson requires every inner rule to carry JSON metadata', () => {
-    const fields = {
+    const _fields = {
       submit: {},
       email: {},
     }
 
-    const { expr, enabledWhenExpr } = createJsonRules<typeof fields>()
+    const { expr, enabledWhenExpr } = createJsonRules<typeof _fields>()
 
     expect(() =>
       eitherOfJson('authPath', {
         password: [
           enabledWhenExpr('submit', expr.present('email')),
-          enabledWhen<typeof fields>('submit', () => true),
+          enabledWhen<typeof _fields>('submit', () => true),
         ],
       }),
     ).toThrow('eitherOfJson() requires every inner rule to carry JSON metadata')

--- a/packages/json/__tests__/serialize.test.ts
+++ b/packages/json/__tests__/serialize.test.ts
@@ -13,12 +13,7 @@ import {
   type Rule,
 } from '@umpire/core'
 
-import {
-  fromJson,
-  hydrateIsEmptyStrategy,
-  namedValidators,
-  toJson,
-} from '../src/index.js'
+import { fromJson, namedValidators, toJson } from '../src/index.js'
 import type { UmpireJsonSchema } from '../src/index.js'
 
 describe('toJson', () => {

--- a/packages/pinia/src/index.ts
+++ b/packages/pinia/src/index.ts
@@ -18,7 +18,7 @@ export function fromPiniaStore<
 >(
   ump: Umpire<F, C>,
   store: PiniaStoreApi<S>,
-  options: FromStoreOptions<S, F, C>,
+  options: FromStoreOptions<S, C>,
 ): UmpireStore<F> {
   const previousState = trackPreviousState(store.$state)
 

--- a/packages/react/__tests__/useUmpire.test.ts
+++ b/packages/react/__tests__/useUmpire.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react'
-import { umpire, enabledWhen, requires, oneOf } from '@umpire/core'
+import { umpire, enabledWhen, oneOf } from '@umpire/core'
 import type { FieldDef } from '@umpire/core'
 import { useUmpire } from '../src/useUmpire.js'
 

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -18,7 +18,7 @@ export function fromReduxStore<
 >(
   ump: Umpire<F, C>,
   store: ReduxStoreApi<S>,
-  options: FromStoreOptions<S, F, C>,
+  options: FromStoreOptions<S, C>,
 ): UmpireStore<F> {
   const previousState = trackPreviousState(store.getState())
 

--- a/packages/signals/__tests__/reactive.test.ts
+++ b/packages/signals/__tests__/reactive.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn, test } from 'bun:test'
+import { describe, expect, spyOn, test } from 'bun:test'
 import { umpire, enabledWhen, requires, disables } from '@umpire/core'
 import type { FieldDef } from '@umpire/core'
 import type { SignalProtocol } from '../src/protocol.js'

--- a/packages/store/src/fromStore.ts
+++ b/packages/store/src/fromStore.ts
@@ -12,11 +12,7 @@ export type StoreApi<S> = {
   subscribe(listener: (state: S, prevState: S) => void): () => void
 }
 
-export type FromStoreOptions<
-  S,
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown>,
-> = {
+export type FromStoreOptions<S, C extends Record<string, unknown>> = {
   select: (state: S) => InputValues
   conditions?: (state: S) => C
 }
@@ -36,7 +32,7 @@ export function fromStore<
 >(
   ump: Umpire<F, C>,
   store: StoreApi<S>,
-  options: FromStoreOptions<S, F, C>,
+  options: FromStoreOptions<S, C>,
 ): UmpireStore<F> {
   const { select, conditions } = options
   const readConditions = (state: S): C | undefined => {

--- a/packages/tanstack-store/src/index.ts
+++ b/packages/tanstack-store/src/index.ts
@@ -36,7 +36,7 @@ export function fromTanStackStore<
 >(
   ump: Umpire<F, C>,
   store: TanStackStoreApi<S>,
-  options: FromStoreOptions<S, F, C>,
+  options: FromStoreOptions<S, C>,
 ): UmpireStore<F> {
   const previousState = trackPreviousState(store.state)
 

--- a/packages/vuex/src/index.ts
+++ b/packages/vuex/src/index.ts
@@ -18,7 +18,7 @@ export function fromVuexStore<
 >(
   ump: Umpire<F, C>,
   store: VuexStoreApi<S>,
-  options: FromStoreOptions<S, F, C>,
+  options: FromStoreOptions<S, C>,
 ): UmpireStore<F> {
   const previousState = trackPreviousState(store.state)
 

--- a/packages/zod/src/devtools.ts
+++ b/packages/zod/src/devtools.ts
@@ -8,10 +8,7 @@ import { deriveErrors, zodErrors } from './derive-errors.js'
 import type { NormalizedFieldError } from './derive-errors.js'
 import type { ZodSafeParseResultLike } from './zod-types.js'
 
-type ZodValidationInspection<
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown> = Record<string, unknown>,
-> = {
+type ZodValidationInspection<F extends Record<string, FieldDef>> = {
   availability?: AvailabilityMap<F>
   result: ZodSafeParseResultLike
   schemaFields?: readonly (keyof F & string)[] | readonly string[]
@@ -28,22 +25,19 @@ type ZodValidationResolveOptions<
   label?: string
   resolve(
     context: DevtoolsExtensionInspectContext<F, C>,
-  ): ZodValidationInspection<F, C> | null
+  ): ZodValidationInspection<F> | null
 }
 
-type ZodValidationStaticOptions<
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown> = Record<string, unknown>,
-> = {
+type ZodValidationStaticOptions<F extends Record<string, FieldDef>> = {
   availability: AvailabilityMap<F>
   id?: string
   label?: string
-} & ZodValidationInspection<F, C>
+} & ZodValidationInspection<F>
 
 export type ZodValidationExtensionOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
-> = ZodValidationResolveOptions<F, C> | ZodValidationStaticOptions<F, C>
+> = ZodValidationResolveOptions<F, C> | ZodValidationStaticOptions<F>
 
 function issueFieldLabel(field: string) {
   return field === '' ? '(form)' : field


### PR DESCRIPTION
## Summary

- Removes the unused `V` type parameter from `FieldSelector<F>` and the signatures of `enabledWhen`, `requires`, and `disables`. The parameter was declared but never referenced in the type body and had no effect on type checking. `fairWhen` retains `V` for use with `FairPredicate<V, F, C>`.
- Tunes lint rules: complexity disabled on `.tsx` files, `no-unused-vars` exempts `_`-prefixed identifiers, and `no-unused-vars` is off entirely in `type-tests/` where values are declared solely to assert types.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` — no new errors beyond the known 9
- [x] Type tests pass — any `FieldSelector` callsite with an explicit `V` arg will need it dropped