### PR TITLE
🐛 fix: target Effect v4 adapter API

### DIFF
--- a/.changeset/add-effect-adapter.md
+++ b/.changeset/add-effect-adapter.md
@@ -2,9 +2,11 @@
 "@umpire/effect": minor
 ---
 
-Add `@umpire/effect` — Effect Schema adapter and SubscriptionRef store bridge for `@umpire/core`.
+Add `@umpire/effect` — Effect v4 Schema adapter and SubscriptionRef store bridge for `@umpire/core`.
 
-- `createEffectAdapter({ schemas, rejectFoul?, build? })` mirrors `createZodAdapter` using Effect Schema. Per-field `Schema<A, I, never>` instances drive both the per-field validators wired into `umpire()` and a full availability-aware struct schema used by `run()`. `R = never` is required — schemas with context dependencies are not supported in the synchronous evaluation model.
+- Supports the Effect v4 beta/stable line via a prerelease-aware peer dependency range.
+- `decodeEffectSchema(schema, input, options?)` normalizes Effect v4 `Result` values into a stable `{ _tag: "Right" | "Left" }` shape for adapter internals and manual `deriveSchema()` usage.
+- `createEffectAdapter({ schemas, rejectFoul?, build? })` mirrors `createZodAdapter` using Effect Schema. Per-field schemas drive both the per-field validators wired into `umpire()` and a full availability-aware struct schema used by `run()`. Schemas with service/context dependencies are not supported in the synchronous evaluation model.
 - `deriveSchema(availability, schemas, options?)` builds an availability-aware `Schema.Struct` from field-level schemas: disabled fields are excluded, optional fields get `Schema.optional()`, and `rejectFoul: true` injects an always-failing refinement (using the field's `reason`) for foul fields.
-- `effectErrors(parseError)` flattens Effect's `ParseIssue` tree into `{ field, message }[]` via `ParseResult.ArrayFormatter`.
-- `fromSubscriptionRef(ump, ref, options)` bridges an Effect `SubscriptionRef<S>` to the `@umpire/store` contract, running a background fiber over `ref.changes` to track state transitions and compute fouls.
+- `effectErrors(parseError)` flattens Effect schema parse errors or issues into `{ field, message }[]`.
+- `fromSubscriptionRef(ump, ref, options)` bridges an Effect `SubscriptionRef<S>` to the `@umpire/store` contract, running a background fiber over the ref changes stream to track state transitions and compute fouls.

--- a/docs/src/content/docs/adapters/validation/effect.md
+++ b/docs/src/content/docs/adapters/validation/effect.md
@@ -11,7 +11,7 @@ description: Build availability-aware Effect schemas from an Umpire availability
 yarn add @umpire/core @umpire/effect effect
 ```
 
-`effect` is a peer dependency — bring your own version (v3+).
+`effect` is a peer dependency — bring your own Effect v4 beta/stable release.
 
 ## API
 
@@ -26,20 +26,35 @@ Builds a `Schema.Struct` from the availability map:
 
 ```ts
 import { Schema } from 'effect'
-import { deriveSchema } from '@umpire/effect'
+import {
+  decodeEffectSchema,
+  deriveSchema,
+} from '@umpire/effect'
 
 const fieldSchemas = {
-  email:       Schema.String.pipe(Schema.filter((s) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s), { message: () => 'Enter a valid email' })),
-  companyName: Schema.String.pipe(Schema.filter((s) => s.length > 0, { message: () => 'Company name is required' })),
+  email: Schema.String.check(
+    Schema.makeFilter((s) =>
+      /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s)
+        ? undefined
+        : 'Enter a valid email',
+    ),
+  ),
+  companyName: Schema.String.check(
+    Schema.makeFilter((s) =>
+      s.length > 0 ? undefined : 'Company name is required',
+    ),
+  ),
   companySize: Schema.String,
 }
 
 const availability = ump.check(values, conditions)
 const schema = deriveSchema(availability, fieldSchemas)
-const result = Schema.decodeUnknownEither(schema)(values)
+const result = decodeEffectSchema(schema, values)
 ```
 
-Schemas must have `R = never` — schemas with context dependencies are not supported.
+`decodeEffectSchema()` returns a convenient `{ _tag: 'Right' | 'Left' }` result. If you call Effect directly, use Effect v4's native `Schema.decodeUnknownResult()` API.
+
+Schemas must have no service/context dependencies.
 
 #### `rejectFoul` option
 
@@ -49,20 +64,18 @@ Fields where `fair: false` hold values that were once valid but are now contextu
 // Server handler — rejects any submission containing a foul value
 const availability = engine.check(body)
 const schema = deriveSchema(availability, fieldSchemas, { rejectFoul: true })
-const result = Schema.decodeUnknownEither(schema)(body)
+const result = decodeEffectSchema(schema, body)
 ```
 
 When `rejectFoul: true`, a foul field with a present value fails with the field's `reason` as the error message. If the field is optional and absent, it passes — only submissions that *contain* a foul value are rejected.
 
 ### `effectErrors(parseError)`
 
-Normalizes an Effect `ParseError` into `{ field, message }[]` pairs.
+Normalizes an Effect schema parse error or issue into `{ field, message }[]` pairs.
 
 ```ts
-import { Either } from 'effect'
-
-const result = Schema.decodeUnknownEither(schema)(values)
-if (Either.isLeft(result)) {
+const result = decodeEffectSchema(schema, values)
+if (result._tag === 'Left') {
   const pairs = effectErrors(result.left)
   // [{ field: 'email', message: 'Enter a valid email' }, ...]
 }
@@ -102,7 +115,7 @@ const ump = umpire({
 
 // Full derived-schema validation
 const result = validation.run(availability, values)
-if (Either.isLeft(result.result)) {
+if (result.result._tag === 'Left') {
   console.log(result.errors)       // { email: 'Enter a valid email' }
   console.log(result.schemaFields)  // ['email'] — disabled fields excluded
 }
@@ -117,12 +130,12 @@ const validation = createEffectAdapter({
     confirmPassword: Schema.String,
   },
   build: (base) =>
-    base.pipe(
-      Schema.filter(
-        (data) =>
-          (data as Record<string, unknown>).password ===
-          (data as Record<string, unknown>).confirmPassword,
-        { message: () => 'Passwords do not match' },
+    base.check(
+      Schema.makeFilter((data) =>
+        (data as Record<string, unknown>).password ===
+        (data as Record<string, unknown>).confirmPassword
+          ? undefined
+          : 'Passwords do not match',
       ),
     ),
 })
@@ -130,7 +143,7 @@ const validation = createEffectAdapter({
 
 The root-level refinement error surfaces under `result.errors._root`.
 
-If you need every issue or deeper control, use `deriveSchema()` and `Schema.decodeUnknownEither()` directly.
+If you need every issue or deeper control, use `deriveSchema()` with either `decodeEffectSchema()` or Effect v4's native decode API.
 
 ## `fromSubscriptionRef()`
 

--- a/docs/src/content/docs/adapters/validation/effect.md
+++ b/docs/src/content/docs/adapters/validation/effect.md
@@ -76,7 +76,7 @@ Normalizes an Effect schema parse error or issue into `{ field, message }[]` pai
 ```ts
 const result = decodeEffectSchema(schema, values)
 if (result._tag === 'Left') {
-  const pairs = effectErrors(result.left)
+  const pairs = effectErrors(result.error)
   // [{ field: 'email', message: 'Enter a valid email' }, ...]
 }
 ```
@@ -86,7 +86,7 @@ if (result._tag === 'Left') {
 Filters normalized error pairs to only include enabled fields and keeps the first message per field. Returns `Partial<Record<string, string>>`. Root-level errors from cross-field refinements are keyed under `'_root'`.
 
 ```ts
