### PR TITLE
🔬 Expanded Testing Utils

### DIFF
--- a/.changeset/testing-coverage-rule-ids.md
+++ b/.changeset/testing-coverage-rule-ids.md
@@ -1,0 +1,8 @@
+---
+"@umpire/core": minor
+"@umpire/testing": minor
+---
+
+Add core rule attribution metadata and testing coverage tracking.
+
+`@umpire/core` now exposes `ump.rules()` with normalized rule entries and includes `ruleId`/`ruleIndex` on challenge reasons. `@umpire/testing` adds `trackCoverage()` to report observed field states and uncovered rule activations from instrumented `check()` and `scorecard()` calls.

--- a/docs/src/content/docs/extensions/testing.md
+++ b/docs/src/content/docs/extensions/testing.md
@@ -1,11 +1,11 @@
 ---
 title: Testing
-description: Invariant testing utilities for umpire rule configurations.
+description: Scenario assertions, coverage tracking, and structural invariant testing for umpire rule configurations.
 ---
 
-`@umpire/testing` exports `monkeyTest()` — a function that probes an umpire instance with exhaustive or randomly-sampled inputs and asserts that six structural invariants hold across all of them.
+`@umpire/testing` covers three layers of umpire test quality.
 
-Use it in your test suite to catch rule bugs that static construction-time validation can't see: impure predicates, foul cycles, undeclared dependencies, and divergence between `check()` and `challenge()`.
+`checkAssert` and `scorecardAssert` add readable assertion chains to scenario tests — you write a specific input, then assert exactly which fields are enabled, disabled, foul, changed, or cascaded. `trackCoverage` instruments an umpire instance so your test suite can report which field states and rule failures it actually exercised. `monkeyTest` probes the instance independently with exhaustive or randomly-sampled inputs and checks that six structural invariants hold across all of them.
 
 ## Install
 
@@ -13,25 +13,339 @@ Use it in your test suite to catch rule bugs that static construction-time valid
 npm install --save-dev @umpire/testing
 ```
 
-## Quick Start
+## checkAssert(result)
+
+`checkAssert` takes the result of `ump.check(values)` and returns a fluent assertion chain for making readable field-level availability assertions in any test framework. When an assertion fails, it throws a plain `Error` listing every failing field — no test runner integration required.
+
+### Signature
 
 ```ts
-import { umpire, enabledWhen, requires } from '@umpire/core'
-import { monkeyTest } from '@umpire/testing'
+function checkAssert<K extends string>(
+  result: Record<K, FieldStatus>,
+): CheckAssertChain<K>
+```
+
+### Methods
+
+Each method accepts one or more field names. All failing fields are collected before throwing, so you see the full picture at once rather than stopping at the first failure. Each method returns the chain so assertions can be composed inline.
+
+| Method | Asserts |
+|--------|---------|
+| `.enabled(...fields)` | `status.enabled === true`. Error message includes the reason string if one is attached to the disabling rule. |
+| `.disabled(...fields)` | `status.enabled === false` |
+| `.fair(...fields)` | `status.fair === true`. Error message includes the reason string if the field is foul. Note: disabled fields always have `fair: true` in umpire, so `.fair()` passes for any disabled field. |
+| `.foul(...fields)` | `status.fair === false`. Includes the current `enabled` state in the error so you can tell whether you hit a disabled field by mistake. |
+| `.required(...fields)` | `status.required === true` |
+| `.optional(...fields)` | `status.required === false` |
+| `.satisfied(...fields)` | `status.satisfied === true` |
+| `.unsatisfied(...fields)` | `status.satisfied === false` |
+
+Passing an unknown field name throws immediately: `checkAssert: unknown field "fieldName"`.
+
+### Error message format
+
+Single-field failures produce a single-line message:
+
+```
+checkAssert: expected "guarded" to be enabled — was disabled (reason: "requires gate")
+```
+
+Multi-field failures list each one:
+
+```
+checkAssert: expected the following field(s) to be enabled:
+  "cardNumber" — was disabled (reason: "Pick a card type first")
+  "expiryDate" — was disabled (reason: "Enter a card number first")
+```
+
+### Example
+
+```ts
+import { fairWhen, requires, umpire } from '@umpire/core'
+import { checkAssert } from '@umpire/testing'
 
 const ump = umpire({
-  fields: { mode: {}, details: {}, submit: {} },
+  fields: {
+    email: { required: true },
+    password: { required: true },
+    referralCode: {},
+    terms: { required: true },
+  },
   rules: [
-    enabledWhen('details', (v) => v.mode === 'advanced'),
-    requires('submit', 'mode'),
+    requires('referralCode', 'email'),
+    fairWhen('password', (val) => String(val).length >= 8, {
+      reason: 'Password must be at least 8 characters',
+    }),
   ],
 })
 
-const result = monkeyTest(ump)
-expect(result.passed).toBe(true)
+// No email — referralCode should be disabled; password foul with short value
+const result = ump.check({ password: 'short' })
+
+checkAssert(result)
+  .disabled('referralCode')
+  .foul('password')
+  .unsatisfied('email', 'terms')
+  .required('email', 'password', 'terms')
 ```
 
-## What it checks
+### In your test suite
+
+`checkAssert` throws a plain `Error`, so any framework that supports `expect(() => ...).not.toThrow()` works without configuration:
+
+```ts
+it('referralCode is disabled without an email', () => {
+  expect(() =>
+    checkAssert(ump.check({ password: 'short' }))
+      .disabled('referralCode')
+      .foul('password')
+  ).not.toThrow()
+})
+```
+
+## scorecardAssert(result)
+
+`scorecardAssert` takes the result of `ump.scorecard(snapshot, { before })` and returns a fluent assertion chain for transition assertions. It answers questions about what changed, what cascaded, and what now needs a foul reset — all on a single scorecard result.
+
+### Signature
+
+```ts
+function scorecardAssert<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(result: ScorecardResult<F, C>): ScorecardAssertChain<keyof F & string>
+```
+
+### Methods
+
+| Method | Asserts |
+|--------|---------|
+| `.changed(...fields)` | `result.fields[f].changed === true` |
+| `.notChanged(...fields)` | `result.fields[f].changed === false` |
+| `.cascaded(...fields)` | `result.fields[f].cascaded === true` |
+| `.fouled(...fields)` | `result.fields[f].foul !== null` — the field has a foul-reset recommendation |
+| `.notFouled(...fields)` | `result.fields[f].foul === null`. Error includes the foul reason if one is present. |
+| `.onlyChanged(...fields)` | `result.transition.changedFields` is exactly this set, order-independent. Throws if any field is missing from the expected set or appears unexpectedly. |
+| `.onlyFouled(...fields)` | `result.transition.fouledFields` is exactly this set, order-independent. |
+| `.check()` | Returns a `CheckAssertChain` over `result.check` — the full availability snapshot from the same scorecard call. |
+
+Passing an unknown field name throws immediately: `scorecardAssert: unknown field "fieldName"`.
+
+### Checking availability through `.check()`
+
+`.check()` delegates to `checkAssert(result.check)`, so you can assert availability within the same chain without calling `ump.check()` separately:
+
+```ts
+scorecardAssert(result)
+  .changed('cardType')
+  .cascaded('cardNumber', 'expiryDate')
+  .check()
+    .disabled('cardNumber', 'expiryDate')
+    .enabled('billingZip')
+```
+
+### Example
+
+The payment form domain used in the test suite makes this concrete: clearing `cardType` disables `cardNumber` and cascades a foul reset to `expiryDate`.
+
+```ts
+import { requires, umpire } from '@umpire/core'
+import { scorecardAssert } from '@umpire/testing'
+
+const ump = umpire({
+  fields: {
+    cardType: {},
+    cardNumber: {},
+    expiryDate: {},
+    billingZip: {},
+  },
+  rules: [
+    requires('cardNumber', 'cardType', { reason: 'Pick a card type first' }),
+    requires('expiryDate', 'cardNumber', { reason: 'Enter a card number first' }),
+  ],
+})
+
+// User clears cardType after having filled in the whole form
+const result = ump.scorecard(
+  {
+    values: {
+      cardType: null,
+      cardNumber: '4111111111111111',
+      expiryDate: '12/30',
+      billingZip: '10001',
+    },
+  },
+  {
+    before: {
+      values: {
+        cardType: 'visa',
+        cardNumber: '4111111111111111',
+        expiryDate: '12/30',
+        billingZip: '10001',
+      },
+    },
+  },
+)
+
+scorecardAssert(result)
+  .onlyChanged('cardType')
+  .cascaded('cardNumber', 'expiryDate')
+  .fouled('cardNumber', 'expiryDate')
+  .notFouled('billingZip')
+  .check()
+    .disabled('cardNumber', 'expiryDate')
+    .enabled('cardType', 'billingZip')
+```
+
+### In your test suite
+
+Same pattern as `checkAssert` — wrap the chain in `expect(() => ...).not.toThrow()`:
+
+```ts
+it('clearing cardType cascades fouls downstream', () => {
+  expect(() =>
+    scorecardAssert(ump.scorecard(after, { before }))
+      .onlyChanged('cardType')
+      .cascaded('cardNumber', 'expiryDate')
+      .fouled('cardNumber', 'expiryDate')
+  ).not.toThrow()
+})
+```
+
+## trackCoverage(ump)
+
+`trackCoverage` wraps an umpire instance and instruments it so your scenario tests can report which field states and rule failures they actually exercised. The goal is to answer: did your test suite visit `cardNumber` while disabled? Did any test trigger the `requires(expiryDate, cardNumber)` rule?
+
+Without this, a passing test suite can silently miss entire branches of your rule graph.
+
+### Signature
+
+```ts
+function trackCoverage<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(ump: Umpire<F, C>): CoverageTracker<F, C>
+```
+
+### Return shape
+
+```ts
+type CoverageTracker<F, C> = {
+  ump: Umpire<F, C>       // instrumented proxy — use this in your tests
+  report(): CoverageReport<keyof F & string>
+  reset(): void
+}
+
+type CoverageReport<K extends string> = {
+  fieldStates: Record<K, FieldStateCoverage>
+  uncoveredRules: RuleCoverage[]
+}
+
+type FieldStateCoverage = {
+  seenEnabled: boolean
+  seenDisabled: boolean
+  seenFair: boolean
+  seenFoul: boolean
+  seenSatisfied: boolean
+  seenUnsatisfied: boolean
+}
+
+type RuleCoverage = {
+  index: number
+  id: string
+  description: string
+}
+```
+
+### How it works
+
+`tracker.ump` is a full `Umpire` proxy — it supports every method on the original, but `check()` and `scorecard()` also record observations. Only calls through `tracker.ump` contribute to coverage; calling the original unwrapped umpire does not.
+
+`report().fieldStates` accumulates across all instrumented calls. Each field starts with all six boolean flags set to `false`, and they flip to `true` as those states appear in results.
+
+`report().uncoveredRules` lists rules from `ump.rules()` that never produced a failure in any instrumented call. Rule coverage is determined by inspecting `challenge()` `ruleId` metadata — each rule instance gets a unique ID, so two `requires()` rules targeting the same field are tracked independently. The normalized `index` is included for cross-referencing with the rule list.
+
+Rule descriptions are generated from inspection metadata:
+
+| Rule type | Description format |
+|-----------|-------------------|
+| `requires(target, dep1, dep2)` | `"requires(target, dep1, dep2)"` |
+| `disables(source, target1)` | `"disables(source, target1)"` |
+| `fairWhen(target, ...)` | `"fairWhen(target, ...)"` |
+| `enabledWhen(target, ...)` | `"enabledWhen(target, ...)"` |
+| `oneOf(groupName)` | `"oneOf(groupName)"` |
+| `anyOf(N rules)` | `"anyOf(N rules)"` |
+| `eitherOf(groupName)` | `"eitherOf(groupName)"` |
+| Custom/opaque rules | `"uninspectable rule #N"` |
+
+### `reset()`
+
+`reset()` clears all field-state observations and covered rule IDs without rebuilding the wrapped umpire. Use it to isolate coverage between distinct scenarios in the same test suite run.
+
+```ts
+tracker.ump.check({ mode: 'guest' })
+const guestReport = tracker.report()
+
+tracker.reset()
+
+tracker.ump.check({ mode: 'admin' })
+const adminReport = tracker.report()
+```
+
+### Example
+
+```ts
+import { fairWhen, requires, umpire } from '@umpire/core'
+import { trackCoverage } from '@umpire/testing'
+
+const ump = umpire({
+  fields: {
+    email: { required: true },
+    password: { required: true },
+    referralCode: {},
+    terms: { required: true },
+  },
+  rules: [
+    requires('referralCode', 'email'),
+    fairWhen('password', (val) => String(val).length >= 8, {
+      reason: 'Password must be at least 8 characters',
+    }),
+  ],
+})
+
+const tracker = trackCoverage(ump)
+
+// Scenario 1: email present, referralCode unlocked, valid password
+tracker.ump.check({
+  email: 'user@example.com',
+  password: 'hunter2!',
+  referralCode: 'PROMO',
+  terms: true,
+})
+
+// Scenario 2: no email, referralCode disabled, short password
+tracker.ump.check({
+  email: null,
+  password: 'abc',
+})
+
+const { fieldStates, uncoveredRules } = tracker.report()
+
+// referralCode was seen both enabled and disabled
+console.log(fieldStates.referralCode.seenEnabled)   // true
+console.log(fieldStates.referralCode.seenDisabled)  // true
+
+// password fairWhen rule was triggered by the short password
+console.log(uncoveredRules) // []
+```
+
+If any entry appears in `uncoveredRules`, you have a rule that no test scenario has exercised as a failure. That rule could be broken and your tests would not catch it.
+
+## monkeyTest(ump, options?)
+
+`monkeyTest` probes an umpire instance with exhaustive or randomly-sampled inputs and checks that six structural invariants hold across all of them. Use it in your test suite to catch rule bugs that static construction-time validation can't see: impure predicates, foul cycles, undeclared dependencies, and divergence between `check()` and `challenge()`.
+
+### What it checks
 
 | Invariant | Description |
 |-----------|-------------|
@@ -42,14 +356,14 @@ expect(result.passed).toBe(true)
 | `disabled-field-immunity` | Mutating a disabled field's value does not change the availability of any field that doesn't declare it as a dependency. Catches undeclared rule sources. |
 | `init-clean` | `play(init(), init())` returns zero fouls. The initial state must always be legal. |
 
-## Input generation
+### Input generation
 
 The probe value set is `[null, undefined, '', 'a', 0, 1, true, false]` — universal enough to trigger most boolean-style conditions without knowing field types at runtime.
 
 - **≤ 6 fields:** all combinations tested exhaustively (up to 8⁶ = 262,144 inputs).
 - **> 6 fields:** `options.samples` random combinations generated using a seeded PRNG. Reproducible by default — seed `42` unless overridden.
 
-## API
+### API
 
 ```ts
 function monkeyTest(ump: Umpire<any, any>, options?: MonkeyTestOptions): MonkeyTestResult
