### PR TITLE
🪝  adjust husky hooks for quicker WIP commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 yarn turbo run lint
 yarn format:check
-yarn typecheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+yarn typecheck


### PR DESCRIPTION
I kind of find waiting for the full typecheck for every commit breaks my flow so this moves that to a push step to catch easily correctable mistakes before CI does lol