### PR TITLE
✨ Add @umpire/write for create/patch policy checks

### DIFF
--- a/.changeset/soft-cars-jam.md
+++ b/.changeset/soft-cars-jam.md
@@ -1,0 +1,7 @@
+---
+'@umpire/write': minor
+---
+
+Add a new `@umpire/write` package for synchronous create/patch policy checks against Umpire availability semantics.
+
+This release includes `checkCreate`/`checkPatch`, exported write-result types, contract tests, and monorepo publish wiring.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       dsl_changed: ${{ steps.versions.outputs.dsl_changed }}
       json_changed: ${{ steps.versions.outputs.json_changed }}
       reads_changed: ${{ steps.versions.outputs.reads_changed }}
+      write_changed: ${{ steps.versions.outputs.write_changed }}
       devtools_changed: ${{ steps.versions.outputs.devtools_changed }}
       store_changed: ${{ steps.versions.outputs.store_changed }}
       signals_changed: ${{ steps.versions.outputs.signals_changed }}
@@ -70,7 +71,7 @@ jobs:
             }
           })();
           const isZeroSha = !before || /^0+$/.test(before);
-          const packages = ['core', 'dsl', 'json', 'reads', 'devtools', 'store', 'signals', 'react', 'redux', 'pinia', 'tanstack-store', 'vuex', 'zustand', 'zod', 'testing', 'eslint-plugin', 'solid'];
+          const packages = ['core', 'dsl', 'json', 'reads', 'write', 'devtools', 'store', 'signals', 'react', 'redux', 'pinia', 'tanstack-store', 'vuex', 'zustand', 'zod', 'testing', 'eslint-plugin', 'solid'];
 
           const readCurrentVersion = (pkg) => {
             const packageJson = path.join('packages', pkg, 'package.json');
@@ -172,6 +173,16 @@ jobs:
       - name: Publish @umpire/reads
         if: needs.detect-version-changes.outputs.reads_changed == 'true'
         working-directory: packages/reads
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="latest"
+          if echo "$VERSION" | grep -q "-"; then TAG="alpha"; fi
+          yarn pack -o package.tgz
+          npm publish package.tgz --provenance --access public --tag "$TAG"
+
+      - name: Publish @umpire/write
+        if: needs.detect-version-changes.outputs.write_changed == 'true'
+        working-directory: packages/write
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG="latest"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ const fouls = signupUmp.play(
 | [`@umpire/vuex`](./packages/vuex/README.md)                     | Vuex 4 adapter (Vue 3)                                                        |
 | [`@umpire/zod`](./packages/zod/README.md)                       | Availability-aware Zod schemas — disabled fields produce no errors            |
 | [`@umpire/reads`](./packages/reads/README.md)                   | Derived read tables and read-backed rule bridges                              |
+| [`@umpire/write`](./packages/write/README.md)                   | Create/patch write-policy checks against Umpire availability                  |
 | [`@umpire/testing`](./packages/testing/README.md)               | Invariant probes for rule configurations                                      |
 | [`@umpire/devtools`](./packages/devtools/README.md)             | In-app inspector panel — scorecard, traces, foul log, graph view              |
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -105,6 +105,7 @@ export default defineConfig({
             { label: 'DevTools', slug: 'extensions/devtools' },
             { label: 'Reads', slug: 'extensions/reads' },
             { label: 'Testing', slug: 'extensions/testing' },
+            { label: 'Write', slug: 'extensions/write' },
             { label: 'ESLint Plugin', slug: 'extensions/eslint-plugin' },
             { label: 'JSON', collapsed: true, items: [
               { label: 'Overview', slug: 'extensions/json' },

--- a/docs/src/content/docs/extensions/write.md
+++ b/docs/src/content/docs/extensions/write.md
@@ -1,0 +1,135 @@
+---
+title: '@umpire/write'
+description: Policy-level create and patch checks for service boundaries — answers whether a candidate passes Umpire availability rules before you persist it.
+---
+
+#### The problem
+
+At the form layer, Umpire tells your UI which fields are available so it can render the right controls. At the service layer, you need the inverse: given a payload that arrived at your endpoint, does it respect the same policy? A form can enforce availability visually, but direct API clients, scripts, and mobile apps can submit anything. `@umpire/write` applies your Umpire instance against an incoming create or patch payload and returns a single pass/fail answer, a structured list of violations, and the normalized candidate that would be persisted.
+
+#### Why not schema validation?
+
+Schema validation is a different check. A Zod schema tells you the payload has the right shape and types — it cannot tell you whether a field should be present at all given the current state of other fields. Availability policy is dynamic: a field that is required when one option is selected may be disabled when another is. `@umpire/write` is the layer that enforces those relationships at the service boundary, after schema validation has already passed.
+
+#### Example
+
+Consider a user-settings endpoint: a feature flag on the account controls which fields are available, and some fields become disabled when others are set. Your form already uses `ump.check()` to render conditionally, but a mobile client or a data migration script bypasses the form entirely. Before you call `db.update()`, you want the same policy evaluation your form relies on — with a clear `ok: false` and a reason string you can return in the response body.
+
+## Install
+
+```bash
+yarn add @umpire/core @umpire/write
+```
+
+## `checkCreate(ump, data, context?)`
+
+Call this when you are creating a new record from an incoming payload.
+
+```ts
+import { checkCreate } from '@umpire/write'
+
+const result = checkCreate(ump, req.body, { tenantId: req.user.tenantId })
+if (!result.ok) {
+  return res.status(422).json({ errors: result.errors })
+}
+await db.insert(result.candidate)
+```
+
+The candidate is built as `{ ...ump.init(), ...data }`. Umpire defaults fill in any fields the payload omitted; the incoming data then overlays them. Extra keys on `data` that are not declared in the Umpire field set pass through onto `result.candidate` untouched, but they are not evaluated for policy.
+
+`result.ok` is `true` when there are no current-state issues. Create results never include transition fouls — `result.fouls` is always `[]`.
+
+Explicit `undefined` values on `data` are treated as real assignments. A payload `{ name: undefined }` produces a candidate with `name` present but undefined, and a required field in that state will produce a `required` issue.
+
+## `checkPatch(ump, existing, patch, context?)`
+
+Call this when you are updating an existing record from a partial payload.
+
+```ts
+import { checkPatch } from '@umpire/write'
+
+const existing = await db.findOne(id)
+const result = checkPatch(ump, existing, req.body, { tenantId: req.user.tenantId })
+if (!result.ok) {
+  return res.status(422).json({ errors: result.errors, fouls: result.fouls })
+}
+await db.update(id, result.candidate)
+```
+
+The candidate is `{ ...existing, ...patch }` — a shallow merge where patch keys win. `existing` is also passed to `ump.check()` as the previous state, which matters for rules like `oneOf` that resolve strategy conflicts by considering what the record held before the patch. Without that previous-state context, the same candidate can resolve to a different availability map.
+
+`checkPatch` computes two independent sets of violations:
+
+- **Issues** — current-state problems on the merged candidate, the same evaluation `checkCreate` performs.
+- **Fouls** — transition problems detected by `play()`. A foul means a field held a value in `existing`, and the patch caused that field to become disabled or foul while the value is still present. This catches the case where a dependent field becomes stale because the field it depends on was cleared.
+
+`result.ok` is `true` only when there are no issues **and** no fouls. A patch that produces clean issues but transition fouls is still `ok: false`.
+
+`result.errors` contains only current-state issue messages. Transition foul details stay on `result.fouls`, where each entry includes a `field`, a `reason`, and a `suggestedValue` for the reset.
+
+Extra keys from either `existing` or `patch` that are not in the Umpire field set pass through onto `result.candidate`, but only declared fields are evaluated for policy or transitions.
+
+## Result shape
+
+```ts
+type WriteCheckResult<F extends Record<string, FieldDef>> = {
+  ok: boolean
+  candidate: WriteCandidate<F>
+  availability: AvailabilityMap<F>
+  issues: WriteIssue<F>[]
+  fouls: Foul<F>[]
+  errors: string[]
+}
+
+type WriteIssue<F extends Record<string, FieldDef>> = {
+  kind: 'required' | 'disabled' | 'foul'
+  field: keyof F & string
+  message: string
+}
+```
+
+Issues are derived only from fields declared in the Umpire instance. At most one issue is emitted per field, checked in this order:
+
+1. **`required`** — the field is enabled, required, and unsatisfied.
+2. **`disabled`** — the field has a value and is disabled. Empty disabled fields are not issues; a field that is disabled and unsatisfied is simply not in play.
+3. **`foul`** — the field has a value, is enabled, and `fair` is `false`.
+
+The `message` for each issue comes from the field's `reason` in the availability status, falling back to the first entry in `reasons`, then to a generated fallback (`"${field} is required"`, `"${field} is disabled"`, or `"${field} is foul"`).
+
+## Issues vs fouls
+
+`issues` and `fouls` report different problems:
+
+- **Issues** are current-state violations — the candidate has a field that is required but missing, disabled but filled, or enabled but foul. These are derived from the availability snapshot and apply to both creates and patches.
+- **Fouls** are transition violations — a field held a value before the patch, and after the patch it became disabled or foul while still holding that value. These are computed by `play()` and only appear in `checkPatch` results (create results always have `fouls: []`).
+
+A patch can be `ok: false` due to issues, fouls, or both. Inspect both lists to understand why.
+
+## Boundary
+
+`result.ok` means the candidate passes Umpire write policy only. It does not mean the input is:
+
+- schema-valid (type constraints, format rules, string lengths)
+- authorized for the caller
+- safe to persist (unique constraints, foreign keys, generated columns)
+- accepted by your database
+
+Schema, authorization, and database constraints belong at the persistence boundary — in your ORM hooks, repository layer, or a dedicated validation pipe. `@umpire/write` checks policy availability; your persistence layer checks structural validity.
+
+## ORM integration
+
+When you pass `result.candidate` toward persistence, remember that it is Umpire-normalized input. Defaults come from `ump.init()`, not from your ORM or database. A field that Umpire defaults to `null` might receive an auto-generated UUID from your database on insert. That difference is intentional — Umpire governs availability policy, your ORM governs storage semantics.
+
+Practical guidance for common ORMs:
+
+- **Sequelize:** run `checkCreate`/`checkPatch` before `Model.create()` or `instance.update()`. Apply Sequelize defaults, hooks, and validators after the Umpire check passes. Use `result.candidate` as the initial payload, not the final one.
+- **Drizzle:** check the candidate before your `db.insert()` or `db.update()` call. Drizzle's schema-level defaults and constraints apply at the SQL layer — Umpire policy and Drizzle validation are independent checks.
+- **Prisma:** check the candidate before `prisma.model.create()` or `prisma.model.update()`. Prisma's own validation, `@default` attributes, and unique constraints run when the query hits the database. Umpire policy is your pre-flight check; Prisma is your persistence guard.
+
+In all cases, the pattern is the same: Umpire first, ORM second. Reject early on policy violations, then let the ORM enforce its own rules.
+
+## See also
+
+- [`ump.check()`](/api/check/) — the availability API that `checkCreate`/`checkPatch` wrap
+- [`play()`](/api/play/) — transition foul computation used by `checkPatch`
+- [Composing Validation](/concepts/validation/) — where Umpire fits in a layered validation strategy

--- a/packages/write/AGENTS.md
+++ b/packages/write/AGENTS.md
@@ -1,0 +1,5 @@
+# @umpire/write
+
+- Use this package for write-policy helpers that coordinate Umpire state updates.
+- Keep helpers thin and composable; prefer adapters around `@umpire/core` over new state machinery.
+- Do not imply persistence, validation, or database safety guarantees here.

--- a/packages/write/README.md
+++ b/packages/write/README.md
@@ -18,6 +18,7 @@ yarn add @umpire/core @umpire/write
 ```ts
 import { checkCreate, checkPatch } from '@umpire/write'
 import type {
+  WriteCandidate,
   WriteCheckResult,
   WriteIssue,
   WriteIssueKind,
@@ -57,17 +58,25 @@ present on `result.candidate`.
 `result.ok` is `true` only when there are no current-state issues and no
 transition fouls.
 
+`result.errors` is a convenience list of current-state issue messages only.
+Transition foul details stay on `result.fouls`.
+
 ## Result Shape
 
 ```ts
 type WriteCheckResult = {
   ok: boolean
-  candidate: Record<string, unknown>
+  candidate: WriteCandidate<F>
   availability: AvailabilityMap<F>
   issues: WriteIssue<F>[]
   fouls: Foul<F>[]
   errors: string[]
 }
+
+type WriteCandidate<F extends Record<string, FieldDef>> = Partial<
+  Record<keyof F & string, unknown>
+> &
+  Record<string, unknown>
 
 type WriteIssue<F extends Record<string, FieldDef>> = {
   kind: 'required' | 'disabled' | 'foul'

--- a/packages/write/README.md
+++ b/packages/write/README.md
@@ -1,0 +1,13 @@
+# @umpire/write
+
+Write-policy helpers for coordinating Umpire state changes.
+
+## Install
+
+```bash
+npm install @umpire/core @umpire/write
+```
+
+## Status
+
+This package is scaffolded for the next implementation phase.

--- a/packages/write/README.md
+++ b/packages/write/README.md
@@ -1,13 +1,97 @@
 # @umpire/write
 
-Write-policy helpers for coordinating Umpire state changes.
+Thin write-policy helpers for service-layer checks with Umpire.
+
+`@umpire/write` answers one narrow question: does this candidate create or
+patch pass the Umpire availability policy for declared fields? It does not
+perform schema validation, authorization, database constraint checks, or any
+other persistence-safety work.
 
 ## Install
 
 ```bash
-npm install @umpire/core @umpire/write
+yarn add @umpire/core @umpire/write
 ```
 
-## Status
+## API
 
-This package is scaffolded for the next implementation phase.
+```ts
+import { checkCreate, checkPatch } from '@umpire/write'
+import type {
+  WriteCheckResult,
+  WriteIssue,
+  WriteIssueKind,
+} from '@umpire/write'
+```
+
+### `checkCreate(ump, data, context?)`
+
+Builds a create candidate from Umpire defaults plus incoming data:
+
+```ts
+const result = checkCreate(ump, data, context)
+```
+
+The evaluated candidate is `{ ...ump.init(), ...data }`. Extra keys on `data`
+are ignored by Umpire policy evaluation, but remain present on
+`result.candidate`.
+
+Create results never include transition fouls, so `result.fouls` is always
+`[]`. `result.ok` is `true` only when there are no current-state policy issues.
+
+### `checkPatch(ump, existing, patch, context?)`
+
+Builds a patch candidate from the existing record plus incoming patch:
+
+```ts
+const result = checkPatch(ump, existing, patch, context)
+```
+
+The evaluated candidate is `{ ...existing, ...patch }`. Current-state issues
+are checked with `existing` as the previous state, and transition fouls are
+computed from `existing` to `candidate`.
+
+Extra keys on either object are ignored by Umpire policy evaluation, but remain
+present on `result.candidate`.
+
+`result.ok` is `true` only when there are no current-state issues and no
+transition fouls.
+
+## Result Shape
+
+```ts
+type WriteCheckResult = {
+  ok: boolean
+  candidate: Record<string, unknown>
+  availability: AvailabilityMap<F>
+  issues: WriteIssue<F>[]
+  fouls: Foul<F>[]
+  errors: string[]
+}
+
+type WriteIssue<F extends Record<string, FieldDef>> = {
+  kind: 'required' | 'disabled' | 'foul'
+  field: keyof F & string
+  message: string
+}
+```
+
+Issues are derived only from fields declared in the Umpire instance. At most one
+current-state issue is emitted per field, using this precedence:
+
+1. `required`: enabled, required, and unsatisfied
+2. `disabled`: satisfied and disabled
+3. `foul`: satisfied, enabled, and `fair: false`
+
+The `message` for each issue comes from the Umpire status `reason`/first
+`reasons` entry when present, otherwise it falls back to:
+
+1. `${field} is required`
+2. `${field} is disabled`
+3. `${field} is foul`
+
+## Boundary
+
+`ok` means the candidate passes Umpire write policy only. It does not mean the
+input is schema-valid, authorized for the caller, safe to persist, or accepted
+by your database.

--- a/packages/write/README.md
+++ b/packages/write/README.md
@@ -37,6 +37,13 @@ The evaluated candidate is `{ ...ump.init(), ...data }`. Extra keys on `data`
 are ignored by Umpire policy evaluation, but remain present on
 `result.candidate`.
 
+> **Note for ORM users:** `result.candidate` is Umpire-normalized — it starts
+> from `ump.init()` and overlays incoming `data`. Fields absent from `data` fall
+> back to Umpire defaults, which may differ from database or ORM defaults (e.g.
+> `null` vs a generated UUID). When persisting, choose deliberately between the
+> incoming `data` and `result.candidate` depending on which default source your
+> layer owns.
+
 Create results never include transition fouls, so `result.fouls` is always
 `[]`. `result.ok` is `true` only when there are no current-state policy issues.
 

--- a/packages/write/__tests__/check.test.ts
+++ b/packages/write/__tests__/check.test.ts
@@ -7,10 +7,12 @@ import {
   fairWhen,
   oneOf,
   umpire,
+  type FieldDef,
 } from '@umpire/core'
 import * as write from '@umpire/write'
 import { checkCreate, checkPatch } from '@umpire/write'
 import type {
+  WriteCandidate,
   WriteCheckResult,
   WriteIssue,
   WriteIssueKind,
@@ -19,22 +21,14 @@ import { deriveSchema } from '@umpire/zod'
 import { z } from 'zod'
 
 type WriteFields = {
-  name: {
-    required?: boolean
-    default?: unknown
-    isEmpty?: (value: unknown) => boolean
-  }
-  toggle: { default?: unknown }
-  dependent: {
-    required?: boolean
-    default?: unknown
-    isEmpty?: (value: unknown) => boolean
-  }
-  optional: { required?: boolean; isEmpty?: (value: unknown) => boolean }
-  guarded: { required?: boolean }
-  forbidden: {}
-  alpha: {}
-  beta: {}
+  name: FieldDef
+  toggle: FieldDef
+  dependent: FieldDef
+  optional: FieldDef
+  guarded: FieldDef
+  forbidden: FieldDef
+  alpha: FieldDef
+  beta: FieldDef
 }
 
 describe('checkCreate', () => {
@@ -186,7 +180,10 @@ describe('checkPatch', () => {
         suggestedValue: undefined,
       },
     ])
-    expect(result.errors).toEqual(['condition not met', 'condition not met'])
+    expect(result.issues).toEqual([
+      { kind: 'disabled', field: 'dependent', message: 'condition not met' },
+    ])
+    expect(result.errors).toEqual(['condition not met'])
   })
 
   test('passes prev through to ump.check semantics', () => {
@@ -216,12 +213,12 @@ describe('checkPatch', () => {
     ])
   })
 
-  test('orders errors as issues first, then fouls', () => {
+  test('keeps transition foul reasons out of errors', () => {
     const ump = umpire<Pick<WriteFields, 'name' | 'toggle' | 'dependent'>>({
       fields: { name: { required: true }, toggle: {}, dependent: {} },
       rules: [
-        fairWhen('dependent', (values) => values.toggle === true, {
-          reason: 'dependent is stale',
+        enabledWhen('dependent', (values) => values.toggle === true, {
+          reason: 'dependent disabled',
         }),
       ],
     })
@@ -234,9 +231,16 @@ describe('checkPatch', () => {
 
     expect(result.issues).toEqual([
       { kind: 'required', field: 'name', message: 'name is required' },
-      { kind: 'foul', field: 'dependent', message: 'dependent is stale' },
+      { kind: 'disabled', field: 'dependent', message: 'dependent disabled' },
     ])
-    expect(result.errors).toEqual(['name is required', 'dependent is stale'])
+    expect(result.fouls).toEqual([
+      {
+        field: 'dependent',
+        reason: 'dependent disabled',
+        suggestedValue: undefined,
+      },
+    ])
+    expect(result.errors).toEqual(['name is required', 'dependent disabled'])
   })
 
   test('respects shallow merge semantics', () => {
@@ -281,6 +285,10 @@ describe('checkPatch', () => {
 
     const result = checkPatch(ump, { name: 'Douglas' }, { optional: 'notes' })
 
+    expect(result.ok).toBe(true)
+    expect(result.issues).toEqual([])
+    expect(result.fouls).toEqual([])
+    expect(result.errors).toEqual([])
     expect(result.candidate).toEqual({ name: 'Douglas', optional: 'notes' })
   })
 
@@ -478,6 +486,67 @@ describe('issue derivation', () => {
     ])
   })
 
+  test('accumulates multiple simultaneous issues', () => {
+    const ump = umpire<Pick<WriteFields, 'name' | 'optional'>>({
+      fields: { name: { required: true }, optional: { required: true } },
+      rules: [],
+    })
+
+    const result = checkCreate(ump, {})
+
+    expect(result.ok).toBe(false)
+    expect(result.issues).toEqual([
+      { kind: 'required', field: 'name', message: 'name is required' },
+      { kind: 'required', field: 'optional', message: 'optional is required' },
+    ])
+    expect(result.errors).toEqual(['name is required', 'optional is required'])
+  })
+
+  test('does not issue disabled unsatisfied required fields', () => {
+    const ump = umpire<Pick<WriteFields, 'dependent'>>({
+      fields: { dependent: { required: true } },
+      rules: [
+        enabledWhen('dependent', () => false, { reason: 'currently disabled' }),
+      ],
+    })
+
+    const result = checkCreate(ump, {})
+
+    expect(result.ok).toBe(true)
+    expect(result.availability.dependent.enabled).toBe(false)
+    expect(result.availability.dependent.required).toBe(false)
+    expect(result.availability.dependent.satisfied).toBe(false)
+    expect(result.issues).toEqual([])
+    expect(result.errors).toEqual([])
+  })
+
+  test('does not issue fouls for unsatisfied fields', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [
+        defineRule({
+          type: 'contextualGate',
+          targets: ['name'],
+          sources: [],
+          constraint: 'fair',
+          evaluate() {
+            return new Map([['name', { fair: false, reason: 'reserved' }]])
+          },
+        }),
+      ],
+    })
+
+    const result = checkCreate(ump, {})
+
+    expect(result.availability.name.enabled).toBe(true)
+    expect(result.availability.name.satisfied).toBe(false)
+    expect(result.availability.name.fair).toBe(false)
+    expect(result.issues).toEqual([
+      { kind: 'required', field: 'name', message: 'reserved' },
+    ])
+    expect(result.errors).toEqual(['reserved'])
+  })
+
   test('uses context on patch and keeps transition fouls separate from current-state issues', () => {
     const ump = umpire<
       Pick<WriteFields, 'toggle' | 'dependent'>,
@@ -499,6 +568,44 @@ describe('issue derivation', () => {
     ])
     expect(result.fouls).toEqual([])
     expect(result.ok).toBe(false)
+  })
+
+  test('uses context when evaluating patch transition fouls', () => {
+    const ump = umpire<
+      Pick<WriteFields, 'toggle' | 'dependent'>,
+      { allow: boolean }
+    >({
+      fields: { toggle: {}, dependent: {} },
+      rules: [
+        enabledWhen('dependent', (values, context) => {
+          return values.toggle === true || context.allow
+        }),
+      ],
+    })
+
+    const blocked = checkPatch(
+      ump,
+      { toggle: true, dependent: 'keep me' },
+      { toggle: false },
+      { allow: false },
+    )
+    const allowed = checkPatch(
+      ump,
+      { toggle: true, dependent: 'keep me' },
+      { toggle: false },
+      { allow: true },
+    )
+
+    expect(blocked.fouls).toEqual([
+      {
+        field: 'dependent',
+        reason: 'condition not met',
+        suggestedValue: undefined,
+      },
+    ])
+    expect(allowed.fouls).toEqual([])
+    expect(allowed.issues).toEqual([])
+    expect(allowed.ok).toBe(true)
   })
 
   test('fails enabled required unsatisfied fields even when a UI would block submission', () => {
@@ -625,10 +732,13 @@ describe('exports', () => {
       )
 
     const result: WriteCheckResult<Pick<WriteFields, 'name'>> = buildResult()
+    const candidate: WriteCandidate<Pick<WriteFields, 'name'>> =
+      result.candidate
     const issue: WriteIssue<Pick<WriteFields, 'name'>> | undefined =
       result.issues[0]
     const kind: WriteIssueKind = issue?.kind ?? 'required'
 
+    expect(candidate).toEqual({})
     expect(issue).toEqual({
       kind: 'required',
       field: 'name',
@@ -637,15 +747,9 @@ describe('exports', () => {
     expect(kind).toBe('required')
   })
 
-  test('exports checkCreate and checkPatch only for runtime checking helpers', () => {
+  test('exports only the runtime checking helpers', () => {
+    expect(Object.keys(write).sort()).toEqual(['checkCreate', 'checkPatch'])
     expect(typeof write.checkCreate).toBe('function')
     expect(typeof write.checkPatch).toBe('function')
-    for (const name of [
-      'ValidationResult',
-      'validateCreate',
-      'validatePatch',
-    ]) {
-      expect(Object.hasOwn(write, name)).toBe(false)
-    }
   })
 })

--- a/packages/write/__tests__/check.test.ts
+++ b/packages/write/__tests__/check.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'bun:test'
+
+import { checkCreate, checkPatch } from '@umpire/write'
+
+test('exports callable write scaffold helpers', () => {
+  expect(checkCreate()).toBe(true)
+  expect(checkPatch()).toBe(true)
+})

--- a/packages/write/__tests__/check.test.ts
+++ b/packages/write/__tests__/check.test.ts
@@ -1,8 +1,64 @@
 import { expect, test } from 'bun:test'
 
+import { enabledWhen, umpire } from '@umpire/core'
+
 import { checkCreate, checkPatch } from '@umpire/write'
 
-test('exports callable write scaffold helpers', () => {
-  expect(checkCreate()).toBe(true)
-  expect(checkPatch()).toBe(true)
+test('checkCreate returns the merged create shape', () => {
+  const ump = umpire({
+    fields: {
+      toggle: { default: false },
+      dependent: {},
+    },
+    rules: [enabledWhen('dependent', (values) => values.toggle === true)],
+  })
+
+  const result = checkCreate(ump, { dependent: 'new value' })
+
+  expect(result.ok).toBe(false)
+  expect(result.candidate).toMatchObject({
+    toggle: false,
+    dependent: 'new value',
+  })
+  expect(result.fouls).toEqual([])
+  expect(result.issues).toEqual([
+    {
+      kind: 'disabled',
+      field: 'dependent',
+      message: 'condition not met',
+    },
+  ])
+})
+
+test('checkPatch returns the write result shape', () => {
+  const ump = umpire({
+    fields: { toggle: {}, dependent: {} },
+    rules: [enabledWhen('dependent', (values) => values.toggle === true)],
+  })
+
+  const result = checkPatch(
+    ump,
+    { toggle: true, dependent: 'keep me' },
+    { toggle: false },
+  )
+
+  expect(result).toMatchObject({
+    ok: false,
+    candidate: { toggle: false, dependent: 'keep me' },
+    fouls: [
+      {
+        field: 'dependent',
+        reason: 'condition not met',
+      },
+    ],
+    errors: ['condition not met', 'condition not met'],
+  })
+  expect(result.availability.dependent.enabled).toBe(false)
+  expect(result.issues).toEqual([
+    {
+      kind: 'disabled',
+      field: 'dependent',
+      message: 'condition not met',
+    },
+  ])
 })

--- a/packages/write/__tests__/check.test.ts
+++ b/packages/write/__tests__/check.test.ts
@@ -1,64 +1,651 @@
-import { expect, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 
-import { enabledWhen, umpire } from '@umpire/core'
-
+import {
+  disables,
+  defineRule,
+  enabledWhen,
+  fairWhen,
+  oneOf,
+  umpire,
+} from '@umpire/core'
+import * as write from '@umpire/write'
 import { checkCreate, checkPatch } from '@umpire/write'
+import type {
+  WriteCheckResult,
+  WriteIssue,
+  WriteIssueKind,
+} from '@umpire/write'
+import { deriveSchema } from '@umpire/zod'
+import { z } from 'zod'
 
-test('checkCreate returns the merged create shape', () => {
-  const ump = umpire({
-    fields: {
-      toggle: { default: false },
-      dependent: {},
-    },
-    rules: [enabledWhen('dependent', (values) => values.toggle === true)],
+type WriteFields = {
+  name: {
+    required?: boolean
+    default?: unknown
+    isEmpty?: (value: unknown) => boolean
+  }
+  toggle: { default?: unknown }
+  dependent: {
+    required?: boolean
+    default?: unknown
+    isEmpty?: (value: unknown) => boolean
+  }
+  optional: { required?: boolean; isEmpty?: (value: unknown) => boolean }
+  guarded: { required?: boolean }
+  forbidden: {}
+  alpha: {}
+  beta: {}
+}
+
+describe('checkCreate', () => {
+  test('passes with no issues', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+
+    const result = checkCreate(ump, { name: 'Douglas' })
+
+    expect(result.ok).toBe(true)
+    expect(result.issues).toEqual([])
+    expect(result.fouls).toEqual([])
+    expect(result.errors).toEqual([])
+    expect(result.candidate).toEqual({ name: 'Douglas' })
   })
 
-  const result = checkCreate(ump, { dependent: 'new value' })
+  test('fails on a missing enabled required field', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [],
+    })
 
-  expect(result.ok).toBe(false)
-  expect(result.candidate).toMatchObject({
-    toggle: false,
-    dependent: 'new value',
+    const result = checkCreate(ump, {})
+
+    expect(result.ok).toBe(false)
+    expect(result.issues).toEqual([
+      { kind: 'required', field: 'name', message: 'name is required' },
+    ])
+    expect(result.fouls).toEqual([])
+    expect(result.errors).toEqual(['name is required'])
+    expect(result.candidate).toEqual({})
   })
-  expect(result.fouls).toEqual([])
-  expect(result.issues).toEqual([
-    {
-      kind: 'disabled',
-      field: 'dependent',
-      message: 'condition not met',
-    },
-  ])
+
+  test('fails on a satisfied disabled field', () => {
+    const ump = umpire<Pick<WriteFields, 'toggle' | 'dependent'>>({
+      fields: { toggle: { default: false }, dependent: {} },
+      rules: [enabledWhen('dependent', (values) => values.toggle === true)],
+    })
+
+    const result = checkCreate(ump, { dependent: 'submitted anyway' })
+
+    expect(result.ok).toBe(false)
+    expect(result.issues).toEqual([
+      { kind: 'disabled', field: 'dependent', message: 'condition not met' },
+    ])
+    expect(result.fouls).toEqual([])
+    expect(result.errors).toEqual(['condition not met'])
+    expect(result.candidate).toEqual({
+      toggle: false,
+      dependent: 'submitted anyway',
+    })
+  })
+
+  test('fails on a foul field', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: {} },
+      rules: [fairWhen('name', (value) => value !== 'reserved')],
+    })
+
+    const result = checkCreate(ump, { name: 'reserved' })
+
+    expect(result.ok).toBe(false)
+    expect(result.issues).toEqual([
+      {
+        kind: 'foul',
+        field: 'name',
+        message: 'selection is no longer valid',
+      },
+    ])
+    expect(result.fouls).toEqual([])
+    expect(result.errors).toEqual(['selection is no longer valid'])
+    expect(result.candidate).toEqual({ name: 'reserved' })
+  })
+
+  test('returns a candidate with Umpire defaults applied', () => {
+    const ump = umpire<Pick<WriteFields, 'toggle' | 'dependent'>>({
+      fields: {
+        toggle: { default: false },
+        dependent: { default: 'defaulted', required: true },
+      },
+      rules: [],
+    })
+
+    const omittedResult = checkCreate(ump, { toggle: true })
+    const result = checkCreate(ump, { toggle: true, dependent: 'submitted' })
+
+    expect(omittedResult.candidate).toEqual({
+      toggle: true,
+      dependent: 'defaulted',
+    })
+    expect(omittedResult.issues).toEqual([])
+    expect(result.candidate.toggle).toBe(true)
+    expect(result.candidate.dependent).toBe('submitted')
+    expect(result.candidate).toEqual({ toggle: true, dependent: 'submitted' })
+  })
+
+  test('treats explicit undefined on create as an assigned value', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+
+    const result = checkCreate(ump, { name: undefined })
+
+    expect(Object.hasOwn(result.candidate, 'name')).toBe(true)
+    expect(result.candidate.name).toBeUndefined()
+    expect(result.issues).toEqual([
+      { kind: 'required', field: 'name', message: 'name is required' },
+    ])
+  })
+
+  test('accepts context when checking create availability', () => {
+    const ump = umpire<Pick<WriteFields, 'guarded'>, { allow: boolean }>({
+      fields: { guarded: {} },
+      rules: [enabledWhen('guarded', (_values, context) => context.allow)],
+    })
+
+    expect(
+      checkCreate(ump, { guarded: 'value' }, { allow: true }).issues,
+    ).toEqual([])
+    expect(
+      checkCreate(ump, { guarded: 'value' }, { allow: false }).issues,
+    ).toEqual([
+      { kind: 'disabled', field: 'guarded', message: 'condition not met' },
+    ])
+  })
 })
 
-test('checkPatch returns the write result shape', () => {
-  const ump = umpire({
-    fields: { toggle: {}, dependent: {} },
-    rules: [enabledWhen('dependent', (values) => values.toggle === true)],
-  })
+describe('checkPatch', () => {
+  test('emits fouls when a transition creates stale values', () => {
+    const ump = umpire<Pick<WriteFields, 'toggle' | 'dependent'>>({
+      fields: { toggle: {}, dependent: {} },
+      rules: [enabledWhen('dependent', (values) => values.toggle === true)],
+    })
 
-  const result = checkPatch(
-    ump,
-    { toggle: true, dependent: 'keep me' },
-    { toggle: false },
-  )
+    const result = checkPatch(
+      ump,
+      { toggle: true, dependent: 'keep me' },
+      { toggle: false },
+    )
 
-  expect(result).toMatchObject({
-    ok: false,
-    candidate: { toggle: false, dependent: 'keep me' },
-    fouls: [
+    expect(result.ok).toBe(false)
+    expect(result.fouls).toEqual([
       {
         field: 'dependent',
         reason: 'condition not met',
+        suggestedValue: undefined,
       },
-    ],
-    errors: ['condition not met', 'condition not met'],
+    ])
+    expect(result.errors).toEqual(['condition not met', 'condition not met'])
   })
-  expect(result.availability.dependent.enabled).toBe(false)
-  expect(result.issues).toEqual([
-    {
-      kind: 'disabled',
-      field: 'dependent',
-      message: 'condition not met',
-    },
-  ])
+
+  test('passes prev through to ump.check semantics', () => {
+    const ump = umpire<Pick<WriteFields, 'alpha' | 'beta'>>({
+      fields: { alpha: {}, beta: {} },
+      rules: [oneOf('strategy', { first: ['alpha'], second: ['beta'] })],
+    })
+
+    const result = checkPatch(
+      ump,
+      { alpha: 'still here' },
+      { beta: 'new value' },
+    )
+    const directResult = ump.check(result.candidate)
+
+    expect(result.availability.alpha.enabled).toBe(false)
+    expect(result.availability.beta.enabled).toBe(true)
+    expect(directResult.alpha.enabled).toBe(true)
+    expect(directResult.beta.enabled).toBe(false)
+    expect(result.availability).not.toEqual(directResult)
+    expect(result.issues).toEqual([
+      {
+        kind: 'disabled',
+        field: 'alpha',
+        message: 'conflicts with second strategy',
+      },
+    ])
+  })
+
+  test('orders errors as issues first, then fouls', () => {
+    const ump = umpire<Pick<WriteFields, 'name' | 'toggle' | 'dependent'>>({
+      fields: { name: { required: true }, toggle: {}, dependent: {} },
+      rules: [
+        fairWhen('dependent', (values) => values.toggle === true, {
+          reason: 'dependent is stale',
+        }),
+      ],
+    })
+
+    const result = checkPatch(
+      ump,
+      { toggle: true, dependent: 'kept' },
+      { toggle: false },
+    )
+
+    expect(result.issues).toEqual([
+      { kind: 'required', field: 'name', message: 'name is required' },
+      { kind: 'foul', field: 'dependent', message: 'dependent is stale' },
+    ])
+    expect(result.errors).toEqual(['name is required', 'dependent is stale'])
+  })
+
+  test('respects shallow merge semantics', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: {} },
+      rules: [],
+    })
+    const existing = { name: { first: 'Douglas', last: 'Brown' } }
+
+    const result = checkPatch(ump, existing, { name: { first: 'Doug' } })
+
+    expect(result.candidate).toEqual({ name: { first: 'Doug' } })
+  })
+
+  test('keeps unknown patch keys on the candidate while ignoring them in policy checks', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: {} },
+      rules: [enabledWhen('name', (values) => values.name !== 'blocked')],
+    })
+
+    const result = checkPatch(
+      ump,
+      { name: 'Douglas', existingOnly: 'kept' },
+      { name: 'Doug', patchOnly: 'kept too' },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.issues).toEqual([])
+    expect(Object.keys(result.availability)).toEqual(['name'])
+    expect(result.candidate).toEqual({
+      name: 'Doug',
+      existingOnly: 'kept',
+      patchOnly: 'kept too',
+    })
+  })
+
+  test('returns the merged candidate', () => {
+    const ump = umpire<Pick<WriteFields, 'name' | 'optional'>>({
+      fields: { name: { default: 'default name' }, optional: {} },
+      rules: [],
+    })
+
+    const result = checkPatch(ump, { name: 'Douglas' }, { optional: 'notes' })
+
+    expect(result.candidate).toEqual({ name: 'Douglas', optional: 'notes' })
+  })
+
+  test('treats explicit undefined as a real assigned value', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+
+    const result = checkPatch(ump, { name: 'Douglas' }, { name: undefined })
+
+    expect(Object.hasOwn(result.candidate, 'name')).toBe(true)
+    expect(result.candidate.name).toBeUndefined()
+    expect(result.issues).toEqual([
+      { kind: 'required', field: 'name', message: 'name is required' },
+    ])
+  })
+})
+
+describe('issue derivation', () => {
+  test('ignores unknown keys outside the Umpire field set', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: {} },
+      rules: [],
+    })
+
+    const result = checkCreate(ump, { name: 'Douglas', extra: 'kept' })
+
+    expect(result.ok).toBe(true)
+    expect(result.issues).toEqual([])
+  })
+
+  test('preserves unknown keys on the candidate', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: {} },
+      rules: [],
+    })
+
+    const result = checkCreate(ump, { name: 'Douglas', extra: 'kept' })
+
+    expect(result.candidate).toEqual({ name: 'Douglas', extra: 'kept' })
+  })
+
+  test('does not issue optional empty fields', () => {
+    const ump = umpire<Pick<WriteFields, 'optional'>>({
+      fields: {
+        optional: { isEmpty: (value) => value === '' || value == null },
+      },
+      rules: [],
+    })
+
+    const result = checkCreate(ump, { optional: '' })
+
+    expect(result.ok).toBe(true)
+    expect(result.issues).toEqual([])
+  })
+
+  test('uses required fallback messages', () => {
+    const requiredUmp = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+
+    expect(checkCreate(requiredUmp, {}).issues).toEqual([
+      { kind: 'required', field: 'name', message: 'name is required' },
+    ])
+  })
+
+  test('uses disabled precedence', () => {
+    const disabledUmp = umpire<Pick<WriteFields, 'toggle' | 'dependent'>>({
+      fields: { toggle: { default: false }, dependent: { required: true } },
+      rules: [
+        enabledWhen('dependent', () => false, { reason: 'disabled reason' }),
+      ],
+    })
+
+    expect(checkCreate(disabledUmp, { dependent: 'value' }).issues).toEqual([
+      { kind: 'disabled', field: 'dependent', message: 'disabled reason' },
+    ])
+  })
+
+  test('uses foul precedence', () => {
+    const foulUmp = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [fairWhen('name', () => false, { reason: 'foul reason' })],
+    })
+
+    expect(checkCreate(foulUmp, { name: 'value' }).issues).toEqual([
+      { kind: 'foul', field: 'name', message: 'foul reason' },
+    ])
+  })
+
+  test('uses explicit reason', () => {
+    const reasonUmp = umpire<Pick<WriteFields, 'dependent'>>({
+      fields: { dependent: {} },
+      rules: [enabledWhen('dependent', () => false, { reason: 'from reason' })],
+    })
+
+    expect(checkCreate(reasonUmp, { dependent: 'value' }).issues).toEqual([
+      { kind: 'disabled', field: 'dependent', message: 'from reason' },
+    ])
+  })
+
+  test('uses reasons[0] when reason is null', () => {
+    const nullReasonUmp = umpire<Pick<WriteFields, 'guarded'>>({
+      fields: { guarded: {} },
+      rules: [
+        defineRule({
+          type: 'contextualGate',
+          targets: ['guarded'],
+          sources: [],
+          constraint: 'enabled',
+          evaluate() {
+            return new Map([
+              [
+                'guarded',
+                {
+                  enabled: false,
+                  reason: null,
+                  reasons: ['derived reason'],
+                },
+              ],
+            ])
+          },
+        }),
+      ],
+    })
+    const nullReasonResult = checkCreate(nullReasonUmp, { guarded: 'value' })
+
+    expect(nullReasonResult.availability.guarded.reason).toBeNull()
+    expect(nullReasonResult.availability.guarded.reasons[0]).toBe(
+      'derived reason',
+    )
+    expect(nullReasonResult.issues).toEqual([
+      { kind: 'disabled', field: 'guarded', message: 'derived reason' },
+    ])
+  })
+
+  test('uses status reasons[0] for a disables rule', () => {
+    const reasonsUmp = umpire<Pick<WriteFields, 'name' | 'guarded'>>({
+      fields: { name: {}, guarded: {} },
+      rules: [disables('name', ['guarded'])],
+    })
+
+    expect(
+      checkCreate(reasonsUmp, { name: 'set', guarded: 'value' }).issues,
+    ).toEqual([
+      { kind: 'disabled', field: 'guarded', message: 'overridden by name' },
+    ])
+  })
+
+  test('falls back for disabled issues with empty reason metadata', () => {
+    const ump = umpire<Pick<WriteFields, 'guarded'>>({
+      fields: { guarded: {} },
+      rules: [
+        defineRule({
+          type: 'contextualGate',
+          targets: ['guarded'],
+          sources: [],
+          constraint: 'enabled',
+          evaluate() {
+            return new Map([
+              ['guarded', { enabled: false, reason: undefined, reasons: [] }],
+            ])
+          },
+        }),
+      ],
+    })
+
+    expect(checkCreate(ump, { guarded: 'value' }).issues).toEqual([
+      { kind: 'disabled', field: 'guarded', message: 'guarded is disabled' },
+    ])
+  })
+
+  test('falls back for foul issues with empty reason metadata', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: {} },
+      rules: [
+        defineRule({
+          type: 'contextualGate',
+          targets: ['name'],
+          sources: [],
+          constraint: 'fair',
+          evaluate() {
+            return new Map([
+              ['name', { fair: false, reason: undefined, reasons: [] }],
+            ])
+          },
+        }),
+      ],
+    })
+
+    expect(checkCreate(ump, { name: 'value' }).issues).toEqual([
+      { kind: 'foul', field: 'name', message: 'name is foul' },
+    ])
+  })
+
+  test('uses context on patch and keeps transition fouls separate from current-state issues', () => {
+    const ump = umpire<
+      Pick<WriteFields, 'toggle' | 'dependent'>,
+      { allow: boolean }
+    >({
+      fields: { toggle: {}, dependent: {} },
+      rules: [enabledWhen('dependent', (_values, context) => context.allow)],
+    })
+
+    const result = checkPatch(
+      ump,
+      { toggle: true, dependent: 'keep me' },
+      { toggle: false },
+      { allow: false },
+    )
+
+    expect(result.issues).toEqual([
+      { kind: 'disabled', field: 'dependent', message: 'condition not met' },
+    ])
+    expect(result.fouls).toEqual([])
+    expect(result.ok).toBe(false)
+  })
+
+  test('fails enabled required unsatisfied fields even when a UI would block submission', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+
+    const result = checkCreate(ump, {})
+
+    expect(result.ok).toBe(false)
+    expect(result.issues[0]).toEqual({
+      kind: 'required',
+      field: 'name',
+      message: 'name is required',
+    })
+  })
+
+  test('fails satisfied disabled values submitted by non-UI clients', () => {
+    const ump = umpire<Pick<WriteFields, 'forbidden'>>({
+      fields: { forbidden: {} },
+      rules: [
+        enabledWhen('forbidden', () => false, { reason: 'server says no' }),
+      ],
+    })
+
+    const result = checkCreate(ump, { forbidden: 'curl payload' })
+
+    expect(result.ok).toBe(false)
+    expect(result.issues).toEqual([
+      { kind: 'disabled', field: 'forbidden', message: 'server says no' },
+    ])
+  })
+
+  test('keeps already-disabled stale values untouched on a no-op patch', () => {
+    const ump = umpire<Pick<WriteFields, 'toggle' | 'dependent'>>({
+      fields: { toggle: { default: false }, dependent: {} },
+      rules: [enabledWhen('dependent', (values) => values.toggle === true)],
+    })
+
+    const result = checkPatch(ump, { toggle: false, dependent: 'stale' }, {})
+
+    expect(result.candidate).toEqual({ toggle: false, dependent: 'stale' })
+    expect(result.issues).toEqual([
+      { kind: 'disabled', field: 'dependent', message: 'condition not met' },
+    ])
+    expect(result.fouls).toEqual([])
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('zod composition', () => {
+  test('checkCreate output composes with deriveSchema', () => {
+    const ump = umpire<Pick<WriteFields, 'name' | 'dependent' | 'toggle'>>({
+      fields: {
+        name: { required: true },
+        toggle: { default: false },
+        dependent: {},
+      },
+      rules: [enabledWhen('dependent', (values) => values.toggle === true)],
+    })
+    const result = checkCreate(ump, { name: 'Douglas' })
+    const schema = deriveSchema(result.availability, {
+      name: z.string(),
+      dependent: z.string(),
+    })
+
+    expect(schema.safeParse(result.candidate).success).toBe(true)
+    expect(Object.keys(schema.shape)).toEqual(['name'])
+  })
+
+  test('checkPatch output composes with deriveSchema', () => {
+    const ump = umpire<Pick<WriteFields, 'name' | 'optional'>>({
+      fields: { name: { required: true }, optional: {} },
+      rules: [],
+    })
+    const result = checkPatch(ump, { name: 'Douglas' }, { optional: 'notes' })
+    const schema = deriveSchema(result.availability, {
+      name: z.string(),
+      optional: z.string(),
+    })
+
+    expect(schema.safeParse(result.candidate).success).toBe(true)
+    expect(schema.safeParse({ optional: 'notes' }).success).toBe(false)
+  })
+
+  test('enabled required unsatisfied fields remain present and required in the derived schema', () => {
+    const ump = umpire<Pick<WriteFields, 'name'>>({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+    const result = checkCreate(ump, {})
+    const schema = deriveSchema(result.availability, { name: z.string() })
+
+    expect(Object.keys(schema.shape)).toEqual(['name'])
+    expect(schema.safeParse({}).success).toBe(false)
+  })
+
+  test('disabled fields are omitted while submitted disabled values are reported by write', () => {
+    const ump = umpire<Pick<WriteFields, 'toggle' | 'dependent'>>({
+      fields: { toggle: { default: false }, dependent: {} },
+      rules: [enabledWhen('dependent', (values) => values.toggle === true)],
+    })
+    const result = checkCreate(ump, { dependent: 'submitted anyway' })
+    const schema = deriveSchema(result.availability, { dependent: z.string() })
+
+    expect(result.issues).toEqual([
+      { kind: 'disabled', field: 'dependent', message: 'condition not met' },
+    ])
+    expect(Object.keys(schema.shape)).toEqual([])
+    expect(schema.safeParse({}).success).toBe(true)
+  })
+})
+
+describe('exports', () => {
+  test('exports public result and issue types', () => {
+    const buildResult = () =>
+      checkCreate(
+        umpire<Pick<WriteFields, 'name'>>({
+          fields: { name: { required: true } },
+          rules: [],
+        }),
+        {},
+      )
+
+    const result: WriteCheckResult<Pick<WriteFields, 'name'>> = buildResult()
+    const issue: WriteIssue<Pick<WriteFields, 'name'>> | undefined =
+      result.issues[0]
+    const kind: WriteIssueKind = issue?.kind ?? 'required'
+
+    expect(issue).toEqual({
+      kind: 'required',
+      field: 'name',
+      message: 'name is required',
+    })
+    expect(kind).toBe('required')
+  })
+
+  test('exports checkCreate and checkPatch only for runtime checking helpers', () => {
+    expect(typeof write.checkCreate).toBe('function')
+    expect(typeof write.checkPatch).toBe('function')
+    for (const name of [
+      'ValidationResult',
+      'validateCreate',
+      'validatePatch',
+    ]) {
+      expect(Object.hasOwn(write, name)).toBe(false)
+    }
+  })
 })

--- a/packages/write/bunfig.toml
+++ b/packages/write/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+preload = ["../../test/preload-workspace-aliases.ts"]
+coverageSkipTestFiles = true

--- a/packages/write/bunfig.toml
+++ b/packages/write/bunfig.toml
@@ -1,3 +1,2 @@
 [test]
-preload = ["../../test/preload-workspace-aliases.ts"]
 coverageSkipTestFiles = true

--- a/packages/write/package.json
+++ b/packages/write/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@umpire/write",
+  "version": "0.1.0-alpha.10",
+  "description": "Write-policy helpers for syncing Umpire state",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
+    "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist",
+    "AGENTS.md",
+    ".claude"
+  ],
+  "dependencies": {
+    "@umpire/core": "workspace:^"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "directory": "packages/write"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/write/package.json
+++ b/packages/write/package.json
@@ -27,6 +27,9 @@
   "dependencies": {
     "@umpire/core": "workspace:^"
   },
+  "devDependencies": {
+    "@umpire/zod": "workspace:^"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sdougbrown/umpire.git",

--- a/packages/write/src/check.ts
+++ b/packages/write/src/check.ts
@@ -1,0 +1,7 @@
+export function checkCreate(): boolean {
+  return true
+}
+
+export function checkPatch(): boolean {
+  return true
+}

--- a/packages/write/src/check.ts
+++ b/packages/write/src/check.ts
@@ -8,9 +8,14 @@ export type WriteIssue<F extends Record<string, FieldDef>> = {
   message: string
 }
 
+export type WriteCandidate<F extends Record<string, FieldDef>> = Partial<
+  Record<keyof F & string, unknown>
+> &
+  Record<string, unknown>
+
 export type WriteCheckResult<F extends Record<string, FieldDef>> = {
   ok: boolean
-  candidate: Record<string, unknown>
+  candidate: WriteCandidate<F>
   availability: AvailabilityMap<F>
   issues: WriteIssue<F>[]
   fouls: Foul<F>[]
@@ -25,7 +30,7 @@ export function checkCreate<
   data: Record<string, unknown>,
   context?: C,
 ): WriteCheckResult<F> {
-  const candidate = { ...ump.init(), ...data }
+  const candidate: WriteCandidate<F> = { ...ump.init(), ...data }
   const availability = ump.check(candidate, context)
   const issues = issuesFromAvailability(availability)
 
@@ -48,7 +53,7 @@ export function checkPatch<
   patch: Record<string, unknown>,
   context?: C,
 ): WriteCheckResult<F> {
-  const candidate = { ...existing, ...patch }
+  const candidate = { ...existing, ...patch } as WriteCandidate<F>
   const availability = ump.check(candidate, context, existing)
   const issues = issuesFromAvailability(availability)
   const fouls = ump.play(
@@ -62,10 +67,7 @@ export function checkPatch<
     availability,
     issues,
     fouls,
-    errors: [
-      ...issues.map((issue) => issue.message),
-      ...fouls.map((foul) => foul.reason),
-    ],
+    errors: issues.map((issue) => issue.message),
   }
 }
 

--- a/packages/write/src/check.ts
+++ b/packages/write/src/check.ts
@@ -1,7 +1,109 @@
-export function checkCreate(): boolean {
-  return true
+import type { AvailabilityMap, FieldDef, Foul, Umpire } from '@umpire/core'
+
+export type WriteIssueKind = 'required' | 'disabled' | 'foul'
+
+export type WriteIssue<F extends Record<string, FieldDef>> = {
+  kind: WriteIssueKind
+  field: keyof F & string
+  message: string
 }
 
-export function checkPatch(): boolean {
-  return true
+export type WriteCheckResult<F extends Record<string, FieldDef>> = {
+  ok: boolean
+  candidate: Record<string, unknown>
+  availability: AvailabilityMap<F>
+  issues: WriteIssue<F>[]
+  fouls: Foul<F>[]
+  errors: string[]
+}
+
+export function checkCreate<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  ump: Umpire<F, C>,
+  data: Record<string, unknown>,
+  context?: C,
+): WriteCheckResult<F> {
+  const candidate = { ...ump.init(), ...data }
+  const availability = ump.check(candidate, context)
+  const issues = issuesFromAvailability(availability)
+
+  return {
+    ok: issues.length === 0,
+    candidate,
+    availability,
+    issues,
+    fouls: [],
+    errors: issues.map((issue) => issue.message),
+  }
+}
+
+export function checkPatch<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  ump: Umpire<F, C>,
+  existing: Record<string, unknown>,
+  patch: Record<string, unknown>,
+  context?: C,
+): WriteCheckResult<F> {
+  const candidate = { ...existing, ...patch }
+  const availability = ump.check(candidate, context, existing)
+  const issues = issuesFromAvailability(availability)
+  const fouls = ump.play(
+    { values: existing, conditions: context },
+    { values: candidate, conditions: context },
+  )
+
+  return {
+    ok: issues.length === 0 && fouls.length === 0,
+    candidate,
+    availability,
+    issues,
+    fouls,
+    errors: [
+      ...issues.map((issue) => issue.message),
+      ...fouls.map((foul) => foul.reason),
+    ],
+  }
+}
+
+function issuesFromAvailability<F extends Record<string, FieldDef>>(
+  availability: AvailabilityMap<F>,
+): WriteIssue<F>[] {
+  const issues: WriteIssue<F>[] = []
+
+  for (const field of Object.keys(availability) as Array<keyof F & string>) {
+    const status = availability[field]
+    const reason = status.reason ?? status.reasons[0]
+
+    if (status.enabled && status.required && !status.satisfied) {
+      issues.push({
+        kind: 'required',
+        field,
+        message: reason ?? `${field} is required`,
+      })
+      continue
+    }
+
+    if (status.satisfied && !status.enabled) {
+      issues.push({
+        kind: 'disabled',
+        field,
+        message: reason ?? `${field} is disabled`,
+      })
+      continue
+    }
+
+    if (status.satisfied && status.enabled && !status.fair) {
+      issues.push({
+        kind: 'foul',
+        field,
+        message: reason ?? `${field} is foul`,
+      })
+    }
+  }
+
+  return issues
 }

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -1,0 +1,1 @@
+export { checkCreate, checkPatch } from './check.js'

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -1,2 +1,7 @@
 export { checkCreate, checkPatch } from './check.js'
-export type { WriteCheckResult, WriteIssue, WriteIssueKind } from './check.js'
+export type {
+  WriteCandidate,
+  WriteCheckResult,
+  WriteIssue,
+  WriteIssueKind,
+} from './check.js'

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -1,1 +1,2 @@
 export { checkCreate, checkPatch } from './check.js'
+export type { WriteCheckResult, WriteIssue, WriteIssueKind } from './check.js'

--- a/packages/write/tsconfig.json
+++ b/packages/write/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "paths": {
+      "@umpire/core": ["../core/src/index.ts"],
+      "@umpire/core/*": ["../core/src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/write/tsconfig.json
+++ b/packages/write/tsconfig.json
@@ -6,9 +6,13 @@
     "composite": true,
     "paths": {
       "@umpire/core": ["../core/src/index.ts"],
-      "@umpire/core/*": ["../core/src/*"]
+      "@umpire/core/*": ["../core/src/*"],
+      "@umpire/write": ["./src/index.ts"],
+      "@umpire/write/*": ["./src/*"],
+      "@umpire/zod": ["../zod/src/index.ts"],
+      "@umpire/zod/*": ["../zod/src/*"]
     }
   },
   "include": ["src"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../zod" }]
 }

--- a/test/preload-workspace-aliases.ts
+++ b/test/preload-workspace-aliases.ts
@@ -15,6 +15,7 @@ if (process.env.BUN_DISABLE_WORKSPACE_MOCKS !== 'true') {
   }))
   mock.module('@umpire/store', () => require('../packages/store/src/index.js'))
   mock.module('@umpire/reads', () => require('../packages/reads/src/index.js'))
+  mock.module('@umpire/write', () => require('../packages/write/src/index.js'))
   mock.module('@umpire/react', () => require('../packages/react/src/index.js'))
   mock.module('@umpire/solid', () => require('../packages/solid/src/index.js'))
   mock.module('@umpire/signals', () =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,6 +1975,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@umpire/write@workspace:packages/write":
+  version: 0.0.0-use.local
+  resolution: "@umpire/write@workspace:packages/write"
+  dependencies:
+    "@umpire/core": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@umpire/zod@workspace:^, @umpire/zod@workspace:packages/zod":
   version: 0.0.0-use.local
   resolution: "@umpire/zod@workspace:packages/zod"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,6 +1980,7 @@ __metadata:
   resolution: "@umpire/write@workspace:packages/write"
   dependencies:
     "@umpire/core": "workspace:^"
+    "@umpire/zod": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
- Introduce a new `@umpire/write` package that evaluates create/patch candidates against existing Umpire availability semantics, giving service-layer write flows a synchronous policy gate without introducing a new validation system.
- Implement `checkCreate` and `checkPatch` plus exported write result/issue types, including candidate construction, issue derivation precedence, transition fouls, and message/error aggregation based on Umpire status output.
- Add comprehensive contract tests, wire the package into workspace aliases and publish workflow, and list it in the root package index.

## Concept and purpose
`@umpire/write` is intentionally a thin policy helper for write paths. It answers:

> Does this create/patch candidate satisfy Umpire availability, requiredness, fairness, and transition policy?

It does **not** parse payloads, validate schema correctness, authorize callers, or guarantee database safety.

## Key decisions captured in this PR
- **No new schema/validation DSL:** package relies only on public `ump.init()`, `ump.check()`, and `ump.play()`.
- **Create candidate construction:** `{ ...ump.init(), ...data }` (defaults first, input overrides).
- **Patch candidate construction:** `{ ...existing, ...patch }` (explicit shallow merge; explicit `undefined` remains assigned).
- **Patch parity with Umpire branch resolution:** `checkPatch` passes `existing` as `prev` to `ump.check(...)`.
- **Issue kinds are intentionally narrow:** `required | disabled | foul`, with one issue per field using precedence `required -> disabled -> foul`.
- **Message resolution contract:** `status.reason ?? status.reasons[0]`, then exact fallbacks (`<field> is required|disabled|foul`).
- **Unknown key handling:** unknown keys are ignored for policy evaluation but preserved on `candidate`.
- **Result semantics:** `ok` means policy passed only; create never emits transition fouls; patch `ok` requires both no issues and no fouls.

## Verification
- `yarn workspace @umpire/write test`
- `yarn workspace @umpire/write typecheck`
- `yarn build`
- `yarn typecheck`
- `yarn test`