@@ -85,7 +399,7 @@ type MonkeyTestViolation = {
 
 At most 50 violations are collected before the run stops early, so the result stays readable even when a rule is broadly broken.
 
-## Testing with conditions
+### Testing with conditions
 
 If your umpire uses conditions, pass representative snapshots so they're included in each probe:
 
@@ -100,7 +414,7 @@ const result = monkeyTest(ump, {
 
 Each conditions entry is tested against every sampled value combination.
 
-## Example: catching a foul cycle
+### Example: catching a foul cycle
 
 ```ts
 import { umpire, disables, enabledWhen } from '@umpire/core'
@@ -123,7 +437,47 @@ if (!result.passed) {
 }
 ```
 
+### Complementing trackCoverage
+
+`trackCoverage` and `monkeyTest` answer different questions and are worth running together.
+
+`trackCoverage` tells you which states your named scenarios exercised — it's coverage in the sense of deliberate test design. If `uncoveredRules` is non-empty, a rule went untested by any scenario you wrote.
+
+`monkeyTest` doesn't know about your scenarios. It probes the rule graph directly across inputs no human would enumerate, looking for structural failures. A rule could be covered by `trackCoverage` and still fail `monkeyTest` — if, for example, the predicate that implements it is impure or produces foul cycles on certain value combinations.
+
+```ts
+import { umpire, fairWhen, requires } from '@umpire/core'
+import { trackCoverage, monkeyTest } from '@umpire/testing'
+
+const ump = umpire({
+  fields: {
+    email: { required: true },
+    password: { required: true },
+    referralCode: {},
+  },
+  rules: [
+    requires('referralCode', 'email'),
+    fairWhen('password', (val) => String(val).length >= 8, {
+      reason: 'Password must be at least 8 characters',
+    }),
+  ],
+})
+
+const tracker = trackCoverage(ump)
+
+// Scenario tests run through the tracker
+tracker.ump.check({ email: 'user@example.com', password: 'hunter2!', referralCode: 'PROMO' })
+tracker.ump.check({ email: null, password: 'abc' })
+
+// Every rule failure was exercised by at least one scenario
+expect(tracker.report().uncoveredRules).toEqual([])
+
+// Structural invariants hold across all sampled inputs
+expect(monkeyTest(ump).passed).toBe(true)
+```
+
 ## See also
 
 - [`umpire()` construction-time checks](/api/umpire/#structural-contradiction-detection) — what gets caught before runtime
+- [scorecard()](/api/scorecard/) — the transition API that `scorecardAssert` wraps
 - [DevTools](/extensions/devtools/) — visual inspection of scorecards and foul logs during development

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -78,6 +78,7 @@ const fouls = signupUmp.play(
 - `ump.init(overrides?)` returns default field values.
 - `ump.challenge(field, values, conditions?, prev?)` returns a debug trace for one field.
 - `ump.graph()` returns the structural dependency graph.
+- `ump.rules()` returns normalized runtime rule entries with `id`, `index`, and inspection metadata for debugging and test tooling.
 
 See the docs for full type details and behavior notes: https://sdougbrown.github.io/umpire/
 

--- a/packages/core/__tests__/challenge.test.ts
+++ b/packages/core/__tests__/challenge.test.ts
@@ -9,6 +9,7 @@ import {
   oneOf,
   requires,
 } from '../src/rules.js'
+import { field } from '../src/field.js'
 import { umpire } from '../src/umpire.js'
 
 type TestFields = {
@@ -27,6 +28,86 @@ type TestConditions = {
 }
 
 describe('challenge', () => {
+  test('exposes normalized runtime rules with inspections', () => {
+    const ump = umpire({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        requires('submit', 'email'),
+        fairWhen('password', (value) => value === 'secret'),
+      ],
+    })
+
+    expect(ump.rules()).toEqual([
+      {
+        index: 0,
+        id: expect.any(String),
+        inspection: expect.objectContaining({
+          kind: 'requires',
+          target: 'submit',
+        }),
+      },
+      {
+        index: 1,
+        id: expect.any(String),
+        inspection: expect.objectContaining({
+          kind: 'fairWhen',
+          target: 'password',
+        }),
+      },
+    ])
+  })
+
+  test('pins field-builder rules before explicit rules in normalized order', () => {
+    const ump = umpire({
+      fields: {
+        email: {},
+        password: {},
+        submit: field('submit').requires('email'),
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [requires('submit', 'password')],
+    })
+
+    expect(ump.rules()).toEqual([
+      {
+        index: 0,
+        id: expect.any(String),
+        inspection: expect.objectContaining({
+          kind: 'requires',
+          target: 'submit',
+          dependencies: [{ kind: 'field', field: 'email' }],
+        }),
+      },
+      {
+        index: 1,
+        id: expect.any(String),
+        inspection: expect.objectContaining({
+          kind: 'requires',
+          target: 'submit',
+          dependencies: [{ kind: 'field', field: 'password' }],
+        }),
+      },
+    ])
+
+    expect(ump.challenge('submit', {}).directReasons).toEqual([
+      expect.objectContaining({ ruleIndex: 0, ruleId: expect.any(String) }),
+      expect.objectContaining({ ruleIndex: 1, ruleId: expect.any(String) }),
+    ])
+  })
+
   test('includes all direct reasons, including passed rules', () => {
     const ump = umpire<TestFields, TestConditions>({
       fields: {
@@ -65,16 +146,22 @@ describe('challenge', () => {
     expect(challenge.directReasons).toEqual([
       expect.objectContaining({
         rule: 'enabledWhen',
+        ruleIndex: 0,
+        ruleId: expect.any(String),
         passed: false,
         reason: 'Complete the captcha to continue',
       }),
       expect.objectContaining({
         rule: 'requires',
+        ruleIndex: 1,
+        ruleId: expect.any(String),
         passed: false,
         reason: 'Enter a valid email address',
       }),
       expect.objectContaining({
         rule: 'enabledWhen',
+        ruleIndex: 2,
+        ruleId: expect.any(String),
         passed: true,
         reason: null,
       }),

--- a/packages/core/__tests__/challenge.test.ts
+++ b/packages/core/__tests__/challenge.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/rules.js'
 import { field } from '../src/field.js'
 import { umpire } from '../src/umpire.js'
+import type { Rule } from '../src/types.js'
 
 type TestFields = {
   email: {}
@@ -105,6 +106,89 @@ describe('challenge', () => {
     expect(ump.challenge('submit', {}).directReasons).toEqual([
       expect.objectContaining({ ruleIndex: 0, ruleId: expect.any(String) }),
       expect.objectContaining({ ruleIndex: 1, ruleId: expect.any(String) }),
+    ])
+  })
+
+  test('exposes undefined inspection for uninspectable rules', () => {
+    const opaqueRule: Rule<TestFields> = {
+      type: 'opaque',
+      targets: ['submit'],
+      sources: [],
+      evaluate: () =>
+        new Map([['submit', { enabled: false, reason: 'Hidden rule' }]]),
+    }
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [opaqueRule],
+    })
+
+    expect(ump.rules()).toEqual([
+      {
+        index: 0,
+        id: 'uninspectable:0',
+        inspection: undefined,
+      },
+    ])
+  })
+
+  test('returns defensive copies of rule inspections', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        anyOf(requires('submit', 'email'), requires('submit', 'password')),
+      ],
+    })
+    const rules = ump.rules()
+    const inspection = rules[0]?.inspection
+
+    if (inspection?.kind === 'anyOf') {
+      inspection.rules.push({
+        kind: 'requires',
+        target: 'submit',
+        dependencies: [],
+        hasDynamicReason: false,
+      })
+    }
+
+    expect(ump.rules()[0]?.inspection).not.toEqual(inspection)
+  })
+
+  test('suffixes duplicate rule ids in normalized order', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [requires('submit', 'email'), requires('submit', 'email')],
+    })
+
+    expect(ump.rules().map((entry) => entry.id)).toEqual([
+      'requires:submit:email',
+      'requires:submit:email#2',
     ])
   })
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
   ChallengeDirectReason,
   ChallengeTraceAttachment,
   Rule,
+  RuleEntry,
   RuleTraceAttachment,
   RuleTraceAttachmentResult,
   RuleTraceDependency,

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -687,6 +687,13 @@ export function inspectRule<
   return undefined
 }
 
+export function cloneRuleInspection<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(inspection: RuleInspection<F, C>): RuleInspection<F, C> {
+  return structuredClone(inspection)
+}
+
 export function getInternalRuleOptions<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,5 @@
+import type { RuleInspection } from './rules.js'
+
 export interface FieldDef<V = unknown> {
   required?: boolean
   default?: V
@@ -136,6 +138,8 @@ export type ChallengeDirectReason = {
   rule: string
   reason: string | null
   passed: boolean
+  ruleIndex?: number
+  ruleId?: string
   trace?: ChallengeTraceAttachment[]
   [key: string]: unknown
 }
@@ -242,6 +246,15 @@ export type Rule<
   ) => Map<string, RuleEvaluation>
 }
 
+export type RuleEntry<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  index: number
+  id: string
+  inspection: RuleInspection<F, C> | undefined
+}
+
 export interface Umpire<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown> = Record<string, unknown>,
@@ -264,6 +277,7 @@ export interface Umpire<
     prev?: InputValues,
   ): ChallengeTrace
   graph(): UmpireGraph
+  rules(): RuleEntry<F, C>[]
 }
 
 export type FieldsOf<U> = U extends Umpire<infer F> ? F : never

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -228,21 +228,6 @@ function didRulePass<
   return isFairRule(rule) ? evaluation.fair !== false : evaluation.enabled
 }
 
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`
-  }
-
-  if (value && typeof value === 'object') {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
-      .join(',')}}`
-  }
-
-  return JSON.stringify(value)
-}
-
 function buildRuleEntries<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -252,7 +237,9 @@ function buildRuleEntries<
   return rules.map((rule, index) => {
     const inspection = inspectRule(rule)
     const baseId = inspection
-      ? `${inspection.kind}:${stableStringify(inspection)}`
+      ? [inspection.kind, rule.targets.join(','), rule.sources.join(',')].join(
+          ':',
+        )
       : `uninspectable:${index}`
     const seenCount = seenIds.get(baseId) ?? 0
 

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -26,6 +26,7 @@ import {
   getInternalRuleMetadata,
   getInternalRuleOptions,
   isFairRule,
+  cloneRuleInspection,
   inspectRule,
   type InternalRuleMetadata,
   getSourceField,
@@ -231,10 +232,16 @@ function didRulePass<
 function buildRuleEntries<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(rules: Rule<F, C>[]): Array<RuleEntry<F, C>> {
+>(
+  rules: Rule<F, C>[],
+): {
+  entries: Array<RuleEntry<F, C>>
+  entryByRule: Map<Rule<F, C>, RuleEntry<F, C>>
+} {
   const seenIds = new Map<string, number>()
+  const entryByRule = new Map<Rule<F, C>, RuleEntry<F, C>>()
 
-  return rules.map((rule, index) => {
+  const entries = rules.map((rule, index) => {
     const inspection = inspectRule(rule)
     const baseId = inspection
       ? [inspection.kind, rule.targets.join(','), rule.sources.join(',')].join(
@@ -245,12 +252,30 @@ function buildRuleEntries<
 
     seenIds.set(baseId, seenCount + 1)
 
-    return {
+    const entry = {
       index,
       id: seenCount === 0 ? baseId : `${baseId}#${seenCount + 1}`,
       inspection,
     }
+
+    entryByRule.set(rule, entry)
+    return entry
   })
+
+  return { entries, entryByRule }
+}
+
+function cloneRuleEntry<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(entry: RuleEntry<F, C>): RuleEntry<F, C> {
+  return {
+    ...entry,
+    inspection:
+      entry.inspection === undefined
+        ? undefined
+        : cloneRuleInspection(entry.inspection),
+  }
 }
 
 function normalizeConfig<
@@ -1066,11 +1091,8 @@ export function umpire<
   detectCycles(graph)
   const topoOrder = topologicalSort(graph, fieldNames)
   const rulesByTarget = indexRulesByTarget(rules)
-  const ruleEntries = buildRuleEntries(rules)
-  const ruleEntryByRule = new Map<
-    Rule<NormalizeFields<FInput>, C>,
-    RuleEntry<NormalizeFields<FInput>, C>
-  >(rules.map((rule, index) => [rule, ruleEntries[index]]))
+  const { entries: ruleEntries, entryByRule: ruleEntryByRule } =
+    buildRuleEntries(rules)
   const rulesByTargetPhase = indexRulesByTargetPhase(rulesByTarget)
   const exportedGraph = exportGraph(graph)
   const { incomingByField, outgoingByField } = buildFieldEdgeLookup(
@@ -1448,7 +1470,7 @@ export function umpire<
     },
 
     rules() {
-      return ruleEntries.map((entry) => ({ ...entry }))
+      return ruleEntries.map((entry) => cloneRuleEntry(entry))
     },
   }
 }

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -26,6 +26,7 @@ import {
   getInternalRuleMetadata,
   getInternalRuleOptions,
   isFairRule,
+  inspectRule,
   type InternalRuleMetadata,
   getSourceField,
   requires,
@@ -47,6 +48,7 @@ import type {
   Foul,
   InputValues,
   Rule,
+  RuleEntry,
   RuleEvaluation,
   RuleTraceAttachment,
   ScorecardOptions,
@@ -226,6 +228,44 @@ function didRulePass<
   return isFairRule(rule) ? evaluation.fair !== false : evaluation.enabled
 }
 
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+      .join(',')}}`
+  }
+
+  return JSON.stringify(value)
+}
+
+function buildRuleEntries<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(rules: Rule<F, C>[]): Array<RuleEntry<F, C>> {
+  const seenIds = new Map<string, number>()
+
+  return rules.map((rule, index) => {
+    const inspection = inspectRule(rule)
+    const baseId = inspection
+      ? `${inspection.kind}:${stableStringify(inspection)}`
+      : `uninspectable:${index}`
+    const seenCount = seenIds.get(baseId) ?? 0
+
+    seenIds.set(baseId, seenCount + 1)
+
+    return {
+      index,
+      id: seenCount === 0 ? baseId : `${baseId}#${seenCount + 1}`,
+      inspection,
+    }
+  })
+}
+
 function normalizeConfig<
   F extends Record<string, FieldInput>,
   C extends Record<string, unknown>,
@@ -290,14 +330,16 @@ function normalizeConfig<
         continue
       }
 
+      const dependency = attachedRule.dependency as keyof NormalizeFields<F> &
+        string
+      const options = attachedRule.options as
+        | Parameters<typeof requires<NormalizeFields<F>, C>>[2]
+        | undefined
+
       attachedRules.push(
-        requires<NormalizeFields<F>, C>(
-          fieldKey,
-          attachedRule.dependency as keyof NormalizeFields<F> & string,
-          attachedRule.options as Parameters<
-            typeof requires<NormalizeFields<F>, C>
-          >[2],
-        ),
+        options
+          ? requires<NormalizeFields<F>, C>(fieldKey, dependency, options)
+          : requires<NormalizeFields<F>, C>(fieldKey, dependency),
       )
     }
   }