-const errors = deriveErrors(availability, effectErrors(result.left))
+const errors = deriveErrors(availability, effectErrors(result.error))
 // { email: 'Enter a valid email' }
 // companyName omitted if disabled on the current plan
 ```

--- a/packages/effect/AGENTS.md
+++ b/packages/effect/AGENTS.md
@@ -1,6 +1,6 @@
 # @umpire/effect
 
-- Use `deriveSchema(availability, fieldSchemas)` with per-field `Schema.Schema<A, I, never>` values (`R = never` is required — schemas with context dependencies are not supported).
+- Use `deriveSchema(availability, fieldSchemas)` with per-field Effect v4 schemas that have no service/context dependencies.
 - Disabled fields are excluded from the derived schema. Enabled but optional fields get `Schema.optional()`.
 - Normalize parse issues with `effectErrors(parseError)`, then filter them with `deriveErrors(availability, errors)`.
 - `fromSubscriptionRef` bridges an Effect `SubscriptionRef<S>` to the `@umpire/store` contract; it runs a background fiber to track changes and interrupts it on `destroy()`.

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -59,7 +59,7 @@ const schema = deriveSchema(availability, fieldSchemas)
 const result = decodeEffectSchema(schema, values)
 
 if (result._tag === 'Left') {
-  const errors = deriveErrors(availability, effectErrors(result.left))
+  const errors = deriveErrors(availability, effectErrors(result.error))
   // errors.email → 'Enter a valid email' (only if email is enabled)
   // errors.companyName → undefined (disabled on personal plan)
 }

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -10,15 +10,16 @@ Availability-aware Effect Schema validation and SubscriptionRef bridge for [@ump
 npm install @umpire/core @umpire/effect effect
 ```
 
-`effect` is a peer dependency — bring your own version (v3+).
+`effect` is a peer dependency — bring your own Effect v4 beta/stable release.
 
 ## Usage
 
 ```ts
-import { Either, Schema } from 'effect'
+import { Schema } from 'effect'
 import { enabledWhen, umpire } from '@umpire/core'
 import {
   createEffectAdapter,
+  decodeEffectSchema,
   deriveErrors,
   deriveSchema,
   effectErrors,
@@ -37,17 +38,17 @@ const ump = umpire({
   ],
 })
 
-// 2. Define per-field Effect schemas (R = never required)
+// 2. Define per-field Effect schemas with no service/context dependencies
 const fieldSchemas = {
-  email: Schema.String.pipe(
-    Schema.filter((s) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s), {
-      message: () => 'Enter a valid email',
-    }),
+  email: Schema.String.check(
+    Schema.makeFilter((s) =>
+      /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s) ? undefined : 'Enter a valid email',
+    ),
   ),
-  companyName: Schema.String.pipe(
-    Schema.filter((s) => s.length > 0, {
-      message: () => 'Company name is required',
-    }),
+  companyName: Schema.String.check(
+    Schema.makeFilter((s) =>
+      s.length > 0 ? undefined : 'Company name is required',
+    ),
   ),
 }
 
@@ -55,9 +56,9 @@ const fieldSchemas = {
 const availability = ump.check(values, { plan })
 
 const schema = deriveSchema(availability, fieldSchemas)
-const result = Schema.decodeUnknownEither(schema)(values)
+const result = decodeEffectSchema(schema, values)
 
-if (Either.isLeft(result)) {
+if (result._tag === 'Left') {
   const errors = deriveErrors(availability, effectErrors(result.left))
   // errors.email → 'Enter a valid email' (only if email is enabled)
   // errors.companyName → undefined (disabled on personal plan)
@@ -92,7 +93,8 @@ Builds a `Schema.Struct` from the availability map:
 - **Enabled + required** fields use the base schema
 - **Enabled + optional** fields get `Schema.optional()`
 
-Pass per-field schemas with `R = never` — schemas with context dependencies are not supported.
+Pass per-field schemas with no service/context dependencies.
+Use `decodeEffectSchema()` for convenience, or call Effect v4's native `Schema.decodeUnknownResult()` directly.
 
 #### `rejectFoul` option
 
@@ -106,7 +108,7 @@ When `rejectFoul: true`, a foul field with a present value fails with the field'
 
 ### `effectErrors(parseError)`
 
-Normalizes an Effect `ParseError` into `{ field, message }[]` pairs for use with `deriveErrors`.
+Normalizes an Effect schema parse error or issue into `{ field, message }[]` pairs for use with `deriveErrors`.
 
 ### `deriveErrors(availability, errors)`
 
@@ -128,18 +130,18 @@ const validation = createEffectAdapter({
     confirmPassword: Schema.String,
   },
   build: (base) =>
-    base.pipe(
-      Schema.filter(
-        (data) =>
-          (data as Record<string, unknown>).password ===
-          (data as Record<string, unknown>).confirmPassword,
-        { message: () => 'Passwords do not match' },
+    base.check(
+      Schema.makeFilter((data) =>
+        (data as Record<string, unknown>).password ===
+        (data as Record<string, unknown>).confirmPassword
+          ? undefined
+          : 'Passwords do not match',
       ),
     ),
 })
 ```
 
-If you need every issue or deeper control, you can use `deriveSchema()` and `Schema.decodeUnknownEither()` directly.
+If you need every issue or deeper control, you can use `deriveSchema()` with either `decodeEffectSchema()` or Effect v4's native decode API.
 
 ### `fromSubscriptionRef(ump, ref, options)`
 
@@ -183,10 +185,12 @@ import { isEmptyString, umpire } from '@umpire/core'
 
 const validation = createEffectAdapter({
   schemas: {
-    email: Schema.String.pipe(
-      Schema.filter((s) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s), {
-        message: () => 'Enter a valid email',
-      }),
+    email: Schema.String.check(
+      Schema.makeFilter((s) =>
+        /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s)
+          ? undefined
+          : 'Enter a valid email',
+      ),
     ),
   },
 })

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -50,6 +50,7 @@ describe('createEffectAdapter', () => {
 
     expect(ump.check({ count: 'not-a-number' }).count).toMatchObject({
       valid: false,
+      error: expect.any(String),
     })
     expect(ump.check({ count: 42 }).count).toMatchObject({ valid: true })
   })
