### PR TITLE
🛠️ devtools rule inspection and live coverage tracking

### DIFF
--- a/.changeset/devtools-inspection-exposure.md
+++ b/.changeset/devtools-inspection-exposure.md
@@ -1,0 +1,10 @@
+---
+'@umpire/devtools': minor
+---
+
+Expose rule inspection and live coverage tracking in devtools
+
+- `RegistryEntry` now includes `rules` (`AnyRuleEntry[]`), `activeRuleIds` (rules currently failing this render), and `coverage` (accumulated field-state and rule-hit data for the session)
+- `ChallengeDrawer` shows the stable `ruleId` on each reason entry, linking the "why" directly to the rule that caused it
+- New built-in **rules** tab: lists every configured rule with its kind, stable ID, and a human-readable description; highlights rules that are actively failing in the current render
+- New built-in **coverage** tab: tracks which field states (enabled/disabled/fair/foul/satisfied/unsatisfied) and which rules have been exercised since the panel was mounted; surfaces uncovered rules so you can spot dead constraints while using the app

--- a/docs/src/content/docs/extensions/devtools.mdx
+++ b/docs/src/content/docs/extensions/devtools.mdx
@@ -5,7 +5,6 @@ description: Mount an in-app Umpire inspector for scorecards, challenge traces, 
 
 `@umpire/devtools` is the in-app inspection surface for Umpire. It mounts a Shadow DOM panel, subscribes to explicit registrations, and lets you inspect the same `scorecard()` and `challenge()` data you would otherwise have to print or assert by hand.
 
-The visual language is intentionally tool-like: tabbed panes, tables, logs, and inspectors. It should feel distinct from your product UI, not like another styled feature surface.
 
 ## How it works
 
@@ -60,6 +59,8 @@ The panel shows:
 - Per-field challenge traces from `challenge()`
 - A rolling foul log for disabled-with-value transitions
 - A graph view of the structural dependency DAG
+- A rules tab listing every rule with its kind, id, and whether it is currently active
+- A coverage tab tracking which rules have been triggered and which field states have been observed this session
 - Optional extension tabs, including reads when you register a reads table
 
 ## React Helpers