@@ -320,6 +362,7 @@ function describeRuleForField<
   prev: FieldValues<F> | undefined,
   availability: AvailabilityMap<F>,
   baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>,
+  ruleEntry?: RuleEntry<F, C>,
 ): ChallengeTrace['directReasons'][number] {
   const metadata = getInternalRuleMetadata(rule)
   const evaluation = evaluateRuleForField(
@@ -339,6 +382,8 @@ function describeRuleForField<
     return withRuleTrace(
       {
         rule: 'enabledWhen',
+        ruleIndex: ruleEntry?.index,
+        ruleId: ruleEntry?.id,
         passed: evaluation.enabled,
         reason: evaluation.reason,
         predicate: metadata.predicate.toString(),
@@ -363,6 +408,8 @@ function describeRuleForField<
     return withRuleTrace(
       {
         rule: 'disables',
+        ruleIndex: ruleEntry?.index,
+        ruleId: ruleEntry?.id,
         passed: evaluation.enabled,
         reason: evaluation.reason,
         source,
@@ -380,6 +427,8 @@ function describeRuleForField<
     return withRuleTrace(
       {
         rule: 'fair',
+        ruleIndex: ruleEntry?.index,
+        ruleId: ruleEntry?.id,
         passed: evaluation.fair !== false,
         reason: evaluation.reason,
         predicate: metadata.predicate.toString(),
@@ -417,6 +466,8 @@ function describeRuleForField<
     return withRuleTrace(
       {
         rule: 'requires',
+        ruleIndex: ruleEntry?.index,
+        ruleId: ruleEntry?.id,
         passed: evaluation.enabled,
         reason: evaluation.reason,
         dependency: dependencies[0]?.dependency,
@@ -476,11 +527,14 @@ function describeRuleForField<
           prev,
           availability,
           baseRuleCache,
+          ruleEntry,
         ),
     )
 
     return {
       rule: 'anyOf',
+      ruleIndex: ruleEntry?.index,
+      ruleId: ruleEntry?.id,
       passed: didRulePass(rule, evaluation),
       reason: evaluation.reason,
       inner,
@@ -500,6 +554,7 @@ function describeRuleForField<
             prev,
             availability,
             baseRuleCache,
+            ruleEntry,
           ),
         )
 
@@ -522,6 +577,8 @@ function describeRuleForField<
 
     return {
       rule: 'eitherOf',
+      ruleIndex: ruleEntry?.index,
+      ruleId: ruleEntry?.id,
       passed: didRulePass(rule, evaluation),
       reason: evaluation.reason,
       group: metadata.groupName,
@@ -534,6 +591,8 @@ function describeRuleForField<
   return withRuleTrace(
     {
       rule: rule.type,
+      ruleIndex: ruleEntry?.index,
+      ruleId: ruleEntry?.id,
       passed: didRulePass(rule, evaluation),
       reason: evaluation.reason,
     },
@@ -693,6 +752,7 @@ function describeCausedBy<
   prev: FieldValues<F> | undefined,
   availability: AvailabilityMap<F>,
   baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>,
+  ruleEntryByRule: Map<Rule<F, C>, RuleEntry<F, C>>,
 ): ChallengeTrace['transitiveDeps'][number]['causedBy'] {
   const causedBy: ChallengeTrace['transitiveDeps'][number]['causedBy'] = []
 
@@ -706,6 +766,7 @@ function describeCausedBy<
       prev,
       availability,
       baseRuleCache,
+      ruleEntryByRule.get(rule),
     )
 
     if (entry.passed) {
@@ -734,6 +795,7 @@ function buildTransitiveDeps<
   prev: FieldValues<F> | undefined,
   availability: AvailabilityMap<F>,
   baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>,
+  ruleEntryByRule: Map<Rule<F, C>, RuleEntry<F, C>>,
 ) {
   const visited = new Set<string>()
   const result: ChallengeTrace['transitiveDeps'] = []
@@ -771,6 +833,7 @@ function buildTransitiveDeps<
             prev,
             availability,
             baseRuleCache,
+            ruleEntryByRule,
           ),
         })
 
@@ -1014,6 +1077,11 @@ export function umpire<
   detectCycles(graph)
   const topoOrder = topologicalSort(graph, fieldNames)
   const rulesByTarget = indexRulesByTarget(rules)
+  const ruleEntries = buildRuleEntries(rules)
+  const ruleEntryByRule = new Map<
+    Rule<NormalizeFields<FInput>, C>,
+    RuleEntry<NormalizeFields<FInput>, C>
+  >(rules.map((rule, index) => [rule, ruleEntries[index]]))
   const rulesByTargetPhase = indexRulesByTargetPhase(rulesByTarget)
   const exportedGraph = exportGraph(graph)
   const { incomingByField, outgoingByField } = buildFieldEdgeLookup(
@@ -1188,6 +1256,7 @@ export function umpire<
         typedPrev,
         availability,
         baseRuleCache,
+        ruleEntryByRule.get(rule),
       ),
     )
 
@@ -1228,6 +1297,7 @@ export function umpire<
         typedPrev,
         availability,
         baseRuleCache,
+        ruleEntryByRule,
       ),
       oneOfResolution,
     }
@@ -1386,6 +1456,10 @@ export function umpire<
 
     graph() {
       return exportCompiledGraph()
+    },
+
+    rules() {
+      return ruleEntries.map((entry) => ({ ...entry }))
     },
   }
 }

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -489,6 +489,8 @@ function describeRuleForField<
     return withRuleTrace(
       {
         rule: 'oneOf',
+        ruleIndex: ruleEntry?.index,
+        ruleId: ruleEntry?.id,
         passed: evaluation.enabled,
         reason: evaluation.reason,
         group: metadata.groupName,

--- a/packages/testing/AGENTS.md
+++ b/packages/testing/AGENTS.md
@@ -14,3 +14,9 @@
 - All methods accept variadic field names and return the chain for further assertions.
 - Disabled fields always have `fair: true`; `.foul()` therefore only fires for enabled fields with invalid values.
 - Throws `Error` with a descriptive message listing all failing fields — compatible with any test framework.
+
+## scorecardAssert
+
+- Use `scorecardAssert(ump.scorecard(after, { before }))` for readable transition assertions.
+- Methods: `.changed()`, `.notChanged()`, `.cascaded()`, `.fouled()`, `.notFouled()`, `.onlyChanged()`, `.onlyFouled()`, `.check()`.
+- `.check()` delegates to `checkAssert(result.check)` for availability assertions on the same scorecard.

--- a/packages/testing/AGENTS.md
+++ b/packages/testing/AGENTS.md
@@ -1,6 +1,16 @@
 # @umpire/testing
 
+## monkeyTest
+
 - Use `monkeyTest(ump, options?)` in tests and assert on the returned `passed` flag or `violations`.
 - Configs with 6 or fewer fields are tested exhaustively; larger configs are sampled with a seeded PRNG.
 - Pass representative `conditions` snapshots when rules depend on external context.
 - Violations are structural invariant failures, not user-facing validation errors.
+
+## checkAssert
+
+- Use `checkAssert(ump.check(values))` for readable scenario-level assertions on field availability.
+- Methods: `.enabled()`, `.disabled()`, `.fair()`, `.foul()`, `.required()`, `.optional()`, `.satisfied()`, `.unsatisfied()`.
+- All methods accept variadic field names and return the chain for further assertions.
+- Disabled fields always have `fair: true`; `.foul()` therefore only fires for enabled fields with invalid values.
+- Throws `Error` with a descriptive message listing all failing fields — compatible with any test framework.

--- a/packages/testing/AGENTS.md
+++ b/packages/testing/AGENTS.md
@@ -20,3 +20,11 @@
 - Use `scorecardAssert(ump.scorecard(after, { before }))` for readable transition assertions.
 - Methods: `.changed()`, `.notChanged()`, `.cascaded()`, `.fouled()`, `.notFouled()`, `.onlyChanged()`, `.onlyFouled()`, `.check()`.
 - `.check()` delegates to `checkAssert(result.check)` for availability assertions on the same scorecard.
+
+## trackCoverage
+
+- Use `trackCoverage(ump)` when tests need to prove they exercised meaningful field states and rule failures.
+- Only instrumented `tracker.ump.check()` and `tracker.ump.scorecard()` calls contribute to coverage.
+- `report().fieldStates` records enabled/disabled, fair/foul, and satisfied/unsatisfied observations for every field.
+- `report().uncoveredRules` relies on core `ump.rules()` plus `challenge()` `ruleId` metadata to distinguish specific rule instances; normalized `index` is still included for lookup.
+- `reset()` clears observed field states and covered rule indexes without rebuilding the wrapped umpire.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -93,3 +93,34 @@ monkeyTest(ump, {
 ```
 
 Each conditions entry is tested against every sampled value combination.
+
+## `checkAssert(result)`
+
+Readable scenario assertions over `ump.check(values)` results.
+
+```typescript
+import { checkAssert } from '@umpire/testing'
+
+checkAssert(ump.check({ gate: 'open' }))
+  .enabled('gate')
+  .optional('gate')
+```
+
+Methods: `.enabled()`, `.disabled()`, `.fair()`, `.foul()`, `.required()`, `.optional()`, `.satisfied()`, `.unsatisfied()`.
+
+## `scorecardAssert(result)`
+
+Readable transition assertions over `ump.scorecard(snapshot, { before })` results.
+
+```typescript
+import { scorecardAssert } from '@umpire/testing'
+
+scorecardAssert(ump.scorecard(after, { before }))
+  .changed('cardType')
+  .cascaded('cardNumber', 'expiryDate')
+  .fouled('cardNumber', 'expiryDate')
+  .check()
+  .disabled('cardNumber', 'expiryDate')
+```
+
+Methods: `.changed()`, `.notChanged()`, `.cascaded()`, `.fouled()`, `.notFouled()`, `.onlyChanged()`, `.onlyFouled()`, `.check()`.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -124,3 +124,28 @@ scorecardAssert(ump.scorecard(after, { before }))
 ```
 
 Methods: `.changed()`, `.notChanged()`, `.cascaded()`, `.fouled()`, `.notFouled()`, `.onlyChanged()`, `.onlyFouled()`, `.check()`.
+
+## `trackCoverage(ump)`
+
+Instruments an umpire instance so scenario tests can report which field states
+and rule failures they exercised. Only calls made through `tracker.ump.check()`
+and `tracker.ump.scorecard()` contribute to coverage.
+
+```typescript
+import { trackCoverage } from '@umpire/testing'
+
+const tracker = trackCoverage(ump)
+
+tracker.ump.check({ cardType: 'visa', cardNumber: '4111' })
+tracker.ump.scorecard(after, { before })
+
+expect(tracker.report().fieldStates.cardNumber.seenEnabled).toBe(true)
+expect(tracker.report().uncoveredRules).toEqual([])
+```
+
+`report().fieldStates` records `seenEnabled`, `seenDisabled`, `seenFair`,
+`seenFoul`, `seenSatisfied`, and `seenUnsatisfied` for every field. The
+`uncoveredRules` list is based on `ump.rules()` and `challenge()` `ruleId`
+metadata from `@umpire/core`, so it can distinguish multiple same-type rules on
+the same target while still exposing the normalized rule `index`. Use
+`tracker.reset()` to clear observations between scenarios.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -96,56 +96,145 @@ Each conditions entry is tested against every sampled value combination.
 
 ## `checkAssert(result)`
 
-Readable scenario assertions over `ump.check(values)` results.
+Takes the result of `ump.check(values)` and returns a fluent assertion chain. Each method accepts variadic field names and throws a plain `Error` listing every failing field if any assertion fails — no test runner integration needed.
 
 ```typescript
+import { fairWhen, requires, umpire } from '@umpire/core'
 import { checkAssert } from '@umpire/testing'
 
-checkAssert(ump.check({ gate: 'open' }))
-  .enabled('gate')
-  .optional('gate')
+const ump = umpire({
+  fields: {
+    email: { required: true },
+    password: { required: true },
+    referralCode: {},
+  },
+  rules: [
+    requires('referralCode', 'email'),
+    fairWhen('password', (val) => String(val).length >= 8, {
+      reason: 'Password must be at least 8 characters',
+    }),
+  ],
+})
+
+// No email — referralCode is disabled; short password is foul
+checkAssert(ump.check({ password: 'abc' }))
+  .disabled('referralCode')
+  .foul('password')
+  .unsatisfied('email')
+  .required('email', 'password')
 ```
 
 Methods: `.enabled()`, `.disabled()`, `.fair()`, `.foul()`, `.required()`, `.optional()`, `.satisfied()`, `.unsatisfied()`.
 
+All methods return `this` for chaining. Disabled fields always have `fair: true` in umpire, so `.foul()` only fires for enabled fields with values that fail a fairness predicate.
+
+For full documentation see the [Testing reference](https://umpire.dev/extensions/testing/#checkassertresult).
+
 ## `scorecardAssert(result)`
 
-Readable transition assertions over `ump.scorecard(snapshot, { before })` results.
+Takes the result of `ump.scorecard(snapshot, { before })` and returns a fluent assertion chain over the transition. Use it to verify what changed, what cascaded, and what earned a foul-reset recommendation.
 
 ```typescript
+import { requires, umpire } from '@umpire/core'
 import { scorecardAssert } from '@umpire/testing'
 
-scorecardAssert(ump.scorecard(after, { before }))
-  .changed('cardType')
+const ump = umpire({
+  fields: {
+    cardType: {},
+    cardNumber: {},
+    expiryDate: {},
+    billingZip: {},
+  },
+  rules: [
+    requires('cardNumber', 'cardType', { reason: 'Pick a card type first' }),
+    requires('expiryDate', 'cardNumber', {
+      reason: 'Enter a card number first',
+    }),
+  ],
+})
+
+// User clears cardType after the form was filled in
+const result = ump.scorecard(
+  {
+    values: {
+      cardType: null,
+      cardNumber: '4111111111111111',
+      expiryDate: '12/30',
+      billingZip: '10001',
+    },
+  },
+  {
+    before: {
+      values: {
+        cardType: 'visa',
+        cardNumber: '4111111111111111',
+        expiryDate: '12/30',
+        billingZip: '10001',
+      },
+    },
+  },
+)
+
+scorecardAssert(result)
+  .onlyChanged('cardType')
   .cascaded('cardNumber', 'expiryDate')
   .fouled('cardNumber', 'expiryDate')
+  .notFouled('billingZip')
   .check()
   .disabled('cardNumber', 'expiryDate')
+  .enabled('cardType', 'billingZip')
 ```
 
 Methods: `.changed()`, `.notChanged()`, `.cascaded()`, `.fouled()`, `.notFouled()`, `.onlyChanged()`, `.onlyFouled()`, `.check()`.
 
+`.check()` delegates to `checkAssert(result.check)` so you can make availability assertions on the same scorecard result without a separate `ump.check()` call.
+
+For full documentation see the [Testing reference](https://umpire.dev/extensions/testing/#scorecardassertresult).
+
 ## `trackCoverage(ump)`
 
-Instruments an umpire instance so scenario tests can report which field states
-and rule failures they exercised. Only calls made through `tracker.ump.check()`
-and `tracker.ump.scorecard()` contribute to coverage.
+Wraps an umpire instance and instruments it so your scenario tests can report which field states and rule failures they actually exercised. The tracker answers: did any test see `referralCode` while disabled? Did the `fairWhen(password, ...)` rule ever fire?
+
+Only calls through `tracker.ump` contribute to coverage — calling the original unwrapped umpire does not.
 
 ```typescript
+import { fairWhen, requires, umpire } from '@umpire/core'
 import { trackCoverage } from '@umpire/testing'
+
+const ump = umpire({
+  fields: {
+    email: { required: true },
+    password: { required: true },
+    referralCode: {},
+  },
+  rules: [
+    requires('referralCode', 'email'),
+    fairWhen('password', (val) => String(val).length >= 8, {
+      reason: 'Password must be at least 8 characters',
+    }),
+  ],
+})
 
 const tracker = trackCoverage(ump)
 
-tracker.ump.check({ cardType: 'visa', cardNumber: '4111' })
-tracker.ump.scorecard(after, { before })
+// Scenario 1: email present — referralCode unlocked, password valid
+tracker.ump.check({
+  email: 'user@example.com',
+  password: 'hunter2!',
+  referralCode: 'PROMO',
+})
 
-expect(tracker.report().fieldStates.cardNumber.seenEnabled).toBe(true)
-expect(tracker.report().uncoveredRules).toEqual([])
+// Scenario 2: no email — referralCode disabled, password foul
+tracker.ump.check({ email: null, password: 'abc' })
+
+const { fieldStates, uncoveredRules } = tracker.report()
+
+expect(fieldStates.referralCode.seenEnabled).toBe(true)
+expect(fieldStates.referralCode.seenDisabled).toBe(true)
+expect(fieldStates.password.seenFoul).toBe(true)
+expect(uncoveredRules).toEqual([])
 ```
 
-`report().fieldStates` records `seenEnabled`, `seenDisabled`, `seenFair`,
-`seenFoul`, `seenSatisfied`, and `seenUnsatisfied` for every field. The
-`uncoveredRules` list is based on `ump.rules()` and `challenge()` `ruleId`
-metadata from `@umpire/core`, so it can distinguish multiple same-type rules on
-the same target while still exposing the normalized rule `index`. Use
-`tracker.reset()` to clear observations between scenarios.
+`report().fieldStates` records `seenEnabled`, `seenDisabled`, `seenFair`, `seenFoul`, `seenSatisfied`, and `seenUnsatisfied` for every field. `report().uncoveredRules` lists rules that never produced a failure in any instrumented call, using `challenge()` `ruleId` metadata to distinguish multiple same-type rules on the same target. Call `tracker.reset()` to clear observations between scenarios without rebuilding the wrapped umpire.
+
+For full documentation see the [Testing reference](https://umpire.dev/extensions/testing/#trackcoverageump).

--- a/packages/testing/__tests__/check-assert.test.ts
+++ b/packages/testing/__tests__/check-assert.test.ts
@@ -1,0 +1,174 @@
+import { fairWhen, requires, umpire } from '@umpire/core'
+import { checkAssert } from '../src/index.js'
+
+const ump = umpire({
+  fields: {
+    gate: {},
+    guarded: {},
+    flagged: {},
+    pinned: { required: true },
+  },
+  rules: [
+    requires('guarded', 'gate'),
+    fairWhen('flagged', (val: string) => val !== 'bad'),
+  ],
+})
+
+describe('checkAssert', () => {
+  describe('.enabled()', () => {
+    test('passes when all specified fields are enabled', () => {
+      const result = ump.check({ gate: 'open', guarded: 'x' })
+      expect(() => checkAssert(result).enabled('gate', 'guarded')).not.toThrow()
+    })
+
+    test('throws with reason when a field is disabled', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).enabled('guarded')).toThrow(
+        'checkAssert: expected "guarded" to be enabled — was disabled (reason: "requires gate")',
+      )
+    })
+
+    test('lists all failing fields when multiple are disabled', () => {
+      const ump2 = umpire({
+        fields: { a: {}, b: {}, c: {} },
+        rules: [requires('b', 'a'), requires('c', 'a')],
+      })
+      const result = ump2.check({})
+      expect(() => checkAssert(result).enabled('b', 'c')).toThrow(
+        'expected the following field(s) to be enabled',
+      )
+    })
+
+    test('returns the chain for further assertions', () => {
+      const result = ump.check({})
+      expect(() =>
+        checkAssert(result).enabled('gate').disabled('guarded'),
+      ).not.toThrow()
+    })
+  })
+
+  describe('.disabled()', () => {
+    test('passes when fields are disabled', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).disabled('guarded')).not.toThrow()
+    })
+
+    test('throws when a field is enabled', () => {
+      const result = ump.check({ gate: 'open', guarded: 'x' })
+      expect(() => checkAssert(result).disabled('guarded')).toThrow(
+        'checkAssert: expected "guarded" to be disabled — was enabled',
+      )
+    })
+  })
+
+  describe('.fair()', () => {
+    test('passes when fields are fair', () => {
+      const result = ump.check({ flagged: 'good' })
+      expect(() => checkAssert(result).fair('flagged')).not.toThrow()
+    })
+
+    test('passes for disabled fields (disabled fields are always fair)', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).fair('guarded')).not.toThrow()
+    })
+
+    test('throws with reason when a field is foul', () => {
+      const result = ump.check({ flagged: 'bad' })
+      expect(() => checkAssert(result).fair('flagged')).toThrow(
+        'checkAssert: expected "flagged" to be fair — was foul',
+      )
+    })
+  })
+
+  describe('.foul()', () => {
+    test('passes when a field has a foul value', () => {
+      const result = ump.check({ flagged: 'bad' })
+      expect(() => checkAssert(result).foul('flagged')).not.toThrow()
+    })
+
+    test('throws when the field is fair', () => {
+      const result = ump.check({ flagged: 'good' })
+      expect(() => checkAssert(result).foul('flagged')).toThrow(
+        'checkAssert: expected "flagged" to be foul — was fair (enabled: true)',
+      )
+    })
+  })
+
+  describe('.required()', () => {
+    test('passes when the field is required', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).required('pinned')).not.toThrow()
+    })
+
+    test('throws when the field is optional', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).required('gate')).toThrow(
+        'checkAssert: expected "gate" to be required — was optional',
+      )
+    })
+  })
+
+  describe('.optional()', () => {
+    test('passes when the field is optional', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).optional('gate')).not.toThrow()
+    })
+
+    test('throws when the field is required', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).optional('pinned')).toThrow(
+        'checkAssert: expected "pinned" to be optional — was required',
+      )
+    })
+  })
+
+  describe('.satisfied()', () => {
+    test('passes when the field has a value', () => {
+      const result = ump.check({ gate: 'open' })
+      expect(() => checkAssert(result).satisfied('gate')).not.toThrow()
+    })
+
+    test('throws when the field has no value', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).satisfied('gate')).toThrow(
+        'checkAssert: expected "gate" to be satisfied — was unsatisfied (no value)',
+      )
+    })
+  })
+
+  describe('.unsatisfied()', () => {
+    test('passes when the field has no value', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).unsatisfied('gate')).not.toThrow()
+    })
+
+    test('throws when the field has a value', () => {
+      const result = ump.check({ gate: 'open' })
+      expect(() => checkAssert(result).unsatisfied('gate')).toThrow(
+        'checkAssert: expected "gate" to be unsatisfied — was satisfied (has a value)',
+      )
+    })
+  })
+
+  describe('unknown field', () => {
+    test('throws immediately for an unknown field name', () => {
+      const result = ump.check({})
+      expect(() =>
+        checkAssert(result).enabled('nonexistent' as 'gate'),
+      ).toThrow('checkAssert: unknown field "nonexistent"')
+    })
+  })
+
+  describe('chaining', () => {
+    test('multiple assertions can be chained on a single result', () => {
+      const result = ump.check({ gate: 'open', flagged: 'good' })
+      expect(() =>
+        checkAssert(result)
+          .enabled('gate', 'guarded')
+          .fair('flagged')
+          .optional('gate')
+          .required('pinned'),
+      ).not.toThrow()
+    })
+  })
+})

