### PR TITLE
fix: wrap changeset version script in bash -c

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         # lockfile still references the old version constraints.
         with:
           title: '🐪 Version Packages'
-          version: yarn changeset version && yarn install
+          version: bash -c "yarn changeset version && yarn install"
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN != '' && secrets.CHANGESETS_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- `changesets/action@v1` passes the `version` input directly to yarn without a shell, so `&&` was treated as a literal argument
- `changeset` CLI received `version`, `&&`, `yarn`, `install` as separate args — "too many arguments" — and bailed without making any changes
- The action then pushed an empty branch and tried to open a PR, hitting the GitHub "no commits between main and changeset-release/main" error

**Fix:** wrap in `bash -c "..."` so the shell interprets `&&` correctly.

## Test plan

- [ ] Merge this PR
- [ ] Trigger the Release PR workflow dispatch
- [ ] Verify `changeset-release/main` is created with version bump commits and a PR opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)