### PR TITLE
🔌 Add @umpire/write to set-latest.sh

### DIFF
--- a/scripts/set-latest.sh
+++ b/scripts/set-latest.sh
@@ -21,7 +21,7 @@ C_DIM="\033[38;5;243m"
 C_BOLD="\033[1m"
 C_RESET="\033[0m"
 
-ALL_PACKAGES=(core dsl json signals react zustand store redux tanstack-store zod reads devtools testing pinia vuex eslint-plugin solid)
+ALL_PACKAGES=(core dsl json signals react zustand store redux tanstack-store zod reads write devtools testing pinia vuex eslint-plugin solid)
 DRY_RUN=false
 MODE=""
 VERSION=""


### PR DESCRIPTION
## Summary
- Adds `write` to `ALL_PACKAGES` in `scripts/set-latest.sh` so it shows up when promoting alpha → latest dist-tag
- `publish.yml` was already wired for `@umpire/write` (output, packages array, and publish step all present from the original PR)

## Notes
- First publish done manually (local npm auth, no `--provenance`)
- Future publishes are fully automated via CI