--- a/packages/testing/__tests__/check-assert.test.ts
+++ b/packages/testing/__tests__/check-assert.test.ts
@@ -1,4 +1,4 @@
-import { fairWhen, requires, umpire } from '@umpire/core'
+import { enabledWhen, fairWhen, requires, umpire } from '@umpire/core'
 import { checkAssert } from '../src/index.js'
 
 const ump = umpire({
@@ -25,6 +25,18 @@ describe('checkAssert', () => {
       const result = ump.check({})
       expect(() => checkAssert(result).enabled('guarded')).toThrow(
         'checkAssert: expected "guarded" to be enabled — was disabled (reason: "requires gate")',
+      )
+    })
+
+    test('throws without reason metadata when a field is disabled silently', () => {
+      const silentUmp = umpire({
+        fields: { guarded: {} },
+        rules: [enabledWhen('guarded', () => false, { reason: () => '' })],
+      })
+      const result = silentUmp.check({})
+
+      expect(() => checkAssert(result).enabled('guarded')).toThrow(
+        'checkAssert: expected "guarded" to be enabled — was disabled',
       )
     })
 
@@ -90,6 +102,13 @@ describe('checkAssert', () => {
       const result = ump.check({ flagged: 'good' })
       expect(() => checkAssert(result).foul('flagged')).toThrow(
         'checkAssert: expected "flagged" to be foul — was fair (enabled: true)',
+      )
+    })
+
+    test('throws when a disabled field is fair', () => {
+      const result = ump.check({})
+      expect(() => checkAssert(result).foul('guarded')).toThrow(
+        'checkAssert: expected "guarded" to be foul — was fair (enabled: false)',
       )
     })
   })

