### PR TITLE
📦 improved oxlint compat for `eslint-plugin`

### DIFF
--- a/docs/src/content/docs/extensions/eslint-plugin.mdx
+++ b/docs/src/content/docs/extensions/eslint-plugin.mdx
@@ -10,8 +10,11 @@ description: Catch umpire schema errors, performance pitfalls, and logical impos
 | | |
 |---|---|
 | ESLint | ≥ 9.0.0 |
+| Oxlint | JS plugins (`jsPlugins`) |
 | Config format | Flat config only (`eslint.config.js`) — legacy `.eslintrc` is not supported |
 | Node | Whatever ESLint 9 requires (≥ 18.18) |
+
+`eslint` is an optional peer dependency — it's only needed when using ESLint directly. Oxlint users don't need it installed.
 
 ## Install
 
@@ -64,6 +67,21 @@ export default [
   },
 ]
 ```
+
+## Oxlint setup
+
+Add the plugin to `jsPlugins`, then enable rules by their full name:
+
+```json
+{
+  "jsPlugins": ["@umpire/eslint-plugin"],
+  "rules": {
+    "@umpire/eslint-plugin/no-self-disable": "error"
+  }
+}
+```
+
+Rule names use the `@umpire/eslint-plugin/` prefix in Oxlint, unlike ESLint's `@umpire/` namespace.
 
 ## Rules
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @umpire/eslint-plugin
 
+## 1.0.1
+
+### Patch Changes
+
+- Mark `eslint` as an optional peer dependency to improve compatibility with Oxlint JS plugin usage.
+
 ## 1.0.0
 
 ### Patch Changes

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,8 +1,8 @@
 # @umpire/eslint-plugin
 
-ESLint rules that catch umpire mistakes at lint time: typo'd field names, inline instance creation, and logical impossibilities like self-disabling fields and circular requires chains.
+Lint rules that catch umpire mistakes at lint time: typo'd field names, inline instance creation, and logical impossibilities like self-disabling fields and circular requires chains.
 
-Requires **ESLint ≥ 9** (flat config only).
+Works with **ESLint ≥ 9** (flat config) and Oxlint JS plugins.
 
 ## Install
 
@@ -22,6 +22,21 @@ export default [
   // ... rest of your config
 ]
 ```
+
+## Oxlint
+
+Add the plugin to `jsPlugins`, then enable rules by full name:
+
+```json
+{
+  "jsPlugins": ["@umpire/eslint-plugin"],
+  "rules": {
+    "@umpire/eslint-plugin/no-self-disable": "error"
+  }
+}
+```
+
+`eslint` is an optional peer dependency and is only needed when using ESLint directly.
 
 ## Rules
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umpire/eslint-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -24,6 +24,11 @@
   ],
   "peerDependencies": {
     "eslint": ">=9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/estree": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1802,6 +1802,9 @@ __metadata:
     eslint: "npm:^10.0.0"
   peerDependencies:
     eslint: ">=9.0.0"
+  peerDependenciesMeta:
+    eslint:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The umpire eslint-plugin already works with oxlint, but requiring `eslint` as a peer dependency makes that... icky. Making it *optional* as we do here totally fixes that!

I considered going whole hog with the [alternative API](https://oxc.rs/docs/guide/usage/linter/writing-js-plugins.html#alternative-api) but the types and testing was a bit funky and the change got too large. This is easy and it works. Can look at the better-performing oxlint runtime wrapper later.

This immediately bumps the plugin with a patch version.