@@ -163,6 +164,78 @@ describe('createEffectAdapter', () => {
     expect(foulResult.result).toMatchObject({ _tag: 'Left' })
     expect(foulResult.errors).toEqual({
       vehicleType: 'Vehicle type does not match the reserved spot',
+    })
+  })
+
+  test('rejectFoul allows absent optional foul fields', () => {
+    const fields = { spotType: {}, vehicleType: { required: false } }
+
+    const validation = createEffectAdapter({
+      schemas: {
+        spotType: Schema.Literals(['electric', 'standard']),
+        vehicleType: Schema.Literals(['electric', 'gas']),
+      },
+      rejectFoul: true,
+    })
+
+    const ump = umpire({
+      fields,
+      rules: [
+        fairWhen(
+          'vehicleType',
+          (value, values) =>
+            value === values.spotType || values.spotType === 'standard',
+          { reason: 'Vehicle type does not match the reserved spot' },
+        ),
+      ],
+    })
+
+    const availability = ump.check({
+      spotType: 'electric',
+      vehicleType: undefined,
+    })
+    const result = validation.run(availability, {
+      spotType: 'electric',
+      vehicleType: undefined,
+    })
+
+    expect(result.result).toMatchObject({ _tag: 'Right' })
+    expect(result.errors).toEqual({})
+  })
+
+  test('rejectFoul uses the default message when no reason is provided', () => {
+    const validation = createEffectAdapter({
+      schemas: {
+        mode: Schema.Literals(['open', 'locked']),
+        choice: Schema.String,
+      },
+      rejectFoul: true,
+    })
+
+    const availability = {
+      mode: {
+        enabled: true,
+        fair: true,
+        required: false,
+        satisfied: true,
+        valid: true,
+      },
+      choice: {
+        enabled: true,
+        fair: false,
+        required: false,
+        satisfied: true,
+        valid: true,
+      },
+    }
+    const result = validation.run(availability, {
+      mode: 'locked',
+      choice: 'stale',
+    })
+
+    expect(result.result).toMatchObject({ _tag: 'Left' })
+    expect(result.errors).toEqual({
+      choice: 'Value is not valid for the current context',
     })
   })
 

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -10,7 +10,7 @@ const emailSchema = stringMatching(
 function stringMatching(
   predicate: (value: string) => boolean,
   message: string,
-): Schema.Top {
+): Schema.Decoder<unknown, never> {
   return Schema.String.check(
     Schema.makeFilter((value) => (predicate(value) ? undefined : message)),
   )
@@ -161,7 +161,7 @@ describe('createEffectAdapter', () => {
       vehicleType: 'gas',
     })
     expect(foulResult.result).toMatchObject({ _tag: 'Left' })
-    expect(foulResult.errors).toMatchObject({
+    expect(foulResult.errors).toEqual({
       vehicleType: 'Vehicle type does not match the reserved spot',
     })
   })

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -2,11 +2,19 @@ import { enabledWhen, fairWhen, umpire } from '@umpire/core'
 import { Schema } from 'effect'
 import { createEffectAdapter } from '../src/adapter.js'
 
-const emailSchema = Schema.String.pipe(
-  Schema.filter((s) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s), {
-    message: () => 'Enter a valid email',
-  }),
+const emailSchema = stringMatching(
+  (s) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s),
+  'Enter a valid email',
 )
+
+function stringMatching(
+  predicate: (value: string) => boolean,
+  message: string,
+): Schema.Top {
+  return Schema.String.check(
+    Schema.makeFilter((value) => (predicate(value) ? undefined : message)),
+  )
+}
 
 describe('createEffectAdapter', () => {
   test('creates per-field validators that surface the first parse error', () => {
@@ -57,11 +65,7 @@ describe('createEffectAdapter', () => {
     const validation = createEffectAdapter({
       schemas: {
         email: emailSchema,
-        password: Schema.String.pipe(
-          Schema.filter((s) => s.length >= 8, {
-            message: () => 'At least 8 characters',
-          }),
-        ),
+        password: stringMatching((s) => s.length >= 8, 'At least 8 characters'),
         confirmPassword: Schema.String,
         companyName: Schema.String,
       },
@@ -119,8 +123,8 @@ describe('createEffectAdapter', () => {
 
     const validation = createEffectAdapter({
       schemas: {
-        spotType: Schema.Literal('electric', 'standard'),
-        vehicleType: Schema.Literal('electric', 'gas'),
+        spotType: Schema.Literals(['electric', 'standard']),
+        vehicleType: Schema.Literals(['electric', 'gas']),
       },
       rejectFoul: true,
     })
@@ -174,12 +178,12 @@ describe('createEffectAdapter', () => {
         confirmPassword: Schema.String,
       },
       build: (base) =>
-        base.pipe(
-          Schema.filter(
-            (data) =>
-              (data as Record<string, unknown>).password ===
-              (data as Record<string, unknown>).confirmPassword,
-            { message: () => 'Passwords do not match' },
+        base.check(
+          Schema.makeFilter((data) =>
+            (data as Record<string, unknown>).password ===
+            (data as Record<string, unknown>).confirmPassword
+              ? undefined
+              : 'Passwords do not match',
           ),
         ),
     })

--- a/packages/effect/__tests__/effect-schema.test.ts
+++ b/packages/effect/__tests__/effect-schema.test.ts
@@ -1,0 +1,45 @@
+import { formatEffectErrors } from '../src/effect-schema.js'
+
+describe('formatEffectErrors', () => {
+  test('formats a bare primitive issue as a root error', () => {
+    expect(formatEffectErrors('Something went wrong')).toEqual([
+      { field: '', message: 'Something went wrong' },
+    ])
+  })
+
+  test('formats a bare issue object without a parse-error wrapper', () => {
+    expect(
+      formatEffectErrors({
+        _tag: 'Pointer',
+        path: ['email'],
+        issue: 'Enter a valid email',
+      }),
+    ).toEqual([{ field: 'email', message: 'Enter a valid email' }])
+  })
+
+  test('unwraps Filter issues to surface the inner message', () => {
+    expect(
+      formatEffectErrors({
+        _tag: 'Filter',
+        issue: 'Passwords do not match',
+      }),
+    ).toEqual([{ field: '', message: 'Passwords do not match' }])
+  })
+
+  test('handles pointer issues without a path', () => {
+    expect(
+      formatEffectErrors({
+        _tag: 'Pointer',
+        issue: 'Root issue',
+      }),
+    ).toEqual([{ field: '', message: 'Root issue' }])
+  })
+
+  test('strips stringified path suffixes from object issues', () => {
+    expect(
+      formatEffectErrors({
+        toString: () => 'Expected string\n  at ["email"]',
+      }),
+    ).toEqual([{ field: '', message: 'Expected string' }])
+  })
+})

--- a/packages/effect/__tests__/effect-schema.test.ts
+++ b/packages/effect/__tests__/effect-schema.test.ts
@@ -17,6 +17,29 @@ describe('formatEffectErrors', () => {
     ).toEqual([{ field: 'email', message: 'Enter a valid email' }])
   })
 
+  test('flattens composite issues from multiple fields', () => {
+    expect(
+      formatEffectErrors({
+        _tag: 'Composite',
+        issues: [
+          {
+            _tag: 'Pointer',
+            path: ['email'],
+            issue: 'Enter a valid email',
+          },
+          {
+            _tag: 'Pointer',
+            path: ['password'],
+            issue: 'At least 8 characters',
+          },
+        ],
+      }),
+    ).toEqual([
+      { field: 'email', message: 'Enter a valid email' },
+      { field: 'password', message: 'At least 8 characters' },
+    ])
+  })
+
   test('unwraps Filter issues to surface the inner message', () => {
     expect(
       formatEffectErrors({

--- a/packages/effect/__tests__/effect-schema.test.ts
+++ b/packages/effect/__tests__/effect-schema.test.ts
@@ -1,6 +1,56 @@
+import { Schema } from 'effect'
 import { formatEffectErrors } from '../src/effect-schema.js'
 
 describe('formatEffectErrors', () => {
+  test('formats real Effect schema decode failures', () => {
+    const emailSchema = Schema.Struct({
+      email: Schema.String.check(
+        Schema.makeFilter((value) =>
+          /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value)
+            ? undefined
+            : 'Enter a valid email',
+        ),
+      ),
+    })
+
+    const result = Schema.decodeUnknownResult(emailSchema)({
+      email: 'not-an-email',
+    })
+
+    expect(result._tag).toBe('Failure')
+    const errors = formatEffectErrors(result.failure)
+    expect(errors).toEqual([{ field: 'email', message: 'Enter a valid email' }])
+  })
+
+  test('flattens real multi-field composite decode failures', () => {
+    const signupSchema = Schema.Struct({
+      email: Schema.String.check(
+        Schema.makeFilter((value) =>
+          /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value)
+            ? undefined
+            : 'Enter a valid email',
+        ),
+      ),
+      password: Schema.String.check(
+        Schema.makeFilter((value) =>
+          value.length >= 8 ? undefined : 'At least 8 characters',
+        ),
+      ),
+    })
+
+    const result = Schema.decodeUnknownResult(signupSchema)(
+      { email: 'bad', password: 'short' },
+      { errors: 'all' },
+    )
+
+    expect(result._tag).toBe('Failure')
+    const errors = formatEffectErrors(result.failure)
+    expect(errors).toEqual([
+      { field: 'email', message: 'Enter a valid email' },
+      { field: 'password', message: 'At least 8 characters' },
+    ])
+  })
+
   test('formats a bare primitive issue as a root error', () => {
     expect(formatEffectErrors('Something went wrong')).toEqual([
       { field: '', message: 'Something went wrong' },

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -29,7 +29,7 @@
     "@umpire/store": "workspace:*"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0-beta.0 <5.0.0"
+    "effect": ">=4.0.0-beta.58 <5.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -29,7 +29,7 @@
     "@umpire/store": "workspace:*"
   },
   "peerDependencies": {
-    "effect": "^3.0.0"
+    "effect": ">=4.0.0-beta.0 <5.0.0"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "effect": "^3.21.2"
+    "effect": "4.0.0-beta.59"
   }
 }

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -1,4 +1,3 @@
-import { Either, ParseResult, Schema } from 'effect'
 import type {
   AvailabilityMap,
   FieldDef,
@@ -12,6 +11,11 @@ import {
   type NormalizedFieldError,
 } from './derive-errors.js'
 import {
+  decodeEffectSchema,
+  isDecodeSuccess,
+  type EffectDecodeResult,
+} from './effect-compat.js'
+import {
   deriveSchema,
   type AnyEffectSchema,
   type DeriveSchemaOptions,
@@ -20,13 +24,13 @@ import {
 
 export type CreateEffectAdapterOptions<F extends Record<string, FieldDef>> = {
   schemas: FieldSchemas<F>
-  build?(schema: Schema.Schema.AnyNoContext): Schema.Schema.AnyNoContext
+  build?(schema: AnyEffectSchema): AnyEffectSchema
 } & DeriveSchemaOptions
 
 export type EffectAdapterRunResult<F extends Record<string, FieldDef>> = {
   errors: DerivedErrorMap<F>
   normalizedErrors: NormalizedFieldError[]
-  result: Either.Either<Record<string, unknown>, ParseResult.ParseError>
+  result: EffectDecodeResult<Record<string, unknown>>
   schemaFields: Array<keyof F & string>
 }
 
@@ -49,13 +53,11 @@ export function createEffectAdapter<F extends Record<string, FieldDef>>(
   >) {
     if (!schema) continue
 
-    const decode = Schema.decodeUnknownEither(schema)
-
     validators[field] = (value: unknown) => {
-      const result = decode(value)
-      if (Either.isRight(result)) return { valid: true }
+      const result = decodeEffectSchema(schema, value)
+      if (isDecodeSuccess(result)) return { valid: true }
 
-      const errors = effectErrors(result.left)
+      const errors = effectErrors(result.error)
       const message = errors[0]?.message
       return message !== undefined
         ? { valid: false, error: message }
@@ -68,14 +70,13 @@ export function createEffectAdapter<F extends Record<string, FieldDef>>(
     run(availability, values) {
       const baseSchema = deriveSchema(availability, schemas, { rejectFoul })
       const schema = build ? build(baseSchema) : baseSchema
-      const decode = Schema.decodeUnknownEither(schema)
-      const result = decode(values, { errors: 'all' }) as Either.Either<
-        Record<string, unknown>,
-        ParseResult.ParseError
-      >
-      const normalizedErrors = Either.isLeft(result)
-        ? effectErrors(result.left)
-        : []
+      const result = decodeEffectSchema<Record<string, unknown>>(
+        schema,
+        values,
+        { errors: 'all' },
+      )
+      const normalizedErrors =
+        result._tag === 'Left' ? effectErrors(result.error) : []
 
       const schemaFields = (
         Object.keys(availability) as Array<keyof F & string>

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -12,9 +12,10 @@ import {
 } from './derive-errors.js'
 import {
   decodeEffectSchema,
+  isDecodeFailure,
   isDecodeSuccess,
   type EffectDecodeResult,
-} from './effect-compat.js'
+} from './effect-schema.js'
 import {
   deriveSchema,
   type AnyEffectSchema,
@@ -75,8 +76,9 @@ export function createEffectAdapter<F extends Record<string, FieldDef>>(
         values,
         { errors: 'all' },
       )
-      const normalizedErrors =
-        result._tag === 'Left' ? effectErrors(result.error) : []
+      const normalizedErrors = isDecodeFailure(result)
+        ? effectErrors(result.error)
+        : []
 
       const schemaFields = (
         Object.keys(availability) as Array<keyof F & string>

--- a/packages/effect/src/derive-errors.ts
+++ b/packages/effect/src/derive-errors.ts
@@ -1,5 +1,5 @@
-import { ParseResult } from 'effect'
 import type { AvailabilityMap, FieldDef } from '@umpire/core'
+import { formatEffectErrors } from './effect-compat.js'
 
 export type NormalizedFieldError = {
   field: string
@@ -33,12 +33,6 @@ export function deriveErrors<F extends Record<string, FieldDef>>(
   return result
 }
 
-export function effectErrors(
-  parseError: ParseResult.ParseError,
-): NormalizedFieldError[] {
-  const formatted = ParseResult.ArrayFormatter.formatErrorSync(parseError)
-  return formatted.map((item) => ({
-    field: String(item.path[0] ?? ''),
-    message: item.message,
-  }))
+export function effectErrors(parseError: unknown): NormalizedFieldError[] {
+  return formatEffectErrors(parseError)
 }

--- a/packages/effect/src/derive-errors.ts
+++ b/packages/effect/src/derive-errors.ts
@@ -1,10 +1,7 @@
 import type { AvailabilityMap, FieldDef } from '@umpire/core'
-import { formatEffectErrors } from './effect-compat.js'
+import type { NormalizedEffectError } from './effect-schema.js'
 
-export type NormalizedFieldError = {
-  field: string
-  message: string
-}
+export type NormalizedFieldError = NormalizedEffectError
 
 export const ROOT_ERROR_FIELD = '_root'
 
@@ -33,6 +30,4 @@ export function deriveErrors<F extends Record<string, FieldDef>>(
   return result
 }
 
-export function effectErrors(parseError: unknown): NormalizedFieldError[] {
-  return formatEffectErrors(parseError)
-}
+export { formatEffectErrors as effectErrors } from './effect-schema.js'

--- a/packages/effect/src/derive-schema.ts
+++ b/packages/effect/src/derive-schema.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'effect'
 import type { AvailabilityMap, FieldDef } from '@umpire/core'
 
-export type AnyEffectSchema = Schema.Schema<unknown, unknown, never>
+export type AnyEffectSchema = Schema.Top
 
 export type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
   Record<keyof F & string, AnyEffectSchema>
@@ -20,15 +20,13 @@ export type DeriveSchemaOptions = {
   rejectFoul?: boolean
 }
 
-// Schema.optional() returns a PropertySignature, not a Schema — both are valid
-// as struct field entries.
-type ShapeEntry = Schema.Schema.All | Schema.PropertySignature.All
+type ShapeEntry = Schema.Top
 
 export function deriveSchema<F extends Record<string, FieldDef>>(
   availability: AvailabilityMap<F>,
   schemas: FieldSchemas<F>,
   options?: DeriveSchemaOptions,
-): Schema.Schema.AnyNoContext {
+): AnyEffectSchema {
   const rejectFoul = options?.rejectFoul ?? false
   const shape: Record<string, ShapeEntry> = {}
 
@@ -43,9 +41,7 @@ export function deriveSchema<F extends Record<string, FieldDef>>(
     if (rejectFoul && !status.fair) {
       const message =
         status.reason ?? 'Value is not valid for the current context'
-      const rejected = base.pipe(
-        Schema.filter(() => false, { message: () => message }),
-      )
+      const rejected = base.check(Schema.makeFilter(() => message))
       shape[field] = status.required ? rejected : Schema.optional(rejected)
       continue
     }
@@ -53,6 +49,5 @@ export function deriveSchema<F extends Record<string, FieldDef>>(
     shape[field] = status.required ? base : Schema.optional(base)
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return Schema.Struct(shape as any) as unknown as Schema.Schema.AnyNoContext
+  return Schema.Struct(shape as Schema.Struct.Fields) as AnyEffectSchema
 }

--- a/packages/effect/src/derive-schema.ts
+++ b/packages/effect/src/derive-schema.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'effect'
 import type { AvailabilityMap, FieldDef } from '@umpire/core'
 
-export type AnyEffectSchema = Schema.Top
+export type AnyEffectSchema = Schema.Decoder<unknown, never>
 
 export type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
   Record<keyof F & string, AnyEffectSchema>
@@ -20,6 +20,8 @@ export type DeriveSchemaOptions = {
   rejectFoul?: boolean
 }
 
+// Effect v4 optional property signatures are also schemas, so Schema.Top covers
+// both required fields and Schema.optional(...) entries in a struct shape.
 type ShapeEntry = Schema.Top
 
 export function deriveSchema<F extends Record<string, FieldDef>>(
@@ -49,5 +51,7 @@ export function deriveSchema<F extends Record<string, FieldDef>>(
     shape[field] = status.required ? base : Schema.optional(base)
   }
 
-  return Schema.Struct(shape as Schema.Struct.Fields) as AnyEffectSchema
+  return Schema.Struct(
+    shape as Schema.Struct.Fields,
+  ) as unknown as AnyEffectSchema
 }

--- a/packages/effect/src/effect-compat.ts
+++ b/packages/effect/src/effect-compat.ts
@@ -1,0 +1,125 @@
+import { Result, Schema } from 'effect'
+import type { SchemaIssue } from 'effect'
+
+export type EffectParseOptions = {
+  readonly errors?: 'first' | 'all'
+} & Record<string, unknown>
+
+export type EffectDecodeResult<A> =
+  | {
+      readonly _tag: 'Right'
+      readonly ok: true
+      readonly right: A
+      readonly value: A
+      readonly source: unknown
+    }
+  | {
+      readonly _tag: 'Left'
+      readonly ok: false
+      readonly left: unknown
+      readonly error: unknown
+      readonly source: unknown
+    }
+
+type Decoder = (input: unknown, options?: EffectParseOptions) => unknown
+
+type EffectSchemaApi = {
+  readonly decodeUnknownResult?: (
+    schema: unknown,
+    options?: EffectParseOptions,
+  ) => Decoder
+}
+
+const schemaApi = Schema as EffectSchemaApi
+
+export function decodeEffectSchema<A = unknown>(
+  schema: unknown,
+  input: unknown,
+  options?: EffectParseOptions,
+): EffectDecodeResult<A> {
+  if (schemaApi.decodeUnknownResult) {
+    return normalizeDecodeResult<A>(
+      schemaApi.decodeUnknownResult(schema)(input, options),
+    )
+  }
+
+  throw new Error(
+    '@umpire/effect requires Effect Schema decodeUnknownResult from Effect v4.',
+  )
+}
+
+export function isDecodeFailure<A>(
+  result: EffectDecodeResult<A>,
+): result is Extract<EffectDecodeResult<A>, { readonly _tag: 'Left' }> {
+  return result._tag === 'Left'
+}
+
+export function isDecodeSuccess<A>(
+  result: EffectDecodeResult<A>,
+): result is Extract<EffectDecodeResult<A>, { readonly _tag: 'Right' }> {
+  return result._tag === 'Right'
+}
+
+function normalizeDecodeResult<A>(source: unknown): EffectDecodeResult<A> {
+  const result = source as Result.Result<A, unknown>
+
+  if (Result.isSuccess(result)) {
+    const value = result.success as A
+    return { _tag: 'Right', ok: true, right: value, value, source }
+  }
+
+  if (Result.isFailure(result)) {
+    const error = result.failure
+    return { _tag: 'Left', ok: false, left: error, error, source }
+  }
+
+  return { _tag: 'Left', ok: false, left: source, error: source, source }
+}
+
+export function formatEffectErrors(
+  parseError: unknown,
+): Array<{ field: string; message: string }> {
+  const issue =
+    isRecord(parseError) && 'issue' in parseError
+      ? parseError.issue
+      : parseError
+
+  return formatV4Issue(issue)
+}
+
+function formatV4Issue(
+  issue: unknown | SchemaIssue.Issue,
+  path: ReadonlyArray<PropertyKey> = [],
+): Array<{ field: string; message: string }> {
+  if (!isRecord(issue)) {
+    return [{ field: String(path[0] ?? ''), message: String(issue) }]
+  }
+
+  if (issue._tag === 'Pointer') {
+    const pointerPath = Array.isArray(issue.path) ? issue.path : []
+    return formatV4Issue(issue.issue, [...path, ...pointerPath])
+  }
+
+  if (issue._tag === 'Composite' && Array.isArray(issue.issues)) {
+    return issue.issues.flatMap((child) => formatV4Issue(child, path))
+  }
+
+  if (issue._tag === 'Filter' && 'issue' in issue) {
+    return formatV4Issue(issue.issue, path)
+  }
+
+  return [
+    {
+      field: String(path[0] ?? ''),
+      message: stripPathSuffix(String(issue)),
+    },
+  ]
+}
+
+function stripPathSuffix(message: string): string {
+  return message.replace(/\n  at \[[\s\S]*$/, '')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/packages/effect/src/effect-schema.ts
+++ b/packages/effect/src/effect-schema.ts
@@ -1,50 +1,30 @@
 import { Result, Schema } from 'effect'
-import type { SchemaIssue } from 'effect'
+import type { SchemaAST, SchemaIssue } from 'effect'
 
-export type EffectParseOptions = {
-  readonly errors?: 'first' | 'all'
-} & Record<string, unknown>
+export type EffectParseOptions = SchemaAST.ParseOptions
+
+export type NormalizedEffectError = {
+  field: string
+  message: string
+}
 
 export type EffectDecodeResult<A> =
   | {
       readonly _tag: 'Right'
-      readonly ok: true
-      readonly right: A
       readonly value: A
-      readonly source: unknown
     }
   | {
       readonly _tag: 'Left'
-      readonly ok: false
-      readonly left: unknown
       readonly error: unknown
-      readonly source: unknown
     }
 
-type Decoder = (input: unknown, options?: EffectParseOptions) => unknown
-
-type EffectSchemaApi = {
-  readonly decodeUnknownResult?: (
-    schema: unknown,
-    options?: EffectParseOptions,
-  ) => Decoder
-}
-
-const schemaApi = Schema as EffectSchemaApi
-
 export function decodeEffectSchema<A = unknown>(
-  schema: unknown,
+  schema: Schema.Decoder<unknown, never>,
   input: unknown,
   options?: EffectParseOptions,
 ): EffectDecodeResult<A> {
-  if (schemaApi.decodeUnknownResult) {
-    return normalizeDecodeResult<A>(
-      schemaApi.decodeUnknownResult(schema)(input, options),
-    )
-  }
-
-  throw new Error(
-    '@umpire/effect requires Effect Schema decodeUnknownResult from Effect v4.',
+  return normalizeDecodeResult<A>(
+    Schema.decodeUnknownResult(schema)(input, options),
   )
 }
 
@@ -64,23 +44,23 @@ function normalizeDecodeResult<A>(source: unknown): EffectDecodeResult<A> {
   const result = source as Result.Result<A, unknown>
 
   if (Result.isSuccess(result)) {
-    const value = result.success as A
-    return { _tag: 'Right', ok: true, right: value, value, source }
+    return { _tag: 'Right', value: result.success as A }
   }
 
   if (Result.isFailure(result)) {
-    const error = result.failure
-    return { _tag: 'Left', ok: false, left: error, error, source }
+    return { _tag: 'Left', error: result.failure }
   }
 
-  return { _tag: 'Left', ok: false, left: source, error: source, source }
+  throw new Error(
+    '@umpire/effect expected Schema.decodeUnknownResult() to return an Effect Result.',
+  )
 }
 
 export function formatEffectErrors(
   parseError: unknown,
-): Array<{ field: string; message: string }> {
+): NormalizedEffectError[] {
   const issue =
-    isRecord(parseError) && 'issue' in parseError
+    isRecord(parseError) && 'issue' in parseError && !('_tag' in parseError)
       ? parseError.issue
       : parseError
 

--- a/packages/effect/src/from-subscription-ref.ts
+++ b/packages/effect/src/from-subscription-ref.ts
@@ -17,11 +17,11 @@ export function fromSubscriptionRef<
   const subscribe = (listener: (next: S, prev: S) => void): (() => void) => {
     const tracker = trackPreviousState(getState())
 
-    // ref.changes emits the current value immediately, then all subsequent
-    // changes. Drop the first emission so the listener only fires on updates,
-    // matching the contract that fromStore expects.
+    // Effect's changes stream emits the current value immediately, then all
+    // subsequent changes. Drop the first emission so the listener only fires on
+    // updates, matching the contract that fromStore expects.
     const fiber = Effect.runFork(
-      Stream.runForEach(Stream.drop(ref.changes, 1), (next) =>
+      Stream.runForEach(Stream.drop(SubscriptionRef.changes(ref), 1), (next) =>
         Effect.sync(() => {
           const prev = tracker.next(next)
           listener(next, prev)

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -6,6 +6,12 @@ export type {
 } from './derive-schema.js'
 export { deriveErrors, effectErrors } from './derive-errors.js'
 export type { DerivedErrorMap, NormalizedFieldError } from './derive-errors.js'
+export {
+  decodeEffectSchema,
+  isDecodeFailure,
+  isDecodeSuccess,
+} from './effect-compat.js'
+export type { EffectDecodeResult, EffectParseOptions } from './effect-compat.js'
 export { createEffectAdapter } from './adapter.js'
 export type {
   CreateEffectAdapterOptions,

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -10,8 +10,8 @@ export {
   decodeEffectSchema,
   isDecodeFailure,
   isDecodeSuccess,
-} from './effect-compat.js'
-export type { EffectDecodeResult, EffectParseOptions } from './effect-compat.js'
+} from './effect-schema.js'
+export type { EffectDecodeResult, EffectParseOptions } from './effect-schema.js'
 export { createEffectAdapter } from './adapter.js'
 export type {
   CreateEffectAdapterOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,7 +1853,7 @@ __metadata:
     "@umpire/store": "workspace:*"
     effect: "npm:4.0.0-beta.59"
   peerDependencies:
-    effect: ^3.0.0 || >=4.0.0-beta.0 <5.0.0
+    effect: ">=4.0.0-beta.0 <5.0.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,7 +1853,7 @@ __metadata:
     "@umpire/store": "workspace:*"
     effect: "npm:4.0.0-beta.59"
   peerDependencies:
-    effect: ">=4.0.0-beta.0 <5.0.0"
+    effect: ">=4.0.0-beta.58 <5.0.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,6 +1017,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/fs-minipass@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@isaacs/fs-minipass@npm:4.0.1"
+  dependencies:
+    minipass: "npm:^7.0.4"
+  checksum: 10c0/c25b6dc1598790d5b55c0947a9b7d111cfa92594db5296c3b907e2f533c033666f692a3939eadac17b1c7c40d362d0b0635dc874cbfe3e70db7c2b07cc97a5d2
+  languageName: node
+  linkType: hard
+
 "@istanbuljs/schema@npm:^0.1.3":
   version: 0.1.3
   resolution: "@istanbuljs/schema@npm:0.1.3"
@@ -1091,6 +1100,48 @@ __metadata:
     globby: "npm:^11.0.0"
     read-yaml-file: "npm:^1.1.0"
   checksum: 10c0/f05907d1174ae28861eaa06d0efdc144f773d9a4b8b65e1e7cdc01eb93361d335351b4a336e05c6aac02661be39e8809a3f7ad28bc67b6b338071434ab442130
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-darwin-x64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-darwin-x64@npm:3.0.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-linux-arm64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-linux-arm64@npm:3.0.3"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-linux-arm@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-linux-arm@npm:3.0.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-linux-x64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-linux-x64@npm:3.0.3"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-win32-x64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-win32-x64@npm:3.0.3"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1306,7 +1357,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0":
+"@standard-schema/spec@npm:^1.0.0, @standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
@@ -1800,9 +1851,9 @@ __metadata:
   dependencies:
     "@umpire/core": "workspace:*"
     "@umpire/store": "workspace:*"
-    effect: "npm:^3.21.2"
+    effect: "npm:4.0.0-beta.59"
   peerDependencies:
-    effect: ^3.0.0
+    effect: ^3.0.0 || >=4.0.0-beta.0 <5.0.0
   languageName: unknown
   linkType: soft
 
@@ -2161,6 +2212,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abbrev@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "abbrev@npm:4.0.0"
+  checksum: 10c0/b4cc16935235e80702fc90192e349e32f8ef0ed151ef506aa78c81a7c455ec18375c4125414b99f84b2e055199d66383e787675f0bcd87da7a4dbd59f9eac1d5
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -2490,6 +2548,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chownr@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chownr@npm:3.0.0"
+  checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
+  languageName: node
+  linkType: hard
+
 "cli-width@npm:^4.1.0":
   version: 4.1.0
   resolution: "cli-width@npm:4.1.0"
@@ -2652,6 +2717,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-libc@npm:^2.0.1":
+  version: 2.1.2
+  resolution: "detect-libc@npm:2.1.2"
+  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
+  languageName: node
+  linkType: hard
+
 "diff-match-patch@npm:1.0.5":
   version: 1.0.5
   resolution: "diff-match-patch@npm:1.0.5"
@@ -2698,13 +2770,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"effect@npm:^3.21.2":
-  version: 3.21.2
-  resolution: "effect@npm:3.21.2"
+"effect@npm:4.0.0-beta.59":
+  version: 4.0.0-beta.59
+  resolution: "effect@npm:4.0.0-beta.59"
   dependencies:
-    "@standard-schema/spec": "npm:^1.0.0"
-    fast-check: "npm:^3.23.1"
-  checksum: 10c0/c6ebf877b11b68a4bced8c89b03a1412a0e55d8b7ab275870dd4845bbc6d697a30065e72e7a370f43e9705fe857b4b89315fea60cdcc061fab85af7f772a0763
+    "@standard-schema/spec": "npm:^1.1.0"
+    fast-check: "npm:^4.6.0"
+    find-my-way-ts: "npm:^0.1.6"
+    ini: "npm:^6.0.0"
+    kubernetes-types: "npm:^1.30.0"
+    msgpackr: "npm:^1.11.9"
+    multipasta: "npm:^0.2.7"
+    toml: "npm:^4.1.1"
+    uuid: "npm:^13.0.0"
+    yaml: "npm:^2.8.3"
+  checksum: 10c0/3879f4d5f7280bcb0cb87467f30b8a70874dd1fd12c161bc9d690767badd21104d8b940d9997165e9eede4f4c75bb5a86c728d21e61d3a99f20d9722b71462a4
   languageName: node
   linkType: hard
 
@@ -2743,6 +2823,13 @@ __metadata:
   version: 7.0.1
   resolution: "entities@npm:7.0.1"
   checksum: 10c0/b4fb9937bb47ecb00aaaceb9db9cdd1cc0b0fb649c0e843d05cf5dbbd2e9d2df8f98721d8b1b286445689c72af7b54a7242fc2d63ef7c9739037a8c73363e7ca
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "env-paths@npm:2.2.1"
+  checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
   languageName: node
   linkType: hard
 
@@ -2971,6 +3058,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exponential-backoff@npm:^3.1.1":
+  version: 3.1.3
+  resolution: "exponential-backoff@npm:3.1.3"
+  checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
+  languageName: node
+  linkType: hard
+
 "extendable-error@npm:^0.1.5":
   version: 0.1.7
   resolution: "extendable-error@npm:0.1.7"
@@ -2978,12 +3072,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-check@npm:^3.23.1":
-  version: 3.23.2
-  resolution: "fast-check@npm:3.23.2"
+"fast-check@npm:^4.6.0":
+  version: 4.7.0
+  resolution: "fast-check@npm:4.7.0"
   dependencies:
-    pure-rand: "npm:^6.1.0"
-  checksum: 10c0/16fcff3c80321ee765e23c3aebd0f6427f175c9c6c1753104ec658970162365dc2d56bda046d815e8f2e90634c07ba7d6f0bcfd327fbd576d98c56a18a9765ed
+    pure-rand: "npm:^8.0.0"
+  checksum: 10c0/7edce2b82d11d5325e9e79a2377e1f6e7200d27219edda2e3449d827e994c34461132fc149c90e41b78fc8e6ef4aae77d45350ac7bb1bc4a81110401d0a49fbc
   languageName: node
   linkType: hard
 
@@ -3098,6 +3192,13 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"find-my-way-ts@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "find-my-way-ts@npm:0.1.6"
+  checksum: 10c0/16ad4b15275b56ee0ec361d0c61afbdff4c75bd0ac04112f6910f188cb1058096ba63529c2363914da6bb60266aa4def1025af04af26368ff87eb0df52f2862f
   languageName: node
   linkType: hard
 
@@ -3286,7 +3387,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.5, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0":
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.5, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -3449,6 +3550,13 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
+"ini@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "ini@npm:6.0.0"
+  checksum: 10c0/9a7f55f306e2b25b41ae67c8b526e8f4673f057b70852b9025816ef4f15f07bf1ba35ed68ea4471ff7b31718f7ef1bc50d709f8d03cb012e10a3135eb99c7206
   languageName: node
   linkType: hard
 
@@ -3684,6 +3792,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isexe@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "isexe@npm:4.0.0"
+  checksum: 10c0/5884815115bceac452877659a9c7726382531592f43dc29e5d48b7c4100661aed54018cb90bd36cb2eaeba521092570769167acbb95c18d39afdccbcca06c5ce
+  languageName: node
+  linkType: hard
+
 "istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0, istanbul-lib-coverage@npm:^3.2.2":
   version: 3.2.2
   resolution: "istanbul-lib-coverage@npm:3.2.2"
@@ -3836,6 +3951,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kubernetes-types@npm:^1.30.0":
+  version: 1.30.0
+  resolution: "kubernetes-types@npm:1.30.0"
+  checksum: 10c0/de3641e4f50cfc123c4102a73c12932e1db8e51783c7cae4ea8ad3561bd56fab0f1c2346801f84a4c36aae8cea0b25d21e9514cc0fcecd4d64b1314043263076
+  languageName: node
+  linkType: hard
+
 "levn@npm:^0.4.1":
   version: 0.4.1
   resolution: "levn@npm:0.4.1"
@@ -3954,6 +4076,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^7.0.4, minipass@npm:^7.1.2":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 10c0/539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
+  languageName: node
+  linkType: hard
+
+"minizlib@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "minizlib@npm:3.1.0"
+  dependencies:
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
+  languageName: node
+  linkType: hard
+
 "mitt@npm:^3.0.1":
   version: 3.0.1
   resolution: "mitt@npm:3.0.1"
@@ -3972,6 +4110,56 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"msgpackr-extract@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "msgpackr-extract@npm:3.0.3"
+  dependencies:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": "npm:3.0.3"
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": "npm:3.0.3"
+    "@msgpackr-extract/msgpackr-extract-linux-arm": "npm:3.0.3"
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": "npm:3.0.3"
+    "@msgpackr-extract/msgpackr-extract-linux-x64": "npm:3.0.3"
+    "@msgpackr-extract/msgpackr-extract-win32-x64": "npm:3.0.3"
+    node-gyp: "npm:latest"
+    node-gyp-build-optional-packages: "npm:5.2.2"
+  dependenciesMeta:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-darwin-x64":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-linux-arm":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-linux-arm64":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-linux-x64":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-win32-x64":
+      optional: true
+  bin:
+    download-msgpackr-prebuilds: bin/download-prebuilds.js
+  checksum: 10c0/e504fd8bf86a29d7527c83776530ee6dc92dcb0273bb3679fd4a85173efead7f0ee32fb82c8410a13c33ef32828c45f81118ffc0fbed5d6842e72299894623b4
+  languageName: node
+  linkType: hard
+
+"msgpackr@npm:^1.11.9":
+  version: 1.11.10
+  resolution: "msgpackr@npm:1.11.10"
+  dependencies:
+    msgpackr-extract: "npm:^3.0.2"
+  dependenciesMeta:
+    msgpackr-extract:
+      optional: true
+  checksum: 10c0/fa5b8b90661cc66127d4550bc3757d0e72fe3217a47f952acd0df647afb4593ffde0bbdb1c9f5a13b9df15d5a170a570a59728dd7ede9b0d711e20e4f970fa82
+  languageName: node
+  linkType: hard
+
+"multipasta@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "multipasta@npm:0.2.7"
+  checksum: 10c0/15917ac88aeefa5b8afac44b90d1e9d0d0ec7148b51e0766f07a69a220ecebcb6404539a856c45aa85a3d7fe517bc58febe81437146705f17ecd2961dc0b9fa5
   languageName: node
   linkType: hard
 
@@ -4030,10 +4218,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-gyp-build-optional-packages@npm:5.2.2":
+  version: 5.2.2
+  resolution: "node-gyp-build-optional-packages@npm:5.2.2"
+  dependencies:
+    detect-libc: "npm:^2.0.1"
+  bin:
+    node-gyp-build-optional-packages: bin.js
+    node-gyp-build-optional-packages-optional: optional.js
+    node-gyp-build-optional-packages-test: build-test.js
+  checksum: 10c0/c81128c6f91873381be178c5eddcbdf66a148a6a89a427ce2bcd457593ce69baf2a8662b6d22cac092d24aa9c43c230dec4e69b3a0da604503f4777cd77e282b
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:latest":
+  version: 12.3.0
+  resolution: "node-gyp@npm:12.3.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    graceful-fs: "npm:^4.2.6"
+    nopt: "npm:^9.0.0"
+    proc-log: "npm:^6.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^7.5.4"
+    tinyglobby: "npm:^0.2.12"
+    undici: "npm:^6.25.0"
+    which: "npm:^6.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 10c0/9d9032b405cbe42f72a105259d9eb679376470c102df4a2dbaa51e07d59bf741dcffb85897087ea9d8318b9cabb824a8978af51508ae142f0239ae1e6a3c2329
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.36":
   version: 2.0.37
   resolution: "node-releases@npm:2.0.37"
   checksum: 10c0/306df89190b3225d0cb001260de52f0befd225a782ec85311ce97b0aa3b2e22f5e4e4c00395c6dc9bc9ef440c64723f6205fe1e27d32b8dd1d140891fbadf901
+  languageName: node
+  linkType: hard
+
+"nopt@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "nopt@npm:9.0.0"
+  dependencies:
+    abbrev: "npm:^4.0.0"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10c0/1822eb6f9b020ef6f7a7516d7b64a8036e09666ea55ac40416c36e4b2b343122c3cff0e2f085675f53de1d2db99a2a89a60ccea1d120bcd6a5347bf6ceb4a7fd
   languageName: node
   linkType: hard
 
@@ -4343,6 +4575,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proc-log@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "proc-log@npm:6.1.0"
+  checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
+  languageName: node
+  linkType: hard
+
 "progress@npm:~2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
@@ -4357,10 +4596,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pure-rand@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "pure-rand@npm:6.1.0"
-  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
+"pure-rand@npm:^8.0.0":
+  version: 8.4.0
+  resolution: "pure-rand@npm:8.4.0"
+  checksum: 10c0/6414bbc1c6f45fb774173431c7205e79783b77cfae0e2145e741b6999363554dbd2f4210d2a5bc08683e0b2f6823198c9308766b1d0911e1dccd7beb8842f860
   languageName: node
   linkType: hard
 
@@ -4646,7 +4885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.3, semver@npm:^7.7.4, semver@npm:~7.7.0":
+"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.3, semver@npm:^7.7.4, semver@npm:~7.7.0":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -4882,6 +5121,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar@npm:^7.5.4":
+  version: 7.5.13
+  resolution: "tar@npm:7.5.13"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  languageName: node
+  linkType: hard
+
 "term-size@npm:^2.1.0":
   version: 2.2.1
   resolution: "term-size@npm:2.2.1"
@@ -4896,7 +5148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.15":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
   version: 0.2.16
   resolution: "tinyglobby@npm:0.2.16"
   dependencies:
@@ -4912,6 +5164,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"toml@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "toml@npm:4.1.1"
+  checksum: 10c0/077bc02ac1ce82091ea073f675d7e2a1df487d1b18bbc7e653daba4956d545954b7095e979b8792f0837339b901ee190ad4464342e5e377c36bbdeca8903e079
   languageName: node
   linkType: hard
 
@@ -5142,6 +5401,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^6.25.0":
+  version: 6.25.0
+  resolution: "undici@npm:6.25.0"
+  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+  languageName: node
+  linkType: hard
+
 "unicorn-magic@npm:^0.3.0":
   version: 0.3.0
   resolution: "unicorn-magic@npm:0.3.0"
@@ -5192,6 +5458,15 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^13.0.0":
+  version: 13.0.1
+  resolution: "uuid@npm:13.0.1"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/7bb8ad18b11871b7bd1b9161a60610c2b6ce8f7300d93932f92117a2ab9b40479dd23e81929ac848e8a7c45f78b8ed3333f88694b71c17ff3265e443f8684642
   languageName: node
   linkType: hard
 
@@ -5289,6 +5564,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "which@npm:6.0.1"
+  dependencies:
+    isexe: "npm:^4.0.0"
+  bin:
+    node-which: bin/which.js
+  checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  languageName: node
+  linkType: hard
+
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
@@ -5315,6 +5601,22 @@ __metadata:
   version: 3.1.1
   resolution: "yallist@npm:3.1.1"
   checksum: 10c0/c66a5c46bc89af1625476f7f0f2ec3653c1a1791d2f9407cfb4c2ba812a1e1c9941416d71ba9719876530e3340a99925f697142989371b72d93b9ee628afd8c1
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "yallist@npm:5.0.0"
+  checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- retarget `@umpire/effect` to Effect v4 beta/stable via peer range `>=4.0.0-beta.58 <5.0.0`
- update adapter internals to use Effect v4 Schema APIs, including `Schema.Top`, `.check(Schema.makeFilter(...))`, `Schema.decodeUnknownResult()`, and `SubscriptionRef.changes(ref)`
- add `decodeEffectSchema()` as a small convenience wrapper returning `{ _tag: 'Right' | 'Left' }`
- refresh tests, README, docs, and changeset around the v4-first public API

intended for use in #115 

## Verification

- `yarn workspace @umpire/effect typecheck`
- `yarn workspace @umpire/effect test`
- `yarn workspace @umpire/effect build`
- push hook full typecheck: 29/29 tasks successful