--- a/packages/testing/__tests__/scorecard-assert.test.ts
+++ b/packages/testing/__tests__/scorecard-assert.test.ts
@@ -1,0 +1,189 @@
+import { requires, umpire } from '@umpire/core'
+import { scorecardAssert } from '../src/index.js'
+
+const ump = umpire({
+  fields: {
+    cardType: {},
+    cardNumber: {},
+    expiryDate: {},
+    billingZip: {},
+  },
+  rules: [
+    requires('cardNumber', 'cardType', {
+      reason: 'Pick a card type first',
+    }),
+    requires('expiryDate', 'cardNumber', {
+      reason: 'Enter a card number first',
+    }),
+  ],
+})
+
+function buildResult() {
+  return ump.scorecard(
+    {
+      values: {
+        cardType: null,
+        cardNumber: '4111111111111111',
+        expiryDate: '12/30',
+        billingZip: '10001',
+      },
+    },
+    {
+      before: {
+        values: {
+          cardType: 'visa',
+          cardNumber: '4111111111111111',
+          expiryDate: '12/30',
+          billingZip: '10001',
+        },
+      },
+    },
+  )
+}
+
+describe('scorecardAssert', () => {
+  describe('.changed()', () => {
+    test('passes when fields changed in the transition', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).changed('cardType'),
+      ).not.toThrow()
+    })
+
+    test('throws when a field did not change', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).changed('billingZip'),
+      ).toThrow(
+        'scorecardAssert: expected "billingZip" to be changed — did not change',
+      )
+    })
+  })
+
+  describe('.notChanged()', () => {
+    test('passes when fields did not change', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).notChanged('billingZip', 'cardNumber'),
+      ).not.toThrow()
+    })
+
+    test('throws when a field changed', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).notChanged('cardType'),
+      ).toThrow(
+        'scorecardAssert: expected "cardType" to be unchanged — changed',
+      )
+    })
+  })
+
+  describe('.cascaded()', () => {
+    test('passes when fields cascaded from the change', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).cascaded('cardNumber', 'expiryDate'),
+      ).not.toThrow()
+    })
+
+    test('throws when a field did not cascade', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).cascaded('billingZip'),
+      ).toThrow(
+        'scorecardAssert: expected "billingZip" to be cascaded — did not cascade',
+      )
+    })
+  })
+
+  describe('.fouled()', () => {
+    test('passes when fields have foul recommendations', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).fouled('cardNumber', 'expiryDate'),
+      ).not.toThrow()
+    })
+
+    test('throws when a field has no foul recommendation', () => {
+      expect(() => scorecardAssert(buildResult()).fouled('billingZip')).toThrow(
+        'scorecardAssert: expected "billingZip" to be fouled — had no foul recommendation',
+      )
+    })
+  })
+
+  describe('.notFouled()', () => {
+    test('passes when fields have no foul recommendation', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).notFouled('cardType', 'billingZip'),
+      ).not.toThrow()
+    })
+
+    test('throws with the foul reason when a field has a recommendation', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).notFouled('cardNumber'),
+      ).toThrow(
+        'scorecardAssert: expected "cardNumber" to be not fouled — had foul recommendation (reason: "Pick a card type first")',
+      )
+    })
+  })
+
+  describe('.onlyChanged()', () => {
+    test('passes when the exact changed field set matches', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).onlyChanged('cardType'),
+      ).not.toThrow()
+    })
+
+    test('throws when the changed set differs', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).onlyChanged('cardType', 'billingZip'),
+      ).toThrow(
+        'scorecardAssert: expected only changed fields to be ["cardType","billingZip"] — missing ["billingZip"]',
+      )
+    })
+  })
+
+  describe('.onlyFouled()', () => {
+    test('passes when the exact fouled field set matches regardless of order', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).onlyFouled('expiryDate', 'cardNumber'),
+      ).not.toThrow()
+    })
+
+    test('throws when the fouled set differs', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).onlyFouled('cardNumber'),
+      ).toThrow(
+        'scorecardAssert: expected only fouled fields to be ["cardNumber"] — unexpected ["expiryDate"]',
+      )
+    })
+  })
+
+  describe('.check()', () => {
+    test('delegates to checkAssert for availability assertions', () => {
+      expect(() =>
+        scorecardAssert(buildResult())
+          .check()
+          .disabled('cardNumber', 'expiryDate')
+          .enabled('billingZip')
+          .fair('cardNumber', 'expiryDate'),
+      ).not.toThrow()
+    })
+  })
+
+  describe('unknown field', () => {
+    test('throws immediately for an unknown field name', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).changed('missing' as 'cardType'),
+      ).toThrow('scorecardAssert: unknown field "missing"')
+    })
+  })
+
+  describe('chaining', () => {
+    test('multiple assertions can be chained on a single result', () => {
+      expect(() =>
+        scorecardAssert(buildResult())
+          .changed('cardType')
+          .notChanged('billingZip')
+          .cascaded('cardNumber', 'expiryDate')
+          .fouled('cardNumber')
+          .notFouled('billingZip')
+          .onlyChanged('cardType')
+          .onlyFouled('cardNumber', 'expiryDate'),
+      ).not.toThrow()
+    })
+  })
+})