@@ -186,7 +187,7 @@ mount({
 | `position` | `'bottom-right'` | One of `top-left`, `top-right`, `bottom-left`, `bottom-right` |
 | `offset` | `{ x: 16, y: 16 }` | Distance from the corner in CSS pixels |
 | `foulLogDepth` | `50` | Max foul events retained in the rolling log |
-| `defaultTab` | `'matrix'` | Starting tab: `matrix`, `conditions`, `fouls`, `graph`, `reads`, or a custom extension id |
+| `defaultTab` | `'matrix'` | Starting tab: `matrix`, `conditions`, `fouls`, `graph`, `rules`, `coverage`, `reads`, or a custom extension id |
 
 ## Slim Build
 

--- a/docs/src/styles/settings/_settings.site-tokens.css
+++ b/docs/src/styles/settings/_settings.site-tokens.css
@@ -34,5 +34,10 @@
   --umpire-demo-green-8: rgba(107, 254, 156, 0.08);
   --umpire-demo-green-16: rgba(107, 254, 156, 0.16);
   --umpire-demo-red-12: rgba(255, 113, 108, 0.12);
+  /* Lock aside caution colors to dark values — Starlight's [data-theme='light'] vars are
+     inside @layer starlight.base so unlayered :root rules here always win. */
+  --sl-color-orange-low: hsl(41, 39%, 14%);
+  --sl-color-orange: hsl(41, 82%, 63%);
+  --sl-color-orange-high: hsl(41, 82%, 87%);
   color-scheme: dark;
 }

--- a/packages/devtools/__tests__/format.test.ts
+++ b/packages/devtools/__tests__/format.test.ts
@@ -1,8 +1,4 @@
-import type {
-  ChallengeTraceAttachment,
-  RuleInspection,
-  RuleOperandInspection,
-} from '@umpire/core'
+import type { ChallengeTraceAttachment, RuleInspection } from '@umpire/core'
 import type { AnyRuleEntry } from '../src/types.js'
 import {
   describeEntry,

--- a/packages/devtools/__tests__/format.test.ts
+++ b/packages/devtools/__tests__/format.test.ts
@@ -1,12 +1,132 @@
-import type { RuleInspection, RuleOperandInspection } from '@umpire/core'
+import type {
+  ChallengeTraceAttachment,
+  RuleInspection,
+  RuleOperandInspection,
+} from '@umpire/core'
 import type { AnyRuleEntry } from '../src/types.js'
 import {
   describeEntry,
   describeInspection,
   describeOperand,
+  formatTimestamp,
+  formatValue,
+  getReasonMeta,
+  getTraceMeta,
 } from '../src/panel/format.js'
 
 describe('format helpers', () => {
+  it('formats primitive values', () => {
+    expect(formatValue(undefined)).toBe('undefined')
+    expect(formatValue(null)).toBe('null')
+    expect(formatValue(42)).toBe('42')
+    expect(formatValue(true)).toBe('true')
+    expect(formatValue('short')).toBe('short')
+    expect(formatValue('abcdef', 4)).toBe('abc…')
+  })
+
+  it('formats arrays', () => {
+    expect(formatValue([1, 'two', false])).toBe('[1, two, false]')
+    expect(formatValue([['nested'], 'value'], 10)).toBe('[[nested]…')
+    expect(formatValue(['x'.repeat(60)], 20)).toBe('[xxxxxxxxxxxxxxxxxx…')
+  })
+
+  it('formats serializable objects', () => {
+    expect(formatValue({ a: 1, b: true })).toBe('{"a":1,"b":true}')
+  })
+
+  it('truncates long json objects deterministically', () => {
+    expect(formatValue({ a: 'x'.repeat(60) }, 20)).toBe('{"a":"xxxxxxxxxxxxx…')
+  })
+
+  it('falls back to String when json serialization yields no value', () => {
+    const fn = () => undefined
+
+    expect(formatValue(fn)).toBe(String(fn))
+    expect(formatValue(Symbol('fallback'))).toBe(String(Symbol('fallback')))
+  })
+
+  it('falls back to String for circular values', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    expect(formatValue(circular)).toBe('[object Object]')
+  })
+
+  it('formats timestamps with a stable time shape', () => {
+    const toLocaleTimeString = vi
+      .spyOn(Date.prototype, 'toLocaleTimeString')
+      .mockImplementation(function (locales, options) {
+        expect(locales).toEqual([])
+        expect(options).toEqual({
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        })
+
+        return `mocked-${this.getTime()}`
+      })
+
+    const morning = Date.UTC(2024, 0, 1, 13, 5, 9)
+    const evening = Date.UTC(2024, 0, 1, 23, 45, 1)
+
+    try {
+      expect(formatTimestamp(morning)).toBe(`mocked-${morning}`)
+      expect(formatTimestamp(evening)).toBe(`mocked-${evening}`)
+      expect(morning).not.toBe(evening)
+    } finally {
+      toLocaleTimeString.mockRestore()
+    }
+  })
+
+  it('filters reason metadata fields', () => {
+    expect(
+      getReasonMeta({
+        inner: [{ rule: 'ignored', reason: 'ignored' }],
+        passed: true,
+        reason: 'ignored',
+        rule: 'ignored',
+        ruleId: 'ignored',
+        ruleIndex: 3,
+        trace: [{ id: 'ignored' }],
+        undefinedValue: undefined,
+        nullValue: null,
+        stringValue: 'ok',
+        numberValue: 7,
+        booleanValue: false,
+        arrayValue: ['ok'],
+        objectValue: { nested: true },
+      }),
+    ).toEqual([
+      ['nullValue', null],
+      ['stringValue', 'ok'],
+      ['numberValue', 7],
+      ['booleanValue', false],
+      ['arrayValue', ['ok']],
+    ])
+  })
+
+  it('filters trace metadata fields', () => {
+    const trace: ChallengeTraceAttachment = {
+      dependencies: ['ignored'],
+      id: 'ignored',
+      kind: 'ignored',
+      undefinedValue: undefined,
+      nullValue: null,
+      stringValue: 'ok',
+      numberValue: 7,
+      booleanValue: true,
+      arrayValue: ['ok'],
+      objectValue: { nested: true },
+    }
+
+    expect(getTraceMeta(trace)).toEqual([
+      ['nullValue', null],
+      ['stringValue', 'ok'],
+      ['numberValue', 7],
+      ['booleanValue', true],
+      ['arrayValue', ['ok']],
+    ])
+  })
+
   it('matches the operand matrix', () => {
     expect(describeOperand({ kind: 'field', field: 'email' })).toBe('email')
     expect(describeOperand({ kind: 'predicate', predicate: undefined })).toBe(

--- a/packages/devtools/__tests__/format.test.ts
+++ b/packages/devtools/__tests__/format.test.ts
@@ -1,0 +1,137 @@
+import type { RuleInspection, RuleOperandInspection } from '@umpire/core'
+import type { AnyRuleEntry } from '../src/types.js'
+import {
+  describeEntry,
+  describeInspection,
+  describeOperand,
+} from '../src/panel/format.js'
+
+describe('format helpers', () => {
+  it('matches the operand matrix', () => {
+    expect(describeOperand({ kind: 'field', field: 'email' })).toBe('email')
+    expect(describeOperand({ kind: 'predicate', predicate: undefined })).toBe(
+      'predicate',
+    )
+    expect(
+      describeOperand({ kind: 'predicate', predicate: { field: 'email' } }),
+    ).toBe('email?')
+    expect(
+      describeOperand({
+        kind: 'predicate',
+        predicate: { namedCheck: { __check: 'minLength' } },
+      }),
+    ).toBe('minLength')
+    expect(
+      describeOperand({
+        kind: 'predicate',
+        predicate: {
+          field: 'email',
+          namedCheck: { __check: 'minLength' },
+        },
+      }),
+    ).toBe('email?.minLength')
+  })
+
+  it('matches the inspection matrix', () => {
+    const requires: RuleInspection<
+      Record<string, { required?: boolean }>,
+      Record<string, unknown>
+    > = {
+      kind: 'requires',
+      target: 'submit',
+      dependencies: [
+        { kind: 'field', field: 'email' },
+        { kind: 'predicate', predicate: { field: 'terms' } },
+      ],
+      reason: undefined,
+      hasDynamicReason: false,
+    }
+
+    const anyOf: RuleInspection<
+      Record<string, { required?: boolean }>,
+      Record<string, unknown>
+    > = {
+      kind: 'anyOf',
+      rules: [requires, requires, requires],
+      reason: undefined,
+      hasDynamicReason: false,
+    }
+
+    const sync: RuleInspection<
+      Record<string, { required?: boolean }>,
+      Record<string, unknown>
+    > = {
+      kind: 'custom',
+      type: 'sync',
+      targets: ['a', 'b'],
+      reason: undefined,
+      hasDynamicReason: false,
+    }
+
+    expect(describeInspection({ kind: 'enabledWhen', target: 'submit' })).toBe(
+      'enabledWhen(submit)',
+    )
+    expect(
+      describeInspection({
+        kind: 'disables',
+        source: { kind: 'field', field: 'sso' },
+        targets: ['email'],
+        reason: undefined,
+        hasDynamicReason: false,
+      }),
+    ).toBe('disables(sso, [email])')
+    expect(
+      describeInspection({
+        kind: 'disables',
+        source: { kind: 'predicate', predicate: { field: 'domain' } },
+        targets: ['sso'],
+        reason: undefined,
+        hasDynamicReason: false,
+      }),
+    ).toBe('disables(domain?, [sso])')
+    expect(describeInspection({ kind: 'fairWhen', target: 'submit' })).toBe(
+      'fairWhen(submit)',
+    )
+    expect(describeInspection(requires)).toBe('requires(submit, email, terms?)')
+    expect(
+      describeInspection({
+        kind: 'oneOf',
+        groupName: 'authMethod',
+        reason: undefined,
+        hasDynamicReason: false,
+      }),
+    ).toBe('oneOf(authMethod)')
+    expect(describeInspection(anyOf)).toBe('anyOf(3 rules)')
+    expect(
+      describeInspection({
+        kind: 'eitherOf',
+        groupName: 'submitAuth',
+        reason: undefined,
+        hasDynamicReason: false,
+      }),
+    ).toBe('eitherOf(submitAuth)')
+    expect(describeInspection(sync)).toBe('sync(a, b)')
+  })
+
+  it('describes inspectable and uninspectable entries', () => {
+    const entry: AnyRuleEntry = {
+      index: 7,
+      id: 'rule-7',
+      inspection: {
+        kind: 'requires',
+        target: 'submit',
+        dependencies: [
+          { kind: 'field', field: 'email' },
+          { kind: 'predicate', predicate: { field: 'terms' } },
+        ],
+        reason: undefined,
+        hasDynamicReason: false,
+      },
+    }
+
+    expect(describeEntry(entry)).toBe('requires(submit, email, terms?)')
+    expect(
+      describeEntry({ index: 0, id: 'rule-0', inspection: undefined }),
+    ).toBe('uninspectable rule #0')
+  })
+})

--- a/packages/devtools/__tests__/registry.test.ts
+++ b/packages/devtools/__tests__/registry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test'
-import { enabledWhen, umpire } from '@umpire/core'
+import { enabledWhen, requires, umpire } from '@umpire/core'
 import { createReads, enabledWhenRead } from '@umpire/reads'
 import type { ReadTableInspection } from '@umpire/reads'
 import {
@@ -71,6 +71,69 @@ describe('registry', () => {
     })
 
     expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it('stores rules, activeRuleIds, and coverage on each entry', () => {
+    register('demo', demoUmp, {
+      gate: '',
+      target: 'kept',
+    })
+
+    const entry = snapshot().get('demo')
+    const gateRuleId = entry?.rules[0]?.id
+
+    expect(gateRuleId).toEqual(expect.any(String))
+    expect(entry?.activeRuleIds).toEqual(new Set([gateRuleId as string]))
+    expect(entry?.coverage.coveredRuleIds).toEqual(
+      new Set([gateRuleId as string]),
+    )
+    expect(entry?.coverage.fieldStates.gate).toBeDefined()
+    expect(entry?.coverage.fieldStates.target).toBeDefined()
+  })
+
+  it('tracks transitive rule IDs in active and covered sets', () => {
+    const transitiveUmp = umpire({
+      fields: {
+        gate: { default: '' },
+        start: { default: '' },
+        end: { default: '' },
+        submit: { default: '' },
+      },
+      rules: [
+        enabledWhen('start', (values) => Boolean(values.gate), {
+          reason: 'gate required',
+        }),
+        requires('end', 'start', { reason: 'need start' }),
+        requires('submit', 'end', { reason: 'need end' }),
+      ],
+    })
+
+    register('transitive', transitiveUmp, {
+      gate: '',
+      start: '09:00',
+      end: '10:00',
+      submit: 'yes',
+    })
+
+    let current = snapshot().get('transitive')
+    const expectedRuleIds = new Set(
+      current?.rules.map((rule) => rule.id).filter(Boolean),
+    )
+
+    expect(current?.activeRuleIds).toEqual(expectedRuleIds)
+    expect(current?.coverage.coveredRuleIds).toEqual(expectedRuleIds)
+
+    register('transitive', transitiveUmp, {
+      gate: 'open',
+      start: '09:00',
+      end: '10:00',
+      submit: 'yes',
+    })
+
+    current = snapshot().get('transitive')
+
+    expect(current?.activeRuleIds).toEqual(new Set())
+    expect(current?.coverage.coveredRuleIds).toEqual(expectedRuleIds)
   })
 
   it('removes entries when unregistered', () => {

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -64,12 +64,14 @@ export function unmount() {
 export { register, snapshot, subscribe, unregister }
 
 export type {
+  AnyDevtoolsExtension,
   AnyReadInspection,
+  AnyRuleEntry,
   AnyScorecard,
   AnySnapshot,
   AnyUmpire,
-  AnyDevtoolsExtension,
   DevtoolsBuiltinTab,
+  DevtoolsCoverage,
   DevtoolsExtension,
   DevtoolsExtensionBadge,
   DevtoolsExtensionInspectContext,
@@ -77,11 +79,12 @@ export type {
   DevtoolsExtensionSection,
   DevtoolsExtensionTone,
   DevtoolsExtensionView,
+  DevtoolsFieldCoverage,
   DevtoolsFoulEvent,
   DevtoolsPosition,
   DevtoolsTab,
   MountOptions,
   RegisterOptions,
-  ResolvedDevtoolsExtension,
   RegistryEntry,
+  ResolvedDevtoolsExtension,
 } from './types.js'

--- a/packages/devtools/src/panel/ChallengeDrawer.tsx
+++ b/packages/devtools/src/panel/ChallengeDrawer.tsx
@@ -187,6 +187,11 @@ function ReasonView({ depth = 0, reason }: ReasonProps) {
             {passed ? 'pass' : 'fail'}
           </span>
         </div>
+        {typeof reason.ruleId === 'string' && (
+          <span style={{ color: theme.fgMuted, fontSize: 10 }}>
+            {reason.ruleId}
+          </span>
+        )}
       </div>
 
       {reason.reason && (

--- a/packages/devtools/src/panel/Panel.tsx
+++ b/packages/devtools/src/panel/Panel.tsx
@@ -19,7 +19,9 @@ import {
   tabStyle,
   theme,
 } from './theme.js'
+import { CoverageTab } from './tabs/CoverageTab.js'
 import { ReadsTab } from './tabs/ReadsTab.js'
+import { RulesTab } from './tabs/RulesTab.js'
 
 type Props = {
   options: Required<MountOptions>
@@ -81,6 +83,9 @@ function resolveTabs(entry: RegistryEntry | null): PanelTab[] {
   if (entry.reads) {
     tabs.push({ id: 'reads', label: 'reads' })
   }
+
+  tabs.push({ id: 'rules', label: 'rules' })
+  tabs.push({ id: 'coverage', label: 'coverage' })
 
   for (const extension of entry.extensions) {
     tabs.push({
@@ -388,6 +393,14 @@ function PanelBody({
 
   if (tab === 'reads') {
     return <ReadsTab inspection={entry.reads} />
+  }
+
+  if (tab === 'rules') {
+    return <RulesTab activeRuleIds={entry.activeRuleIds} rules={entry.rules} />
+  }
+
+  if (tab === 'coverage') {
+    return <CoverageTab coverage={entry.coverage} rules={entry.rules} />
   }
 
   const extension =

--- a/packages/devtools/src/panel/format.ts
+++ b/packages/devtools/src/panel/format.ts
@@ -10,11 +10,13 @@ export type ReasonLike = {
 }
 
 const skippedReasonKeys = new Set([
-  'rule',
+  'inner',
   'passed',
   'reason',
+  'ruleId',
+  'ruleIndex',
+  'rule',
   'trace',
-  'inner',
 ])
 
 export function formatValue(value: unknown, maxLength = 44): string {

--- a/packages/devtools/src/panel/format.ts
+++ b/packages/devtools/src/panel/format.ts
@@ -1,4 +1,9 @@
-import type { ChallengeTraceAttachment } from '@umpire/core'
+import type {
+  ChallengeTraceAttachment,
+  RuleInspection,
+  RuleOperandInspection,
+} from '@umpire/core'
+import type { AnyRuleEntry } from '../types.js'
 
 export type ReasonLike = {
   inner?: ReasonLike[]
@@ -87,4 +92,68 @@ export function getTraceMeta(trace: ChallengeTraceAttachment) {
       value !== undefined &&
       (typeof value !== 'object' || value === null || Array.isArray(value)),
   )
+}
+
+export function describeOperand(
+  operand: RuleOperandInspection<string>,
+): string {
+  if (operand.kind === 'field') {
+    return operand.field
+  }
+
+  const predicate = operand.predicate
+
+  if (!predicate) {
+    return 'predicate'
+  }
+
+  if (predicate.field && predicate.namedCheck) {
+    return `${predicate.field}?.${predicate.namedCheck.__check}`
+  }
+
+  if (predicate.field) {
+    return `${predicate.field}?`
+  }
+
+  if (predicate.namedCheck) {
+    return predicate.namedCheck.__check
+  }
+
+  return 'predicate'
+}
+
+export function describeInspection(
+  inspection: RuleInspection<
+    Record<string, { required?: boolean }>,
+    Record<string, unknown>
+  >,
+): string {
+  switch (inspection.kind) {
+    case 'enabledWhen':
+      return `enabledWhen(${inspection.target})`
+    case 'fairWhen':
+      return `fairWhen(${inspection.target})`
+    case 'disables':
+      return `disables(${describeOperand(inspection.source)}, [${inspection.targets.join(', ')}])`
+    case 'requires':
+      return `requires(${inspection.target}, ${inspection.dependencies.map(describeOperand).join(', ')})`
+    case 'oneOf':
+      return `oneOf(${inspection.groupName})`
+    case 'anyOf':
+      return `anyOf(${inspection.rules.length} rules)`
+    case 'eitherOf':
+      return `eitherOf(${inspection.groupName})`
+    case 'custom':
+      return `${inspection.type}(${inspection.targets.join(', ')})`
+  }
+
+  const exhaustive: never = inspection
+
+  return exhaustive
+}
+
+export function describeEntry(entry: AnyRuleEntry): string {
+  return entry.inspection
+    ? describeInspection(entry.inspection)
+    : `uninspectable rule #${entry.index}`
 }

--- a/packages/devtools/src/panel/tabs/CoverageTab.tsx
+++ b/packages/devtools/src/panel/tabs/CoverageTab.tsx
@@ -1,5 +1,15 @@
-import type { AnyRuleEntry, DevtoolsCoverage, DevtoolsFieldCoverage } from '../../types.js'
-import { getRuleTone, pillStyle, scrollPaneStyle, sectionHeadingStyle, theme } from '../theme.js'
+import type {
+  AnyRuleEntry,
+  DevtoolsCoverage,
+  DevtoolsFieldCoverage,
+} from '../../types.js'
+import {
+  getRuleTone,
+  pillStyle,
+  scrollPaneStyle,
+  sectionHeadingStyle,
+  theme,
+} from '../theme.js'
 
 type Props = {
   coverage: DevtoolsCoverage
@@ -77,7 +87,11 @@ export function CoverageTab({ coverage, rules }: Props) {
         >
           <h3 style={sectionHeadingStyle()}>Rule Coverage</h3>
           <span style={{ color: theme.fgMuted, fontSize: 11 }}>
-            <span style={{ color: coveredCount === rules.length ? theme.enabled : theme.fg }}>
+            <span
+              style={{
+                color: coveredCount === rules.length ? theme.enabled : theme.fg,
+              }}
+            >
               {coveredCount}
             </span>
             {' / '}
@@ -166,7 +180,11 @@ export function CoverageTab({ coverage, rules }: Props) {
                   <tr key={field}>
                     <td style={fieldCellStyle}>
                       <div
-                        style={{ alignItems: 'center', display: 'flex', gap: 8 }}
+                        style={{
+                          alignItems: 'center',
+                          display: 'flex',
+                          gap: 8,
+                        }}
                       >
                         <span
                           style={{

--- a/packages/devtools/src/panel/tabs/CoverageTab.tsx
+++ b/packages/devtools/src/panel/tabs/CoverageTab.tsx
@@ -1,0 +1,199 @@
+import type { AnyRuleEntry, DevtoolsCoverage, DevtoolsFieldCoverage } from '../../types.js'
+import { getRuleTone, pillStyle, scrollPaneStyle, sectionHeadingStyle, theme } from '../theme.js'
+
+type Props = {
+  coverage: DevtoolsCoverage
+  rules: AnyRuleEntry[]
+}
+
+const headerCellStyle = {
+  borderBottom: `1px solid ${theme.border}`,
+  color: theme.fgMuted,
+  fontSize: 10,
+  letterSpacing: '0.08em',
+  padding: '8px 6px',
+  textAlign: 'center' as const,
+  textTransform: 'uppercase' as const,
+}
+
+const fieldCellStyle = {
+  borderBottom: `1px solid ${theme.border}`,
+  color: theme.fg,
+  fontSize: 11,
+  padding: '8px 10px',
+}
+
+const boolCellStyle = {
+  borderBottom: `1px solid ${theme.border}`,
+  fontSize: 11,
+  padding: '8px 6px',
+  textAlign: 'center' as const,
+}
+
+function dot(seen: boolean) {
+  return (
+    <span style={{ color: seen ? theme.enabled : theme.unavailable }}>
+      {seen ? '✓' : '○'}
+    </span>
+  )
+}
+
+function coverageScore(fc: DevtoolsFieldCoverage): number {
+  const flags = [
+    fc.seenEnabled,
+    fc.seenDisabled,
+    fc.seenFair,
+    fc.seenFoul,
+    fc.seenSatisfied,
+    fc.seenUnsatisfied,
+  ]
+  return flags.filter(Boolean).length
+}
+
+export function CoverageTab({ coverage, rules }: Props) {
+  const fieldEntries = Object.entries(coverage.fieldStates)
+  const uncoveredRules = rules.filter(
+    (entry) => !coverage.coveredRuleIds.has(entry.id),
+  )
+  const coveredCount = rules.length - uncoveredRules.length
+
+  return (
+    <div style={scrollPaneStyle()}>
+      <section
+        style={{
+          borderBottom: `1px solid ${theme.border}`,
+          display: 'grid',
+          gap: 10,
+          padding: 12,
+        }}
+      >
+        <div
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+            gap: 10,
+            justifyContent: 'space-between',
+          }}
+        >
+          <h3 style={sectionHeadingStyle()}>Rule Coverage</h3>
+          <span style={{ color: theme.fgMuted, fontSize: 11 }}>
+            <span style={{ color: coveredCount === rules.length ? theme.enabled : theme.fg }}>
+              {coveredCount}
+            </span>
+            {' / '}
+            {rules.length} rules triggered
+          </span>
+        </div>
+
+        {uncoveredRules.length === 0 ? (
+          <div style={{ color: theme.enabled, fontSize: 11 }}>
+            All rules have been triggered this session.
+          </div>
+        ) : (
+          <div style={{ display: 'grid', gap: 6 }}>
+            {uncoveredRules.map((entry) => {
+              const kind = entry.inspection?.kind ?? 'custom'
+              const tone = getRuleTone(kind)
+              return (
+                <div
+                  key={entry.id}
+                  style={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    gap: 8,
+                  }}
+                >
+                  <span style={pillStyle(tone, true)}>{kind}</span>
+                  <span style={{ color: theme.fgMuted, fontSize: 10 }}>
+                    {entry.id}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </section>
+
+      <section style={{ padding: 12 }}>
+        <div
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+            gap: 10,
+            justifyContent: 'space-between',
+            marginBottom: 10,
+          }}
+        >
+          <h3 style={sectionHeadingStyle()}>Field State Coverage</h3>
+        </div>
+
+        {fieldEntries.length === 0 ? (
+          <div style={{ color: theme.fgMuted, fontSize: 11 }}>
+            No field data recorded yet.
+          </div>
+        ) : (
+          <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+            <thead>
+              <tr>
+                <th
+                  style={{
+                    ...headerCellStyle,
+                    padding: '8px 10px',
+                    textAlign: 'left' as const,
+                  }}
+                >
+                  Field
+                </th>
+                <th style={headerCellStyle}>En</th>
+                <th style={headerCellStyle}>Dis</th>
+                <th style={headerCellStyle}>Fair</th>
+                <th style={headerCellStyle}>Foul</th>
+                <th style={headerCellStyle}>Sat</th>
+                <th style={headerCellStyle}>Unsat</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fieldEntries.map(([field, fc]) => {
+                const score = coverageScore(fc)
+                const tone =
+                  score === 6
+                    ? theme.enabled
+                    : score >= 4
+                      ? theme.changed
+                      : theme.fgMuted
+
+                return (
+                  <tr key={field}>
+                    <td style={fieldCellStyle}>
+                      <div
+                        style={{ alignItems: 'center', display: 'flex', gap: 8 }}
+                      >
+                        <span
+                          style={{
+                            background: tone,
+                            borderRadius: 999,
+                            display: 'inline-block',
+                            flexShrink: 0,
+                            height: 6,
+                            width: 6,
+                          }}
+                        />
+                        {field}
+                      </div>
+                    </td>
+                    <td style={boolCellStyle}>{dot(fc.seenEnabled)}</td>
+                    <td style={boolCellStyle}>{dot(fc.seenDisabled)}</td>
+                    <td style={boolCellStyle}>{dot(fc.seenFair)}</td>
+                    <td style={boolCellStyle}>{dot(fc.seenFoul)}</td>
+                    <td style={boolCellStyle}>{dot(fc.seenSatisfied)}</td>
+                    <td style={boolCellStyle}>{dot(fc.seenUnsatisfied)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/packages/devtools/src/panel/tabs/CoverageTab.tsx
+++ b/packages/devtools/src/panel/tabs/CoverageTab.tsx
@@ -10,6 +10,7 @@ import {
   sectionHeadingStyle,
   theme,
 } from '../theme.js'
+import { describeEntry } from '../format.js'
 
 type Props = {
   coverage: DevtoolsCoverage
@@ -114,15 +115,25 @@ export function CoverageTab({ coverage, rules }: Props) {
                 <div
                   key={entry.id}
                   style={{
-                    alignItems: 'center',
-                    display: 'flex',
-                    gap: 8,
+                    display: 'grid',
+                    gap: 4,
                   }}
                 >
-                  <span style={pillStyle(tone, true)}>{kind}</span>
-                  <span style={{ color: theme.fgMuted, fontSize: 10 }}>
-                    {entry.id}
-                  </span>
+                  <div
+                    style={{
+                      alignItems: 'center',
+                      display: 'flex',
+                      gap: 8,
+                    }}
+                  >
+                    <span style={pillStyle(tone, true)}>{kind}</span>
+                    <span style={{ color: theme.fgMuted, fontSize: 10 }}>
+                      {entry.id}
+                    </span>
+                  </div>
+                  <div style={{ color: theme.fgMuted, fontSize: 10 }}>
+                    {describeEntry(entry)}
+                  </div>
                 </div>
               )
             })}

--- a/packages/devtools/src/panel/tabs/CoverageTab.tsx
+++ b/packages/devtools/src/panel/tabs/CoverageTab.tsx
@@ -101,7 +101,9 @@ export function CoverageTab({ coverage, rules }: Props) {
 
         {uncoveredRules.length === 0 ? (
           <div style={{ color: theme.enabled, fontSize: 11 }}>
-            All rules have been triggered this session.
+            {rules.length === 0
+              ? 'No rules configured for this instance.'
+              : 'All rules have been triggered this session.'}
           </div>
         ) : (
           <div style={{ display: 'grid', gap: 6 }}>

--- a/packages/devtools/src/panel/tabs/RulesTab.tsx
+++ b/packages/devtools/src/panel/tabs/RulesTab.tsx
@@ -1,57 +1,10 @@
-import type { RuleInspection } from '@umpire/core'
 import type { AnyRuleEntry } from '../../types.js'
+import { describeEntry } from '../format.js'
 import { getRuleTone, pillStyle, scrollPaneStyle, theme } from '../theme.js'
 
 type Props = {
   activeRuleIds: Set<string>
   rules: AnyRuleEntry[]
-}
-
-type AnyRuleInspection = RuleInspection<
-  Record<string, { required?: boolean }>,
-  Record<string, unknown>
->
-
-function describeOperand(operand: { kind: string; field?: string }): string {
-  if (operand.kind === 'field' && typeof operand.field === 'string') {
-    return operand.field
-  }
-  return 'predicate'
-}
-
-function describeInspection(inspection: AnyRuleInspection): string {
-  if (inspection.kind === 'enabledWhen') {
-    return `enabledWhen(${inspection.target})`
-  }
-  if (inspection.kind === 'disables') {
-    return `disables(${describeOperand(inspection.source)}, [${inspection.targets.join(', ')}])`
-  }
-  if (inspection.kind === 'fairWhen') {
-    return `fairWhen(${inspection.target})`
-  }
-  if (inspection.kind === 'requires') {
-    return `requires(${inspection.target}, ${inspection.dependencies.map(describeOperand).join(', ')})`
-  }
-  if (inspection.kind === 'oneOf') {
-    return `oneOf(${inspection.groupName})`
-  }
-  if (inspection.kind === 'anyOf') {
-    return `anyOf(${inspection.rules.length} rules)`
-  }
-  if (inspection.kind === 'eitherOf') {
-    return `eitherOf(${inspection.groupName})`
-  }
-  if (inspection.kind === 'custom') {
-    return `${inspection.type}(${inspection.targets.join(', ')})`
-  }
-  const _exhaustive: never = inspection
-  return _exhaustive
-}
-
-function describeEntry(entry: AnyRuleEntry): string {
-  return entry.inspection
-    ? describeInspection(entry.inspection as AnyRuleInspection)
-    : `uninspectable rule #${entry.index}`
 }
 
 export function RulesTab({ activeRuleIds, rules }: Props) {

--- a/packages/devtools/src/panel/tabs/RulesTab.tsx
+++ b/packages/devtools/src/panel/tabs/RulesTab.tsx
@@ -101,9 +101,7 @@ export function RulesTab({ activeRuleIds, rules }: Props) {
             >
               <div style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
                 <span style={pillStyle(tone, true)}>{kind}</span>
-                {isActive && (
-                  <span style={pillStyle(tone, false)}>active</span>
-                )}
+                {isActive && <span style={pillStyle(tone, false)}>active</span>}
               </div>
               <span style={{ color: theme.fgMuted, fontSize: 10 }}>
                 #{entry.index}
@@ -112,9 +110,7 @@ export function RulesTab({ activeRuleIds, rules }: Props) {
             <div style={{ color: theme.fg, fontSize: 11 }}>
               {describeEntry(entry)}
             </div>
-            <div style={{ color: theme.fgMuted, fontSize: 10 }}>
-              {entry.id}
-            </div>
+            <div style={{ color: theme.fgMuted, fontSize: 10 }}>{entry.id}</div>
           </div>
         )
       })}

--- a/packages/devtools/src/panel/tabs/RulesTab.tsx
+++ b/packages/devtools/src/panel/tabs/RulesTab.tsx
@@ -1,0 +1,123 @@
+import type { RuleInspection } from '@umpire/core'
+import type { AnyRuleEntry } from '../../types.js'
+import { getRuleTone, pillStyle, scrollPaneStyle, theme } from '../theme.js'
+
+type Props = {
+  activeRuleIds: Set<string>
+  rules: AnyRuleEntry[]
+}
+
+type AnyRuleInspection = RuleInspection<
+  Record<string, { required?: boolean }>,
+  Record<string, unknown>
+>
+
+function describeOperand(operand: { kind: string; field?: string }): string {
+  if (operand.kind === 'field' && typeof operand.field === 'string') {
+    return operand.field
+  }
+  return 'predicate'
+}
+
+function describeInspection(inspection: AnyRuleInspection): string {
+  if (inspection.kind === 'enabledWhen') {
+    return `enabledWhen(${inspection.target})`
+  }
+  if (inspection.kind === 'disables') {
+    return `disables(${describeOperand(inspection.source)}, [${inspection.targets.join(', ')}])`
+  }
+  if (inspection.kind === 'fairWhen') {
+    return `fairWhen(${inspection.target})`
+  }
+  if (inspection.kind === 'requires') {
+    return `requires(${inspection.target}, ${inspection.dependencies.map(describeOperand).join(', ')})`
+  }
+  if (inspection.kind === 'oneOf') {
+    return `oneOf(${inspection.groupName})`
+  }
+  if (inspection.kind === 'anyOf') {
+    return `anyOf(${inspection.rules.length} rules)`
+  }
+  if (inspection.kind === 'eitherOf') {
+    return `eitherOf(${inspection.groupName})`
+  }
+  if (inspection.kind === 'custom') {
+    return `${inspection.type}(${inspection.targets.join(', ')})`
+  }
+  const _exhaustive: never = inspection
+  return _exhaustive
+}
+
+function describeEntry(entry: AnyRuleEntry): string {
+  return entry.inspection
+    ? describeInspection(entry.inspection as AnyRuleInspection)
+    : `uninspectable rule #${entry.index}`
+}
+
+export function RulesTab({ activeRuleIds, rules }: Props) {
+  if (rules.length === 0) {
+    return (
+      <div
+        style={{
+          ...scrollPaneStyle(),
+          color: theme.fgMuted,
+          display: 'grid',
+          lineHeight: 1.6,
+          padding: 16,
+          placeItems: 'center',
+          textAlign: 'center',
+        }}
+      >
+        No inspectable rules found for this instance.
+      </div>
+    )
+  }
+
+  return (
+    <div style={scrollPaneStyle()}>
+      {rules.map((entry) => {
+        const kind = entry.inspection?.kind ?? 'custom'
+        const tone = getRuleTone(kind)
+        const isActive = activeRuleIds.has(entry.id)
+
+        return (
+          <div
+            key={entry.id}
+            style={{
+              borderBottom: `1px solid ${theme.border}`,
+              borderLeft: `3px solid ${isActive ? tone : theme.border}`,
+              display: 'grid',
+              gap: 6,
+              padding: '10px 12px 10px 14px',
+            }}
+          >
+            <div
+              style={{
+                alignItems: 'center',
+                display: 'flex',
+                gap: 8,
+                justifyContent: 'space-between',
+              }}
+            >
+              <div style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
+                <span style={pillStyle(tone, true)}>{kind}</span>
+                {isActive && (
+                  <span style={pillStyle(tone, false)}>active</span>
+                )}
+              </div>
+              <span style={{ color: theme.fgMuted, fontSize: 10 }}>
+                #{entry.index}
+              </span>
+            </div>
+            <div style={{ color: theme.fg, fontSize: 11 }}>
+              {describeEntry(entry)}
+            </div>
+            <div style={{ color: theme.fgMuted, fontSize: 10 }}>
+              {entry.id}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/devtools/src/registry.ts
+++ b/packages/devtools/src/registry.ts
@@ -283,9 +283,7 @@ export const register: RegisterFn = <
   const renderIndex = (existing?.renderIndex ?? 0) + 1
   const readsInspection = resolveReadsInspection(values, options)
   const rules: AnyRuleEntry[] =
-    existing?.ump === ump
-      ? existing.rules
-      : (ump.rules() as AnyRuleEntry[])
+    existing?.ump === ump ? existing.rules : (ump.rules() as AnyRuleEntry[])
   const { coverage, activeRuleIds } = buildCoverage(
     existing?.coverage,
     ump as Umpire<Record<string, FieldDef>, Record<string, unknown>>,

--- a/packages/devtools/src/registry.ts
+++ b/packages/devtools/src/registry.ts
@@ -1,5 +1,7 @@
 import type {
+  ChallengeDirectReason,
   FieldDef,
+  FieldStatus,
   InputValues,
   ScorecardResult,
   Snapshot,
@@ -8,13 +10,91 @@ import type {
 import type { ReadTableInspection } from '@umpire/reads'
 import type {
   AnyReadInspection,
-  ResolvedDevtoolsExtension,
+  AnyRuleEntry,
   AnySnapshot,
+  DevtoolsCoverage,
+  DevtoolsFieldCoverage,
   DevtoolsFoulEvent,
   RegisterFn,
   RegisterOptions,
   RegistryEntry,
+  ResolvedDevtoolsExtension,
 } from './types.js'
+
+type AnyReason = ChallengeDirectReason & {
+  inner?: AnyReason[]
+  branches?: Record<string, { inner?: AnyReason[] }>
+}
+
+function collectFromReason(
+  reason: AnyReason,
+  ids: Set<string>,
+  assumeFailed = false,
+): void {
+  if ((assumeFailed || !reason.passed) && reason.ruleId) {
+    ids.add(reason.ruleId)
+  }
+  for (const inner of reason.inner ?? []) {
+    collectFromReason(inner, ids)
+  }
+  for (const branch of Object.values(reason.branches ?? {})) {
+    for (const inner of branch.inner ?? []) {
+      collectFromReason(inner, ids)
+    }
+  }
+}
+
+function mergeFieldCoverage(
+  existing: DevtoolsFieldCoverage | undefined,
+  status: FieldStatus,
+): DevtoolsFieldCoverage {
+  return {
+    seenDisabled: (existing?.seenDisabled ?? false) || !status.enabled,
+    seenEnabled: (existing?.seenEnabled ?? false) || status.enabled,
+    seenFair: (existing?.seenFair ?? false) || status.fair,
+    seenFoul: (existing?.seenFoul ?? false) || !status.fair,
+    seenSatisfied: (existing?.seenSatisfied ?? false) || status.satisfied,
+    seenUnsatisfied: (existing?.seenUnsatisfied ?? false) || !status.satisfied,
+  }
+}
+
+function buildCoverage(
+  existing: DevtoolsCoverage | undefined,
+  ump: Umpire<Record<string, FieldDef>, Record<string, unknown>>,
+  scorecard: ScorecardResult<Record<string, FieldDef>, Record<string, unknown>>,
+  values: InputValues,
+  conditions: Record<string, unknown> | undefined,
+  prevValues: InputValues | undefined,
+): { coverage: DevtoolsCoverage; activeRuleIds: Set<string> } {
+  const fieldStates: Record<string, DevtoolsFieldCoverage> = {
+    ...existing?.fieldStates,
+  }
+  const coveredRuleIds = new Set(existing?.coveredRuleIds)
+  const activeRuleIds = new Set<string>()
+
+  for (const [field, status] of Object.entries(
+    scorecard.check as Record<string, FieldStatus>,
+  )) {
+    fieldStates[field] = mergeFieldCoverage(fieldStates[field], status)
+
+    if (!status.enabled || !status.fair) {
+      const trace = ump.challenge(field, values, conditions, prevValues)
+
+      for (const reason of trace.directReasons) {
+        collectFromReason(reason as AnyReason, activeRuleIds)
+        collectFromReason(reason as AnyReason, coveredRuleIds)
+      }
+      for (const dep of trace.transitiveDeps) {
+        for (const reason of dep.causedBy) {
+          collectFromReason(reason as AnyReason, activeRuleIds, true)
+          collectFromReason(reason as AnyReason, coveredRuleIds, true)
+        }
+      }
+    }
+  }
+
+  return { activeRuleIds, coverage: { coveredRuleIds, fieldStates } }
+}
 
 const registry = new Map<string, RegistryEntry>()
 const listeners = new Set<() => void>()
@@ -23,11 +103,13 @@ let foulLogDepth = 50
 let registryVersion = 0
 
 const RESERVED_EXTENSION_IDS = new Set([
+  'coverage',
   'matrix',
   'conditions',
   'fouls',
   'graph',
   'reads',
+  'rules',
 ])
 
 function notify() {
@@ -200,8 +282,25 @@ export const register: RegisterFn = <
   })
   const renderIndex = (existing?.renderIndex ?? 0) + 1
   const readsInspection = resolveReadsInspection(values, options)
+  const rules: AnyRuleEntry[] =
+    existing?.ump === ump
+      ? existing.rules
+      : (ump.rules() as AnyRuleEntry[])
+  const { coverage, activeRuleIds } = buildCoverage(
+    existing?.coverage,
+    ump as Umpire<Record<string, FieldDef>, Record<string, unknown>>,
+    scorecard as ScorecardResult<
+      Record<string, FieldDef>,
+      Record<string, unknown>
+    >,
+    values,
+    conditions as Record<string, unknown> | undefined,
+    previous?.values,
+  )
 
   const nextEntry: RegistryEntry = {
+    activeRuleIds,
+    coverage,
     extensions: resolveExtensions(
       ump,
       values,
@@ -218,6 +317,7 @@ export const register: RegisterFn = <
     previous: previous as RegistryEntry['previous'],
     reads: readsInspection,
     renderIndex,
+    rules,
     scorecard: scorecard as RegistryEntry['scorecard'],
     snapshot: currentSnapshot as AnySnapshot,
     ump: ump as RegistryEntry['ump'],

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -1,13 +1,20 @@
 import type {
   FieldDef,
   InputValues,
+  RuleEntry,
   ScorecardResult,
   Snapshot,
   Umpire,
 } from '@umpire/core'
 import type { ReadTable, ReadTableInspection } from '@umpire/reads'
 
-export type DevtoolsBuiltinTab = 'matrix' | 'conditions' | 'fouls' | 'graph'
+export type DevtoolsBuiltinTab =
+  | 'matrix'
+  | 'conditions'
+  | 'fouls'
+  | 'graph'
+  | 'rules'
+  | 'coverage'
 export type DevtoolsTab = DevtoolsBuiltinTab | 'reads' | (string & {})
 
 export type DevtoolsPosition =
@@ -126,6 +133,25 @@ export type AnyReadInspection = ReadTableInspection<
   Record<string, unknown>,
   Record<string, unknown>
 >
+
+export type AnyRuleEntry = RuleEntry<
+  Record<string, FieldDef>,
+  Record<string, unknown>
+>
+
+export type DevtoolsFieldCoverage = {
+  seenEnabled: boolean
+  seenDisabled: boolean
+  seenFair: boolean
+  seenFoul: boolean
+  seenSatisfied: boolean
+  seenUnsatisfied: boolean
+}
+
+export type DevtoolsCoverage = {
+  fieldStates: Record<string, DevtoolsFieldCoverage>
+  coveredRuleIds: Set<string>
+}
 export type AnyDevtoolsExtension = DevtoolsExtension<
   Record<string, FieldDef>,
   Record<string, unknown>
@@ -138,6 +164,8 @@ export type ResolvedDevtoolsExtension = {
 }
 
 export type RegistryEntry = {
+  activeRuleIds: Set<string>
+  coverage: DevtoolsCoverage
   extensions: ResolvedDevtoolsExtension[]
   foulLog: DevtoolsFoulEvent[]
   id: string
@@ -147,6 +175,7 @@ export type RegistryEntry = {
   previous: AnySnapshot | null
   reads: AnyReadInspection | null
   renderIndex: number
+  rules: AnyRuleEntry[]
   scorecard: AnyScorecard
   snapshot: AnySnapshot
   ump: AnyUmpire


### PR DESCRIPTION
## Summary

Builds on the `ump.rules()` and `ruleId` infrastructure landed in #97 to give the devtools panel four new capabilities:

- **`RegistryEntry` data**: `rules` (all configured rules, reused across renders when the `ump` reference is stable), `activeRuleIds` (rules currently failing this render), and `coverage` (accumulated session-wide field-state + rule-hit data)
- **ChallengeDrawer**: `ruleId` now appears in the header of each reason row, linking the "why" directly back to the rule that produced it; `ruleId`/`ruleIndex` are suppressed from the generic meta-row renderer so they don't appear twice
- **New "rules" tab**: lists every configured rule with its kind pill (color-coded), stable ID, and a human-readable description (`enabledWhen(field)`, `requires(target, dep)`, etc.); highlights rules with an "active" badge when they are currently the reason something is disabled or foul
- **New "coverage" tab**: session-wide observability — field-state heat map showing which of (enabled/disabled/fair/foul/satisfied/unsatisfied) have been seen per field, plus an uncovered-rules list for rules that have never fired; lets you spot dead constraints while exercising the UI normally

## How coverage tracking works

On every `register()` call, for each field that is not `(enabled && fair)`, the registry runs `ump.challenge()` and walks the reason tree collecting `ruleId` values from failing reasons. These accumulate in `coverage.coveredRuleIds` across renders. Field-state coverage accumulates from `scorecard.check`. Both are session-scoped and reset on `unregister()`.

## Test plan

- [ ] Mount devtools on an app with a few `enabledWhen`/`requires`/`disables` rules
- [ ] Open the **rules** tab — all rules listed with IDs; rules currently blocking a field show the "active" badge
- [ ] Click into a constrained field in the matrix tab — the `ruleId` appears in the reason header in the challenge drawer
- [ ] Exercise the UI — open the **coverage** tab and confirm field states fill in as you toggle fields; uncovered rules shrink as you trigger each constraint
- [ ] Verify `AnyRuleEntry`, `DevtoolsCoverage`, `DevtoolsFieldCoverage` are importable from `@umpire/devtools`
- [ ] Typecheck: `yarn typecheck` passes

https://claude.ai/code/session_01M3fzzWawnoyzq3DL8S4XUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3fzzWawnoyzq3DL8S4XUK)_