--- a/packages/testing/__tests__/scorecard-assert.test.ts
+++ b/packages/testing/__tests__/scorecard-assert.test.ts
@@ -111,6 +111,21 @@ describe('scorecardAssert', () => {
       ).not.toThrow()
     })
 
+    test('passes for an enabled fair field with no foul recommendation', () => {
+      const result = ump.scorecard({
+        values: {
+          cardType: 'visa',
+          cardNumber: '4111111111111111',
+          expiryDate: '12/30',
+          billingZip: '10001',
+        },
+      })
+
+      expect(() =>
+        scorecardAssert(result).notFouled('billingZip'),
+      ).not.toThrow()
+    })
+
     test('throws with the foul reason when a field has a recommendation', () => {
       expect(() =>
         scorecardAssert(buildResult()).notFouled('cardNumber'),
@@ -134,6 +149,12 @@ describe('scorecardAssert', () => {
         'scorecardAssert: expected only changed fields to be ["cardType","billingZip"] — missing ["billingZip"]',
       )
     })
+
+    test('throws when the actual changed set has extra fields', () => {
+      expect(() => scorecardAssert(buildResult()).onlyChanged()).toThrow(
+        'scorecardAssert: expected only changed fields to be [] — unexpected ["cardType"]',
+      )
+    })
   })
 
   describe('.onlyFouled()', () => {
@@ -148,6 +169,18 @@ describe('scorecardAssert', () => {
         scorecardAssert(buildResult()).onlyFouled('cardNumber'),
       ).toThrow(
         'scorecardAssert: expected only fouled fields to be ["cardNumber"] — unexpected ["expiryDate"]',
+      )
+    })
+
+    test('throws when an expected fouled field is missing', () => {
+      expect(() =>
+        scorecardAssert(buildResult()).onlyFouled(
+          'cardNumber',
+          'expiryDate',
+          'billingZip',
+        ),
+      ).toThrow(
+        'scorecardAssert: expected only fouled fields to be ["cardNumber","expiryDate","billingZip"] — missing ["billingZip"]',
       )
     })
   })

--- a/packages/testing/__tests__/track-coverage.test.ts
+++ b/packages/testing/__tests__/track-coverage.test.ts
@@ -2,6 +2,7 @@ import {
   anyOf,
   eitherOf,
   fairWhen,
+  oneOf,
   requires,
   type Rule,
   umpire,
@@ -200,6 +201,35 @@ describe('trackCoverage', () => {
     )
 
     tracker.ump.check({ submit: true, expiry: '12/30' })
+
+    expect(tracker.report().uncoveredRules).toEqual([])
+  })
+
+  test('marks oneOf rules as covered when a branch is disabled', () => {
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [
+          oneOf(
+            'entry',
+            { card: ['cardNumber'], details: ['details'] },
+            {
+              activeBranch: 'card',
+            },
+          ),
+        ],
+      }),
+    )
+
+    expect(tracker.report().uncoveredRules).toEqual([
+      {
+        index: 0,
+        id: expect.any(String),
+        description: 'oneOf(entry)',
+      },
+    ])
+
+    tracker.ump.check({ details: 'open' })
 
     expect(tracker.report().uncoveredRules).toEqual([])
   })

--- a/packages/testing/__tests__/track-coverage.test.ts
+++ b/packages/testing/__tests__/track-coverage.test.ts
@@ -1,0 +1,234 @@
+import {
+  anyOf,
+  eitherOf,
+  fairWhen,
+  requires,
+  type Rule,
+  umpire,
+} from '@umpire/core'
+import { trackCoverage } from '../src/index.js'
+
+type Fields = {
+  mode: {}
+  details: {}
+  cardNumber: {}
+  expiry: {}
+  submit: {}
+}
+
+const fields: Fields = {
+  mode: {},
+  details: {},
+  cardNumber: {},
+  expiry: {},
+  submit: {},
+}
+
+describe('trackCoverage', () => {
+  test('records field states from check calls', () => {
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [
+          requires('details', 'mode'),
+          fairWhen('cardNumber', (value) => value === '4111', {
+            reason: 'Use a test Visa number',
+          }),
+        ],
+      }),
+    )
+
+    tracker.ump.check({ mode: 'card', details: 'open', cardNumber: '4111' })
+    tracker.ump.check({ mode: null, details: 'open', cardNumber: '5555' })
+
+    expect(tracker.report().fieldStates.details).toEqual({
+      seenEnabled: true,
+      seenDisabled: true,
+      seenFair: true,
+      seenFoul: false,
+      seenSatisfied: true,
+      seenUnsatisfied: false,
+    })
+    expect(tracker.report().fieldStates.cardNumber).toMatchObject({
+      seenFair: true,
+      seenFoul: true,
+    })
+    expect(tracker.report().fieldStates.expiry).toMatchObject({
+      seenSatisfied: false,
+      seenUnsatisfied: true,
+    })
+  })
+
+  test('records field states and rule coverage from scorecard calls', () => {
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [requires('details', 'mode')],
+      }),
+    )
+
+    const scorecard = tracker.ump.scorecard(
+      { values: { mode: null, details: 'open' } },
+      { before: { values: { mode: 'advanced', details: 'open' } } },
+    )
+
+    expect(scorecard.check.details.enabled).toBe(false)
+    expect(tracker.report().fieldStates.details.seenDisabled).toBe(true)
+    expect(tracker.report().uncoveredRules).toEqual([])
+  })
+
+  test('preserves return values and forwards conditions and prev', () => {
+    type Conditions = { allowDetails?: boolean }
+    const seen: Array<{
+      conditions: Conditions
+      prev: unknown
+    }> = []
+    const rule: Rule<Fields, Conditions> = {
+      type: 'custom',
+      targets: ['details'],
+      sources: ['mode'],
+      evaluate: (_values, conditions, prev) => {
+        seen.push({ conditions, prev })
+        return new Map([
+          [
+            'details',
+            {
+              enabled: conditions.allowDetails === true,
+              reason:
+                conditions.allowDetails === true
+                  ? null
+                  : 'Details are not allowed',
+            },
+          ],
+        ])
+      },
+    }
+    const base = umpire<Fields, Conditions>({
+      fields,
+      rules: [rule],
+    })
+    const tracker = trackCoverage(base)
+    const conditions = { allowDetails: false }
+    const prev = { mode: 'basic' }
+
+    const result = tracker.ump.check(
+      { mode: 'advanced', details: 'open' },
+      conditions,
+      prev,
+    )
+
+    expect(result).toEqual(
+      base.check({ mode: 'advanced', details: 'open' }, conditions, prev),
+    )
+    expect(seen).toContainEqual({ conditions, prev })
+  })
+
+  test('supports reset', () => {
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [requires('details', 'mode')],
+      }),
+    )
+
+    tracker.ump.check({ mode: null, details: 'open' })
+    expect(tracker.report().fieldStates.details.seenDisabled).toBe(true)
+
+    tracker.reset()
+
+    expect(tracker.report().fieldStates.details).toEqual({
+      seenEnabled: false,
+      seenDisabled: false,
+      seenFair: false,
+      seenFoul: false,
+      seenSatisfied: false,
+      seenUnsatisfied: false,
+    })
+    expect(tracker.report().uncoveredRules).toEqual([
+      {
+        index: 0,
+        id: expect.any(String),
+        description: 'requires(details, mode)',
+      },
+    ])
+  })
+
+  test('distinguishes same-type direct rules by ruleId', () => {
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [requires('submit', 'mode'), requires('submit', 'cardNumber')],
+      }),
+    )
+
+    expect(tracker.report().uncoveredRules).toEqual([
+      {
+        index: 0,
+        id: expect.any(String),
+        description: 'requires(submit, mode)',
+      },
+      {
+        index: 1,
+        id: expect.any(String),
+        description: 'requires(submit, cardNumber)',
+      },
+    ])
+
+    tracker.ump.check({ mode: 'card', submit: true })
+
+    expect(tracker.report().uncoveredRules).toEqual([
+      {
+        index: 0,
+        id: expect.any(String),
+        description: 'requires(submit, mode)',
+      },
+    ])
+  })
+
+  test('collects nested anyOf and eitherOf rule coverage', () => {
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [
+          anyOf(requires('submit', 'mode'), requires('submit', 'cardNumber')),
+          eitherOf('payment', {
+            card: [requires('expiry', 'cardNumber')],
+            details: [requires('expiry', 'details')],
+          }),
+        ],
+      }),
+    )
+
+    tracker.ump.check({ submit: true, expiry: '12/30' })
+
+    expect(tracker.report().uncoveredRules).toEqual([])
+  })
+
+  test('uses a fallback description for uninspectable rules', () => {
+    const opaqueRule: Rule<Fields> = {
+      type: 'opaque',
+      targets: ['details'],
+      sources: [],
+      evaluate: () =>
+        new Map([['details', { enabled: false, reason: 'Hidden test rule' }]]),
+    }
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [opaqueRule],
+      }),
+    )
+
+    expect(tracker.report().uncoveredRules).toEqual([
+      {
+        index: 0,
+        id: expect.any(String),
+        description: 'uninspectable rule #0',
+      },
+    ])
+
+    tracker.ump.check({ details: 'open' })
+
+    expect(tracker.report().uncoveredRules).toEqual([])
+  })
+})

--- a/packages/testing/__tests__/track-coverage.test.ts
+++ b/packages/testing/__tests__/track-coverage.test.ts
@@ -78,6 +78,27 @@ describe('trackCoverage', () => {
     expect(tracker.report().uncoveredRules).toEqual([])
   })
 
+  test('records foul field states from scorecard calls', () => {
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [
+          fairWhen('cardNumber', (value) => value === '4111', {
+            reason: 'Use a test Visa number',
+          }),
+        ],
+      }),
+    )
+
+    const scorecard = tracker.ump.scorecard({
+      values: { cardNumber: '5555' },
+    })
+
+    expect(scorecard.check.cardNumber.fair).toBe(false)
+    expect(tracker.report().fieldStates.cardNumber.seenFoul).toBe(true)
+    expect(tracker.report().uncoveredRules).toEqual([])
+  })
+
   test('preserves return values and forwards conditions and prev', () => {
     type Conditions = { allowDetails?: boolean }
     const seen: Array<{
@@ -200,9 +221,30 @@ describe('trackCoverage', () => {
       }),
     )
 
-    tracker.ump.check({ submit: true, expiry: '12/30' })
+    const result = tracker.ump.check({ submit: true, expiry: '12/30' })
 
+    expect(result.submit.enabled).toBe(false)
+    expect(result.expiry.enabled).toBe(false)
     expect(tracker.report().uncoveredRules).toEqual([])
+  })
+
+  test('does not collect coverage from direct challenge calls', () => {
+    const tracker = trackCoverage(
+      umpire({
+        fields,
+        rules: [requires('details', 'mode')],
+      }),
+    )
+
+    tracker.ump.challenge('details', { details: 'open' })
+
+    expect(tracker.report().uncoveredRules).toEqual([
+      {
+        index: 0,
+        id: expect.any(String),
+        description: 'requires(details, mode)',
+      },
+    ])
   })
 
   test('marks oneOf rules as covered when a branch is disabled', () => {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,4 +1,146 @@
-import type { FieldDef, Umpire } from '@umpire/core'
+import type { FieldDef, FieldStatus, Umpire } from '@umpire/core'
+
+export type CheckAssertChain<K extends string> = {
+  enabled(...fields: K[]): CheckAssertChain<K>
+  disabled(...fields: K[]): CheckAssertChain<K>
+  fair(...fields: K[]): CheckAssertChain<K>
+  foul(...fields: K[]): CheckAssertChain<K>
+  required(...fields: K[]): CheckAssertChain<K>
+  optional(...fields: K[]): CheckAssertChain<K>
+  satisfied(...fields: K[]): CheckAssertChain<K>
+  unsatisfied(...fields: K[]): CheckAssertChain<K>
+}
+
+function buildFailMessage(
+  label: string,
+  failures: Array<{ field: string; detail: string }>,
+): string {
+  if (failures.length === 1) {
+    return `checkAssert: expected "${failures[0].field}" to be ${label} — ${failures[0].detail}`
+  }
+
+  return [
+    `checkAssert: expected the following field(s) to be ${label}:`,
+    ...failures.map((f) => `  "${f.field}" — ${f.detail}`),
+  ].join('\n')
+}
+
+function runAssert<K extends string>(
+  result: Record<K, FieldStatus>,
+  fields: K[],
+  predicate: (status: FieldStatus) => boolean,
+  label: string,
+  detail: (field: K, status: FieldStatus) => string,
+): void {
+  const failures: Array<{ field: string; detail: string }> = []
+
+  for (const field of fields) {
+    const status = result[field]
+
+    if (status === undefined) {
+      throw new Error(`checkAssert: unknown field "${field}"`)
+    }
+
+    if (!predicate(status)) {
+      failures.push({ field, detail: detail(field, status) })
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(buildFailMessage(label, failures))
+  }
+}
+
+export function checkAssert<K extends string>(
+  result: Record<K, FieldStatus>,
+): CheckAssertChain<K> {
+  const chain: CheckAssertChain<K> = {
+    enabled(...fields) {
+      runAssert(
+        result,
+        fields,
+        (s) => s.enabled,
+        'enabled',
+        (_f, s) =>
+          `was disabled${s.reason ? ` (reason: ${JSON.stringify(s.reason)})` : ''}`,
+      )
+      return chain
+    },
+    disabled(...fields) {
+      runAssert(
+        result,
+        fields,
+        (s) => !s.enabled,
+        'disabled',
+        () => 'was enabled',
+      )
+      return chain
+    },
+    fair(...fields) {
+      runAssert(
+        result,
+        fields,
+        (s) => s.fair,
+        'fair',
+        (_f, s) =>
+          `was foul${s.reason ? ` (reason: ${JSON.stringify(s.reason)})` : ''}`,
+      )
+      return chain
+    },
+    foul(...fields) {
+      runAssert(
+        result,
+        fields,
+        (s) => !s.fair,
+        'foul',
+        (_f, s) => `was fair (enabled: ${s.enabled})`,
+      )
+      return chain
+    },
+    required(...fields) {
+      runAssert(
+        result,
+        fields,
+        (s) => s.required,
+        'required',
+        () => 'was optional',
+      )
+      return chain
+    },
+    optional(...fields) {
+      runAssert(
+        result,
+        fields,
+        (s) => !s.required,
+        'optional',
+        () => 'was required',
+      )
+      return chain
+    },
+    satisfied(...fields) {
+      runAssert(
+        result,
+        fields,
+        (s) => s.satisfied,
+        'satisfied',
+        () => 'was unsatisfied (no value)',
+      )
+      return chain
+    },
+    unsatisfied(...fields) {
+      runAssert(
+        result,
+        fields,
+        (s) => !s.satisfied,
+        'unsatisfied',
+        () => 'was satisfied (has a value)',
+      )
+      return chain
+    },
+  }
+
+  return chain
+}
 
 const VALUE_PROBES = [null, undefined, '', 'a', 0, 1, true, false] as const
 const MAX_VIOLATIONS = 50

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,4 +1,9 @@
-import type { FieldDef, FieldStatus, Umpire } from '@umpire/core'
+import type {
+  FieldDef,
+  FieldStatus,
+  ScorecardResult,
+  Umpire,
+} from '@umpire/core'
 
 export type CheckAssertChain<K extends string> = {
   enabled(...fields: K[]): CheckAssertChain<K>
@@ -11,16 +16,28 @@ export type CheckAssertChain<K extends string> = {
   unsatisfied(...fields: K[]): CheckAssertChain<K>
 }
 
+export type ScorecardAssertChain<K extends string> = {
+  changed(...fields: K[]): ScorecardAssertChain<K>
+  notChanged(...fields: K[]): ScorecardAssertChain<K>
+  cascaded(...fields: K[]): ScorecardAssertChain<K>
+  fouled(...fields: K[]): ScorecardAssertChain<K>
+  notFouled(...fields: K[]): ScorecardAssertChain<K>
+  onlyChanged(...fields: K[]): ScorecardAssertChain<K>
+  onlyFouled(...fields: K[]): ScorecardAssertChain<K>
+  check(): CheckAssertChain<K>
+}
+
 function buildFailMessage(
+  prefix: string,
   label: string,
   failures: Array<{ field: string; detail: string }>,
 ): string {
   if (failures.length === 1) {
-    return `checkAssert: expected "${failures[0].field}" to be ${label} — ${failures[0].detail}`
+    return `${prefix}: expected "${failures[0].field}" to be ${label} — ${failures[0].detail}`
   }
 
   return [
-    `checkAssert: expected the following field(s) to be ${label}:`,
+    `${prefix}: expected the following field(s) to be ${label}:`,
     ...failures.map((f) => `  "${f.field}" — ${f.detail}`),
   ].join('\n')
 }
@@ -47,7 +64,99 @@ function runAssert<K extends string>(
   }
 
   if (failures.length > 0) {
-    throw new Error(buildFailMessage(label, failures))
+    throw new Error(buildFailMessage('checkAssert', label, failures))
+  }
+}
+
+function buildSetFailMessage<K extends string>(
+  label: string,
+  actualFields: K[],
+  expectedFields: K[],
+): string {
+  const actual = new Set(actualFields)
+  const expected = new Set(expectedFields)
+  const missing = [...expected].filter((field) => !actual.has(field))
+  const unexpected = [...actual].filter((field) => !expected.has(field))
+  const details: string[] = []
+
+  if (missing.length > 0) {
+    details.push(`missing ${JSON.stringify(missing)}`)
+  }
+
+  if (unexpected.length > 0) {
+    details.push(`unexpected ${JSON.stringify(unexpected)}`)
+  }
+
+  return `scorecardAssert: expected only ${label} to be ${JSON.stringify(expectedFields)} — ${details.join('; ')}`
+}
+
+function assertKnownScorecardFields<K extends string>(
+  result: ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+  fields: K[],
+): void {
+  for (const field of fields) {
+    if (result.fields[field] === undefined) {
+      throw new Error(`scorecardAssert: unknown field "${field}"`)
+    }
+  }
+}
+
+function runScorecardFieldAssert<K extends string>(
+  result: ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+  fields: K[],
+  predicate: (
+    field: ScorecardResult<
+      Record<K, FieldDef>,
+      Record<string, unknown>
+    >['fields'][K],
+  ) => boolean,
+  label: string,
+  detail: (
+    field: K,
+    scorecardField: ScorecardResult<
+      Record<K, FieldDef>,
+      Record<string, unknown>
+    >['fields'][K],
+  ) => string,
+): void {
+  const failures: Array<{ field: string; detail: string }> = []
+
+  for (const field of fields) {
+    const scorecardField = result.fields[field]
+
+    if (scorecardField === undefined) {
+      throw new Error(`scorecardAssert: unknown field "${field}"`)
+    }
+
+    if (!predicate(scorecardField)) {
+      failures.push({ field, detail: detail(field, scorecardField) })
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(buildFailMessage('scorecardAssert', label, failures))
+  }
+}
+
+function runExactSetAssert<K extends string>(
+  result: ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+  actualFields: K[],
+  expectedFields: K[],
+  label: string,
+): void {
+  assertKnownScorecardFields(result, expectedFields)
+
+  const actual = new Set(actualFields)
+  const expected = new Set(expectedFields)
+
+  if (actual.size !== expected.size) {
+    throw new Error(buildSetFailMessage(label, actualFields, expectedFields))
+  }
+
+  for (const field of expected) {
+    if (!actual.has(field)) {
+      throw new Error(buildSetFailMessage(label, actualFields, expectedFields))
+    }
   }
 }
 
@@ -136,6 +245,90 @@ export function checkAssert<K extends string>(
         () => 'was satisfied (has a value)',
       )
       return chain
+    },
+  }
+
+  return chain
+}
+
+export function scorecardAssert<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(result: ScorecardResult<F, C>): ScorecardAssertChain<keyof F & string> {
+  type K = keyof F & string
+
+  const chain: ScorecardAssertChain<K> = {
+    changed(...fields) {
+      runScorecardFieldAssert(
+        result as ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+        fields,
+        (scorecardField) => scorecardField.changed,
+        'changed',
+        () => 'did not change',
+      )
+      return chain
+    },
+    notChanged(...fields) {
+      runScorecardFieldAssert(
+        result as ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+        fields,
+        (scorecardField) => !scorecardField.changed,
+        'unchanged',
+        () => 'changed',
+      )
+      return chain
+    },
+    cascaded(...fields) {
+      runScorecardFieldAssert(
+        result as ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+        fields,
+        (scorecardField) => scorecardField.cascaded,
+        'cascaded',
+        () => 'did not cascade',
+      )
+      return chain
+    },
+    fouled(...fields) {
+      runScorecardFieldAssert(
+        result as ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+        fields,
+        (scorecardField) => scorecardField.foul !== null,
+        'fouled',
+        () => 'had no foul recommendation',
+      )
+      return chain
+    },
+    notFouled(...fields) {
+      runScorecardFieldAssert(
+        result as ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+        fields,
+        (scorecardField) => scorecardField.foul === null,
+        'not fouled',
+        (_field, scorecardField) =>
+          `had foul recommendation${scorecardField.foul?.reason ? ` (reason: ${JSON.stringify(scorecardField.foul.reason)})` : ''}`,
+      )
+      return chain
+    },
+    onlyChanged(...fields) {
+      runExactSetAssert(
+        result as ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+        result.transition.changedFields as K[],
+        fields,
+        'changed fields',
+      )
+      return chain
+    },
+    onlyFouled(...fields) {
+      runExactSetAssert(
+        result as ScorecardResult<Record<K, FieldDef>, Record<string, unknown>>,
+        result.transition.fouledFields as K[],
+        fields,
+        'fouled fields',
+      )
+      return chain
+    },
+    check() {
+      return checkAssert(result.check)
     },
   }
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,6 +1,9 @@
 import type {
+  ChallengeDirectReason,
   FieldDef,
   FieldStatus,
+  RuleEntry,
+  RuleInspection,
   ScorecardResult,
   Umpire,
 } from '@umpire/core'
@@ -333,6 +336,305 @@ export function scorecardAssert<
   }
 
   return chain
+}
+
+export type FieldStateCoverage = {
+  seenEnabled: boolean
+  seenDisabled: boolean
+  seenFair: boolean
+  seenFoul: boolean
+  seenSatisfied: boolean
+  seenUnsatisfied: boolean
+}
+
+export type RuleCoverage = {
+  index: number
+  id: string
+  description: string
+}
+
+export type CoverageReport<K extends string = string> = {
+  fieldStates: Record<K, FieldStateCoverage>
+  uncoveredRules: RuleCoverage[]
+}
+
+export type CoverageTracker<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+> = {
+  ump: Umpire<F, C>
+  report(): CoverageReport<keyof F & string>
+  reset(): void
+}
+
+function createEmptyFieldStateCoverage(): FieldStateCoverage {
+  return {
+    seenEnabled: false,
+    seenDisabled: false,
+    seenFair: false,
+    seenFoul: false,
+    seenSatisfied: false,
+    seenUnsatisfied: false,
+  }
+}
+
+function cloneFieldStateCoverage(
+  coverage: FieldStateCoverage,
+): FieldStateCoverage {
+  return { ...coverage }
+}
+
+function recordFieldStates<K extends string>(
+  accumulator: Record<K, FieldStateCoverage>,
+  result: Record<K, FieldStatus>,
+): void {
+  for (const [field, status] of Object.entries(result) as Array<
+    [K, FieldStatus]
+  >) {
+    const fieldCoverage = accumulator[field]
+
+    if (!fieldCoverage) {
+      continue
+    }
+
+    fieldCoverage.seenEnabled ||= status.enabled
+    fieldCoverage.seenDisabled ||= !status.enabled
+    fieldCoverage.seenFair ||= status.fair
+    fieldCoverage.seenFoul ||= !status.fair
+    fieldCoverage.seenSatisfied ||= status.satisfied
+    fieldCoverage.seenUnsatisfied ||= !status.satisfied
+  }
+}
+
+function describeOperand(operand: unknown): string {
+  if (typeof operand === 'string') {
+    return operand
+  }
+
+  if (
+    operand &&
+    typeof operand === 'object' &&
+    'field' in operand &&
+    typeof operand.field === 'string'
+  ) {
+    return operand.field
+  }
+
+  if (
+    operand &&
+    typeof operand === 'object' &&
+    'kind' in operand &&
+    typeof operand.kind === 'string'
+  ) {
+    return operand.kind
+  }
+
+  return 'predicate'
+}
+
+function describeRuleInspection(
+  inspection: RuleInspection<Record<string, FieldDef>, Record<string, unknown>>,
+): string {
+  if (inspection.kind === 'enabledWhen') {
+    return `enabledWhen(${inspection.target}, ...)`
+  }
+
+  if (inspection.kind === 'disables') {
+    return `disables(${describeOperand(inspection.source)}, ${inspection.targets.join(', ')})`
+  }
+
+  if (inspection.kind === 'fairWhen') {
+    return `fairWhen(${inspection.target}, ...)`
+  }
+
+  if (inspection.kind === 'requires') {
+    return `requires(${inspection.target}, ${inspection.dependencies.map(describeOperand).join(', ')})`
+  }
+
+  if (inspection.kind === 'oneOf') {
+    return `oneOf(${inspection.groupName})`
+  }
+
+  if (inspection.kind === 'anyOf') {
+    return `anyOf(${inspection.rules.length} rules)`
+  }
+
+  if (inspection.kind === 'eitherOf') {
+    return `eitherOf(${inspection.groupName})`
+  }
+
+  return `${inspection.type}(${inspection.targets.join(', ')})`
+}
+
+function describeRuleEntry<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(entry: RuleEntry<F, C>): string {
+  return entry.inspection
+    ? describeRuleInspection(
+        entry.inspection as RuleInspection<
+          Record<string, FieldDef>,
+          Record<string, unknown>
+        >,
+      )
+    : `uninspectable rule #${entry.index}`
+}
+
+type ChallengeReasonLike = ChallengeDirectReason & {
+  inner?: ChallengeReasonLike[]
+  branches?: Record<string, { inner?: ChallengeReasonLike[] }>
+}
+
+function collectCoveredRulesFromReason(
+  reason: ChallengeReasonLike,
+  coveredRuleIds: Set<string>,
+  assumeFailed = false,
+): void {
+  if ((assumeFailed || reason.passed === false) && reason.ruleId) {
+    coveredRuleIds.add(reason.ruleId)
+  }
+
+  for (const inner of reason.inner ?? []) {
+    collectCoveredRulesFromReason(inner, coveredRuleIds)
+  }
+
+  for (const branch of Object.values(reason.branches ?? {})) {
+    for (const inner of branch.inner ?? []) {
+      collectCoveredRulesFromReason(inner, coveredRuleIds)
+    }
+  }
+}
+
+function collectCoveredRulesFromChallenge(
+  challenge: ReturnType<AnyUmpire['challenge']>,
+  coveredRuleIds: Set<string>,
+): void {
+  for (const reason of challenge.directReasons) {
+    collectCoveredRulesFromReason(reason as ChallengeReasonLike, coveredRuleIds)
+  }
+
+  for (const dep of challenge.transitiveDeps) {
+    for (const reason of dep.causedBy) {
+      collectCoveredRulesFromReason(
+        reason as ChallengeReasonLike,
+        coveredRuleIds,
+        true,
+      )
+    }
+  }
+}
+
+function collectRuleCoverageFromCheck<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  ump: Umpire<F, C>,
+  result: Record<keyof F & string, FieldStatus>,
+  values: Record<string, unknown>,
+  conditions: C | undefined,
+  prev: Record<string, unknown> | undefined,
+  coveredRuleIds: Set<string>,
+): void {
+  for (const [field, status] of Object.entries(result) as Array<
+    [keyof F & string, FieldStatus]
+  >) {
+    if (status.enabled && status.fair) {
+      continue
+    }
+
+    collectCoveredRulesFromChallenge(
+      ump.challenge(field, values, conditions, prev),
+      coveredRuleIds,
+    )
+  }
+}
+
+export function trackCoverage<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(ump: Umpire<F, C>): CoverageTracker<F, C> {
+  type K = keyof F & string
+
+  const fieldNames = ump.graph().nodes as K[]
+  const rules = ump.rules()
+  const fieldStates = Object.fromEntries(
+    fieldNames.map((field) => [field, createEmptyFieldStateCoverage()]),
+  ) as Record<K, FieldStateCoverage>
+  const coveredRuleIds = new Set<string>()
+
+  const reset = () => {
+    for (const field of fieldNames) {
+      fieldStates[field] = createEmptyFieldStateCoverage()
+    }
+
+    coveredRuleIds.clear()
+  }
+
+  const trackedUmp: Umpire<F, C> = {
+    check(values, conditions, prev) {
+      const result = ump.check(values, conditions, prev)
+      recordFieldStates(fieldStates, result as Record<K, FieldStatus>)
+      collectRuleCoverageFromCheck(
+        ump,
+        result as Record<K, FieldStatus>,
+        values,
+        conditions,
+        prev,
+        coveredRuleIds,
+      )
+      return result
+    },
+    play(before, after) {
+      return ump.play(before, after)
+    },
+    init(overrides) {
+      return ump.init(overrides)
+    },
+    scorecard(snapshot, options) {
+      const result = ump.scorecard(snapshot, options)
+      recordFieldStates(fieldStates, result.check as Record<K, FieldStatus>)
+      collectRuleCoverageFromCheck(
+        ump,
+        result.check as Record<K, FieldStatus>,
+        snapshot.values,
+        snapshot.conditions,
+        options?.before?.values,
+        coveredRuleIds,
+      )
+      return result
+    },
+    challenge(field, values, conditions, prev) {
+      return ump.challenge(field, values, conditions, prev)
+    },
+    graph() {
+      return ump.graph()
+    },
+    rules() {
+      return ump.rules()
+    },
+  }
+
+  return {
+    ump: trackedUmp,
+    report() {
+      return {
+        fieldStates: Object.fromEntries(
+          fieldNames.map((field) => [
+            field,
+            cloneFieldStateCoverage(fieldStates[field]),
+          ]),
+        ) as Record<K, FieldStateCoverage>,
+        uncoveredRules: rules
+          .filter((entry) => !coveredRuleIds.has(entry.id))
+          .map((entry) => ({
+            index: entry.index,
+            id: entry.id,
+            description: describeRuleEntry(entry),
+          })),
+      }
+    },
+    reset,
+  }
 }
 
 const VALUE_PROBES = [null, undefined, '', 'a', 0, 1, true, false] as const

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -378,12 +378,6 @@ function createEmptyFieldStateCoverage(): FieldStateCoverage {
   }
 }
 
-function cloneFieldStateCoverage(
-  coverage: FieldStateCoverage,
-): FieldStateCoverage {
-  return { ...coverage }
-}
-
 function recordFieldStates<K extends string>(
   accumulator: Record<K, FieldStateCoverage>,
   result: Record<K, FieldStatus>,
@@ -463,7 +457,12 @@ function describeRuleInspection(
     return `eitherOf(${inspection.groupName})`
   }
 
-  return `${inspection.type}(${inspection.targets.join(', ')})`
+  if (inspection.kind === 'custom') {
+    return `${inspection.type}(${inspection.targets.join(', ')})`
+  }
+
+  const _exhaustive: never = inspection
+  return _exhaustive
 }
 
 function describeRuleEntry<
@@ -490,7 +489,7 @@ function collectCoveredRulesFromReason(
   coveredRuleIds: Set<string>,
   assumeFailed = false,
 ): void {
-  if ((assumeFailed || reason.passed === false) && reason.ruleId) {
+  if ((assumeFailed || !reason.passed) && reason.ruleId) {
     coveredRuleIds.add(reason.ruleId)
   }
 
@@ -619,10 +618,7 @@ export function trackCoverage<
     report() {
       return {
         fieldStates: Object.fromEntries(
-          fieldNames.map((field) => [
-            field,
-            cloneFieldStateCoverage(fieldStates[field]),
-          ]),
+          fieldNames.map((field) => [field, { ...fieldStates[field] }]),
         ) as Record<K, FieldStateCoverage>,
         uncoveredRules: rules
           .filter((entry) => !coveredRuleIds.has(entry.id))


### PR DESCRIPTION
**Add `checkAssert`, `scorecardAssert`, and `trackCoverage` to `@umpire/testing`**

## What's in this PR

Three new exports for `@umpire/testing`, plus the core attribution metadata they depend on.

### `@umpire/core` — rule attribution metadata (minor)

`ump.rules()` now returns a normalized list of rule entries, each with a stable `id` and positional `index`. Challenge reasons include `ruleId` and `ruleIndex` so downstream consumers can correlate a failure back to a specific rule instance — even when multiple rules of the same type target the same field.

### `@umpire/testing` — new exports (minor)

**`checkAssert(result)`** — fluent assertion chain over `ump.check()` results. Accepts variadic field names, collects all failures before throwing, and produces descriptive error messages that include reason strings. Works with any test framework via plain `Error`.

**`scorecardAssert(result)`** — fluent assertion chain over `ump.scorecard()` results. Covers `changed`, `notChanged`, `cascaded`, `fouled`, `notFouled`, `onlyChanged`, and `onlyFouled`. `.check()` delegates to `checkAssert` so availability and transition assertions compose on one result.

**`trackCoverage(ump)`** — wraps an umpire instance and accumulates field-state and rule-failure observations across instrumented `check()` and `scorecard()` calls. `report()` returns per-field enabled/disabled/fair/foul/satisfied/unsatisfied flags and a list of rules that never produced a failure. Uses `ruleId` metadata from core to distinguish multiple same-type rules on the same target. `reset()` clears observations between scenarios.

### Docs

`docs/extensions/testing` expanded to document all four exports, with the page restructured so `monkeyTest` comes last alongside an example showing how it complements `trackCoverage`.