### PR TITLE
💧 eslint plugin coverage for new drizzle pkg

### DIFF
--- a/.changeset/busy-cycles-own.md
+++ b/.changeset/busy-cycles-own.md
@@ -1,0 +1,5 @@
+---
+'@umpire/eslint-plugin': patch
+---
+
+adds new write/orm rule for key and timestamp overrides

--- a/.changeset/busy-cycles-own.md
+++ b/.changeset/busy-cycles-own.md
@@ -2,4 +2,4 @@
 '@umpire/eslint-plugin': patch
 ---
 
-adds new write/orm rule for key and timestamp overrides
+Extends `no-write-owned-fields` rule to cover Drizzle write helpers (`checkDrizzleCreate`, `checkDrizzlePatch`, `checkDrizzleModelCreate`, `checkDrizzleModelPatch`) with correct candidate argument positions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,26 @@ If you add a new exported subpath that sibling package tests import **before** t
 
 Add a changeset with `yarn changeset` for any user-facing change. `.changeset/config.json` is configured with `updateInternalDependencies: "minor"`, so adapter packages get an automatic patch bump and republish when `core` bumps minor or major. You don't need separate changesets for downstream packages unless the change is in that package itself.
 
+## Database Adapters
+
+New database adapters (`@umpire/drizzle` is the reference implementation) must follow the write-helper argument convention so `@umpire/eslint-plugin`'s `no-write-owned-fields` rule can cover them statically:
+
+| Function shape              | Arguments                                                              |
+| --------------------------- | ---------------------------------------------------------------------- |
+| `check[Adapter]Create`      | `(resource, ump, data, options?)` — candidate at index 2               |
+| `check[Adapter]Patch`       | `(resource, ump, existing, patch, options?)` — candidate at index 3    |
+| `check[Adapter]ModelCreate` | `(modelConfig, ump, data, options?)` — candidate at index 2            |
+| `check[Adapter]ModelPatch`  | `(modelConfig, ump, existing, patch, options?)` — candidate at index 3 |
+
+Do not deviate from this order. Consistency is the point — a future adapter that shifts arguments breaks static analysis and surprises users switching between adapters.
+
+When a new adapter ships its write helpers, add two things alongside it:
+
+1. The new function names to `defaultOptions.writeHelpers` in `packages/eslint-plugin/src/rules/no-write-owned-fields.ts`.
+2. Their argument positions to `getCandidateIndex` in the same file (if they match the table above, the existing returns already cover them — just add the names to `defaultOptions`).
+
+See [`@umpire/drizzle`](./packages/drizzle/) for the reference implementation and [`@umpire/eslint-plugin`](./packages/eslint-plugin/) for the rule.
+
 ## Commits
 
 Commits use an emoji prefix plus a descriptive summary. Browse `git log` for the conventions actually in use, but the common prefixes are:

--- a/docs/package.json
+++ b/docs/package.json
@@ -40,7 +40,12 @@
     "@umpire/reads": "portal:../packages/reads",
     "@umpire/devtools": "portal:../packages/devtools",
     "@umpire/json": "portal:../packages/json",
+    "@umpire/react": "portal:../packages/react",
     "@umpire/store": "portal:../packages/store",
+    "@umpire/signals": "portal:../packages/signals",
+    "@umpire/write": "portal:../packages/write",
+    "@umpire/zod": "portal:../packages/zod",
+    "@umpire/zustand": "portal:../packages/zustand",
     "vite": "^6.4.1"
   },
   "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,7 @@
     "@umpire/reads": "portal:../packages/reads",
     "@umpire/signals": "portal:../packages/signals",
     "@umpire/store": "portal:../packages/store",
+    "@umpire/write": "portal:../packages/write",
     "@umpire/zod": "portal:../packages/zod",
     "@umpire/zustand": "portal:../packages/zustand",
     "astro": "^5.18.1",

--- a/docs/src/content/docs/adapters/database/drizzle.md
+++ b/docs/src/content/docs/adapters/database/drizzle.md
@@ -21,6 +21,8 @@ yarn add @umpire/core @umpire/write @umpire/drizzle drizzle-orm
 `drizzle-orm` is a peer dependency. This RC targets Drizzle `1.0.0-rc.1` and
 newer 1.x releases.
 
+The ESLint plugin ships an opt-in [`no-write-owned-fields`](/extensions/eslint-plugin/#no-write-owned-fields) rule that catches database-owned fields leaking into write candidates at lint time — catching these before they reach `checkDrizzleCreate` or `checkDrizzlePatch` at runtime.
+
 ## Example
 
 ```ts
@@ -450,3 +452,4 @@ constraints for a complete write pipeline.
 - [`@umpire/effect`](/adapters/validation/effect/) — Effect adapter with the same nested validation support
 - [`umpire()`](/api/umpire/) — the engine constructor that consumes the derived fields
 - [Satisfaction](/concepts/satisfaction/) — how Umpire decides whether a value counts as present
+- [ESLint plugin](/extensions/eslint-plugin/) — the `no-write-owned-fields` rule for catching database-owned field leaks at lint time

--- a/docs/src/content/docs/adapters/database/drizzle.md
+++ b/docs/src/content/docs/adapters/database/drizzle.md
@@ -199,6 +199,8 @@ derived fields.
 
 ## Write Checks
 
+`fromDrizzleTable` already removes primary keys and generated columns from the Umpire field map, so they never participate in policy evaluation. At runtime, if one of those columns appears in `req.body` anyway, the Drizzle-aware checks reject it by default — that's what `nonWritableKeys: 'reject'` enforces. For earlier feedback, the ESLint plugin's [`no-write-owned-fields`](/extensions/eslint-plugin/#no-write-owned-fields) rule flags the same problem at lint time, before the code runs.
+
 Use `checkCreate` and `checkPatch` from `@umpire/write` to check availability policy against any Umpire instance:
 
 ```ts

--- a/docs/src/content/docs/extensions/eslint-plugin.mdx
+++ b/docs/src/content/docs/extensions/eslint-plugin.mdx
@@ -3,7 +3,7 @@ title: ESLint Plugin
 description: Catch umpire schema errors, performance pitfalls, and logical impossibilities at lint time.
 ---
 
-`@umpire/eslint-plugin` adds five ESLint rules that catch umpire mistakes before your tests run. Two catch likely bugs (unknown fields, inline instantiation), three catch logical impossibilities that would silently produce fields that can never be enabled.
+`@umpire/eslint-plugin` adds six ESLint rules that catch umpire mistakes before your tests run. Two catch likely bugs (unknown fields, inline instantiation), three catch logical impossibilities that would silently produce fields that can never be enabled, and one catches database-owned fields leaking into write candidates.
 
 ## Compatibility
 
@@ -35,7 +35,7 @@ export default [
 ]
 ```
 
-This enables all five rules with the severities shown in the table below. To customize individual rules, spread the config and override:
+This enables five rules at the severities shown in the table below. The sixth rule (`no-write-owned-fields`) is opt-in because it's Drizzle-specific. To customize individual rules, spread the config and override:
 
 ```js
 import umpire from '@umpire/eslint-plugin'
@@ -89,6 +89,7 @@ Rule names use the `@umpire/eslint-plugin/` prefix in Oxlint, unlike ESLint's `@
 |------|----------|-----------------|
 | `no-unknown-fields` | `warn` | Field names in rules that aren't declared in `fields` |
 | `no-inline-umpire-init` | `warn` | `umpire()` called inside a component or hook body without `useMemo` |
+| `no-write-owned-fields` | opt-in | Database-owned fields (like `id`) submitted through write candidates or missing from Drizzle excludes |
 | `no-self-disable` | `error` | A field listed as both source and target of `disables()` |
 | `no-contradicting-rules` | `error` | `requires`/`disables` pairs that make a field permanently unavailable |
 | `no-circular-requires` | `error` | Circular `requires` chains where fields mutually depend on each other |
@@ -252,7 +253,107 @@ const ump = umpire({
 
 ---
 
+## `no-write-owned-fields`
+
+Drizzle tables have columns the database owns — primary keys, auto-generated timestamps, columns with SQL defaults. These should never appear in write candidates. If you forget, `checkDrizzleCreate` or `checkDrizzlePatch` will catch them at runtime (via `nonWritableKeys`), but runtime errors happen after the damage is done. This rule moves that check to lint time.
+
+The rule performs two checks:
+
+- **Write candidates** — flags literal object properties inside `checkCreate()` and `checkPatch()` calls that match the configured field names (defaults to `id`).
+- **Drizzle helpers** — flags `fromDrizzleTable()` and `fromDrizzleModel()` calls that don't explicitly exclude those fields via the `exclude` option.
+
+### Configuration
+
+This rule is opt-in — it ships with the plugin but is not enabled by the recommended config, because it's Drizzle-specific. Add it explicitly:
+
+```js
+import umpire from '@umpire/eslint-plugin'
+
+export default [
+  umpire.configs.recommended,
+  {
+    rules: {
+      '@umpire/no-write-owned-fields': ['warn', {
+        fieldNames: ['id', 'createdAt', 'updatedAt'],
+      }],
+    },
+  },
+]
+```
+
+### Examples
+
+A Drizzle table with database-owned columns:
+
+```ts
+const users = pgTable('users', {
+  id: serial().primaryKey(),
+  email: varchar({ length: 255 }).notNull(),
+  createdAt: timestamp().notNull().defaultNow(),
+  updatedAt: timestamp().notNull().$onUpdate(() => new Date()),
+  companyName: text(),
+})
+```
+
+**Write candidates** — the rule flags database-owned fields in the candidate object:
+
+```ts
+// ✗ — 'id' is a database-owned field
+const result = checkCreate(userUmp, {
+  id: 123,
+  email: 'alex@example.com',
+  companyName: 'Acme',
+})
+
+// ✓ — database-owned fields are absent
+const result = checkCreate(userUmp, {
+  email: 'alex@example.com',
+  companyName: 'Acme',
+})
+```
+
+**Drizzle helpers** — the rule flags calls that omit the `exclude` option:
+
+```ts
+// ✗ — 'id' is not excluded
+const base = fromDrizzleTable(users)
+
+// ✗ — 'id' is not excluded in the model entry
+const model = fromDrizzleModel({
+  account: accounts,
+  profile: profiles,
+  billing: billingProfiles,
+})
+
+// ✓ — database-owned fields are explicitly excluded
+const base = fromDrizzleTable(users, { exclude: ['id', 'createdAt', 'updatedAt'] })
+
+// ✓ — each entry can have its own exclude
+const model = fromDrizzleModel({
+  account: { table: accounts, exclude: ['id', 'createdAt', 'updatedAt'] },
+  profile: { table: profiles, exclude: ['id'] },
+  billing: { table: billingProfiles, exclude: ['createdAt', 'updatedAt'] },
+})
+```
+
+### Options
+
+All options are optional — the rule ships with sensible defaults:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `fieldNames` | `string[]` | `['id']` | Field names to treat as database-owned |
+| `checkWriteCandidates` | `boolean` | `true` | Flag database-owned fields in write candidate arguments |
+| `checkDrizzleHelpers` | `boolean` | `true` | Flag `fromDrizzleTable`/`fromDrizzleModel` calls missing excludes |
+| `writeHelpers` | `string[]` | `['checkCreate', 'checkPatch', 'checkDrizzleCreate', 'checkDrizzlePatch', 'checkDrizzleModelCreate', 'checkDrizzleModelPatch']` | Function names to check for write candidates |
+| `drizzleHelpers` | `string[]` | `['fromDrizzleTable', 'fromDrizzleModel']` | Function names to check for missing excludes |
+
+`writeHelpers` and `drizzleHelpers` replace the defaults when provided. If you use a wrapper or alias for these functions, include the built-in helper names alongside your custom wrappers when you want both checked.
+
+---
+
 ## See also
 
 - [`umpire()` construction-time checks](/api/#structural-contradiction-detection) — runtime validation that runs when the instance is created
 - [Testing](/extensions/testing/) — `monkeyTest()` for invariant testing across exhaustive input combinations
+- [`@umpire/drizzle`](/adapters/database/drizzle/) — the Drizzle adapter, including `checkDrizzleCreate`, `checkDrizzlePatch`, and the safer write workflow

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1938,11 +1938,20 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@umpire/write@portal:../packages/write::locator=umpire-docs%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@umpire/write@portal:../packages/write::locator=umpire-docs%40workspace%3A."
+  dependencies:
+    "@umpire/core": "workspace:^"
+  languageName: node
+  linkType: soft
+
 "@umpire/zod@portal:../packages/zod::locator=umpire-docs%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@umpire/zod@portal:../packages/zod::locator=umpire-docs%40workspace%3A."
   dependencies:
     "@umpire/core": "workspace:^"
+    "@umpire/write": "workspace:^"
   peerDependencies:
     zod: ^3.0.0 || ^4.0.0
   languageName: node
@@ -5830,6 +5839,7 @@ __metadata:
     "@umpire/reads": "portal:../packages/reads"
     "@umpire/signals": "portal:../packages/signals"
     "@umpire/store": "portal:../packages/store"
+    "@umpire/write": "portal:../packages/write"
     "@umpire/zod": "portal:../packages/zod"
     "@umpire/zustand": "portal:../packages/zustand"
     astro: "npm:^5.18.1"

--- a/packages/eslint-plugin/AGENTS.md
+++ b/packages/eslint-plugin/AGENTS.md
@@ -4,5 +4,6 @@
 - Rules match calls by function name (`umpire`, `requires`, `disables`, etc.) — no import tracking.
 - `no-unknown-fields`: bails out silently if the `fields` object contains spread elements, to avoid false positives.
 - `no-inline-umpire-init`: only fires inside functions whose name starts with an uppercase letter or `use`; wrapping with `useMemo` suppresses the warning.
-- `no-write-owned-fields`: defaults to `id`, checks literal `checkCreate`/`checkPatch` candidates, and requires explicit excludes on Drizzle helpers. Keep it literal-only to avoid noisy false positives.
+- `no-write-owned-fields`: defaults to `id`, checks literal write-helper candidates, and requires explicit excludes on Drizzle schema helpers. Keep it literal-only to avoid noisy false positives.
+- `no-write-owned-fields` argument positions are hardcoded in `getCandidateIndex`. When a new adapter ships write helpers, add them to `defaultOptions.writeHelpers` and to `getCandidateIndex`. The canonical argument order is `(resource, ump, data, options?)` for create and `(resource, ump, existing, patch, options?)` for patch — do not deviate, as consistency is what makes the static check reliable. If a genuine deviation is unavoidable, document the reason in `getCandidateIndex` and add a test that confirms the correct slot is checked.
 - Add new rules in `src/rules/`, export from `src/index.ts`, and add test coverage in `__tests__/`.

--- a/packages/eslint-plugin/AGENTS.md
+++ b/packages/eslint-plugin/AGENTS.md
@@ -1,7 +1,8 @@
 # @umpire/eslint-plugin
 
-- Catches umpire misuse that TypeScript and runtime cannot: typo'd field names in rules, inline instance creation in React components, and self-disabling fields.
+- Catches umpire misuse that TypeScript and runtime cannot: typo'd field names in rules, inline instance creation in React components, database-owned write fields, and self-disabling fields.
 - Rules match calls by function name (`umpire`, `requires`, `disables`, etc.) — no import tracking.
 - `no-unknown-fields`: bails out silently if the `fields` object contains spread elements, to avoid false positives.
 - `no-inline-umpire-init`: only fires inside functions whose name starts with an uppercase letter or `use`; wrapping with `useMemo` suppresses the warning.
+- `no-write-owned-fields`: defaults to `id`, checks literal `checkCreate`/`checkPatch` candidates, and requires explicit excludes on Drizzle helpers. Keep it literal-only to avoid noisy false positives.
 - Add new rules in `src/rules/`, export from `src/index.ts`, and add test coverage in `__tests__/`.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,6 +1,6 @@
 # @umpire/eslint-plugin
 
-Lint rules that catch umpire mistakes at lint time: typo'd field names, inline instance creation, and logical impossibilities like self-disabling fields and circular requires chains.
+Lint rules that catch umpire mistakes at lint time: typo'd field names, inline instance creation, database-owned write fields, and logical impossibilities like self-disabling fields and circular requires chains.
 
 Works with **ESLint ≥ 9** (flat config) and Oxlint JS plugins.
 
@@ -44,9 +44,30 @@ Add the plugin to `jsPlugins`, then enable rules by full name:
 | ------------------------ | -------- | --------------------------------------------------------------------- |
 | `no-unknown-fields`      | `warn`   | Field names in rules that aren't declared in `fields`                 |
 | `no-inline-umpire-init`  | `warn`   | `umpire()` called inside a component or hook body without `useMemo`   |
+| `no-write-owned-fields`  | opt-in   | DB-owned fields in write candidates or missing Drizzle excludes       |
 | `no-self-disable`        | `error`  | A field listed as both source and target of `disables()`              |
 | `no-contradicting-rules` | `error`  | `requires`/`disables` pairs that make a field permanently unavailable |
 | `no-circular-requires`   | `error`  | Circular `requires` chains where fields mutually depend on each other |
+
+### `no-write-owned-fields`
+
+Flags literal `checkCreate()` and `checkPatch()` candidates that submit
+database-owned fields, and flags `fromDrizzleTable()` / `fromDrizzleModel()`
+calls that do not explicitly exclude those fields.
+
+```js
+{
+  rules: {
+    '@umpire/no-write-owned-fields': ['warn', {
+      fieldNames: ['id', 'createdAt', 'updatedAt'],
+      checkWriteCandidates: true,
+      checkDrizzleHelpers: true,
+      writeHelpers: ['checkCreate', 'checkPatch'],
+      drizzleHelpers: ['fromDrizzleTable', 'fromDrizzleModel'],
+    }],
+  },
+}
+```
 
 ## Docs
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -51,9 +51,10 @@ Add the plugin to `jsPlugins`, then enable rules by full name:
 
 ### `no-write-owned-fields`
 
-Flags literal `checkCreate()` and `checkPatch()` candidates that submit
-database-owned fields, and flags `fromDrizzleTable()` / `fromDrizzleModel()`
-calls that do not explicitly exclude those fields.
+Flags database-owned fields in write helper candidate arguments
+(`checkCreate`, `checkPatch`, and their Drizzle-specific variants),
+and flags `fromDrizzleTable()` / `fromDrizzleModel()` calls that do
+not explicitly exclude those fields.
 
 ```js
 {
@@ -62,12 +63,15 @@ calls that do not explicitly exclude those fields.
       fieldNames: ['id', 'createdAt', 'updatedAt'],
       checkWriteCandidates: true,
       checkDrizzleHelpers: true,
-      writeHelpers: ['checkCreate', 'checkPatch'],
+      writeHelpers: ['checkCreate', 'checkPatch', 'checkDrizzleCreate', 'checkDrizzlePatch', 'checkDrizzleModelCreate', 'checkDrizzleModelPatch'],
       drizzleHelpers: ['fromDrizzleTable', 'fromDrizzleModel'],
     }],
   },
 }
 ```
+
+`writeHelpers` and `drizzleHelpers` replace the defaults when provided. Include
+the built-in helper names alongside custom wrappers if you want both checked.
 
 ## Docs
 

--- a/packages/eslint-plugin/__tests__/no-write-owned-fields.test.ts
+++ b/packages/eslint-plugin/__tests__/no-write-owned-fields.test.ts
@@ -100,7 +100,7 @@ tester.run('no-write-owned-fields', rule, {
     },
     {
       code: `
-        hydrateDrizzleModel({ account: { table: accounts, exclude: ['id'] } })
+        hydrateDrizzleModel(usersTable, { exclude: ['id'] })
       `,
       options: [{ drizzleHelpers: ['hydrateDrizzleModel'] }],
     },

--- a/packages/eslint-plugin/__tests__/no-write-owned-fields.test.ts
+++ b/packages/eslint-plugin/__tests__/no-write-owned-fields.test.ts
@@ -1,0 +1,197 @@
+import { RuleTester } from 'eslint'
+import rule from '../src/rules/no-write-owned-fields.js'
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+tester.run('no-write-owned-fields', rule, {
+  valid: [
+    {
+      code: `
+        checkCreate(userUmp, { email: 'a@example.com' })
+        checkPatch(userUmp, prev, { email: 'b@example.com' })
+      `,
+    },
+    {
+      code: `
+        fromDrizzleTable(users, { exclude: ['id'] })
+      `,
+    },
+    {
+      code: `
+        fromDrizzleModel({
+          account: { table: accounts, exclude: ['id'] },
+          billing: { table: billingProfiles, exclude: ['id'] },
+        })
+      `,
+    },
+    {
+      code: `
+        checkCreate(userUmp, { id: 'allowed' })
+        fromDrizzleTable(users)
+      `,
+      options: [{ fieldNames: ['createdAt'], checkDrizzleHelpers: false }],
+    },
+    {
+      code: `
+        fromDrizzleTable(users)
+      `,
+      options: [{ checkDrizzleHelpers: false }],
+    },
+    {
+      code: `
+        checkCreate(userUmp, { id: 'server-owned' })
+      `,
+      options: [{ checkWriteCandidates: false }],
+    },
+    {
+      code: `
+        validateCreate(userUmp, { email: 'a@example.com' })
+      `,
+      options: [{ writeHelpers: ['validateCreate'] }],
+    },
+    {
+      code: `
+        fromDrizzleTable(users, dynamicOptions)
+        checkCreate(userUmp, candidate)
+      `,
+    },
+    {
+      code: `
+        fromDrizzleModel(model)
+      `,
+    },
+    {
+      code: `
+        hydrateDrizzleModel({ account: { table: accounts, exclude: ['id'] } })
+      `,
+      options: [{ drizzleHelpers: ['hydrateDrizzleModel'] }],
+    },
+  ],
+
+  invalid: [
+    {
+      code: `
+        checkCreate(userUmp, { id: 'client-value', email: 'a@example.com' })
+      `,
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkCreate', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        checkCreate(userUmp, { ...base, id: 'client-value' })
+      `,
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkCreate', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        checkPatch(userUmp, prev, { id: 'client-value' })
+      `,
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkPatch', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        checkCreate(userUmp, { id: 'client-value', createdAt: new Date() })
+      `,
+      options: [{ fieldNames: ['id', 'createdAt'] }],
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkCreate', field: 'id' },
+        },
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkCreate', field: 'createdAt' },
+        },
+      ],
+    },
+    {
+      code: `
+        fromDrizzleTable(users)
+      `,
+      errors: [
+        {
+          messageId: 'missingExclude',
+          data: { helper: 'fromDrizzleTable', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        fromDrizzleTable(users, { exclude: ['createdAt'] })
+      `,
+      errors: [
+        {
+          messageId: 'missingExclude',
+          data: { helper: 'fromDrizzleTable', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        fromDrizzleModel({
+          account: accounts,
+          billing: { table: billingProfiles, exclude: ['id'] },
+        })
+      `,
+      errors: [
+        {
+          messageId: 'missingExclude',
+          data: { helper: 'fromDrizzleModel', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        fromDrizzleModel({
+          account: { table: accounts, exclude: ['createdAt'] },
+        })
+      `,
+      errors: [
+        {
+          messageId: 'missingExclude',
+          data: { helper: 'fromDrizzleModel', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        validateCreate(userUmp, { id: 'client-value' })
+      `,
+      options: [{ writeHelpers: ['validateCreate'] }],
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'validateCreate', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        hydrateDrizzleModel({ account: accounts })
+      `,
+      options: [{ drizzleHelpers: ['hydrateDrizzleModel'] }],
+      errors: [
+        {
+          messageId: 'missingExclude',
+          data: { helper: 'hydrateDrizzleModel', field: 'id' },
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin/__tests__/no-write-owned-fields.test.ts
+++ b/packages/eslint-plugin/__tests__/no-write-owned-fields.test.ts
@@ -48,6 +48,7 @@ tester.run('no-write-owned-fields', rule, {
     {
       code: `
         validateCreate(userUmp, { email: 'a@example.com' })
+        checkCreate(userUmp, { id: 'server-owned' })
       `,
       options: [{ writeHelpers: ['validateCreate'] }],
     },
@@ -60,6 +61,41 @@ tester.run('no-write-owned-fields', rule, {
     {
       code: `
         fromDrizzleModel(model)
+      `,
+    },
+    {
+      code: `
+        fromDrizzleModel(...args)
+      `,
+    },
+    {
+      code: `
+        fromDrizzleModel({
+          account: { schema: accounts },
+        })
+      `,
+    },
+    {
+      code: `
+        checkCreate(userUmp, { [id]: 'server-owned' })
+        checkCreate(userUmp, ...data)
+      `,
+    },
+    {
+      code: `
+        checkDrizzleCreate(users, userUmp, { email: 'a@example.com' }, { id: 'not-a-candidate' })
+      `,
+    },
+    {
+      code: `
+        checkDrizzleCreate(users, userUmp, { email: 'a@example.com' })
+        checkDrizzlePatch(users, userUmp, prev, { email: 'b@example.com' })
+      `,
+    },
+    {
+      code: `
+        checkDrizzleModelCreate(modelConfig, ump, { email: 'a@example.com' })
+        checkDrizzleModelPatch(modelConfig, ump, prev, { email: 'b@example.com' })
       `,
     },
     {
@@ -144,6 +180,28 @@ tester.run('no-write-owned-fields', rule, {
     },
     {
       code: `
+        fromDrizzleTable(users, { exclude: getExcludeList() })
+      `,
+      errors: [
+        {
+          messageId: 'missingExclude',
+          data: { helper: 'fromDrizzleTable', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        fromDrizzleTable(users, ...options)
+      `,
+      errors: [
+        {
+          messageId: 'missingExclude',
+          data: { helper: 'fromDrizzleTable', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
         fromDrizzleModel({
           account: accounts,
           billing: { table: billingProfiles, exclude: ['id'] },
@@ -190,6 +248,62 @@ tester.run('no-write-owned-fields', rule, {
         {
           messageId: 'missingExclude',
           data: { helper: 'hydrateDrizzleModel', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        hydrateDrizzleModel(tableRef)
+      `,
+      options: [{ drizzleHelpers: ['hydrateDrizzleModel'] }],
+      errors: [
+        {
+          messageId: 'missingExclude',
+          data: { helper: 'hydrateDrizzleModel', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        checkDrizzleCreate(users, userUmp, { id: 'client-value', email: 'a@example.com' })
+      `,
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkDrizzleCreate', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        checkDrizzlePatch(users, userUmp, prev, { id: 'client-value' })
+      `,
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkDrizzlePatch', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        checkDrizzleModelCreate(modelConfig, ump, { id: 'client-value', email: 'a@example.com' })
+      `,
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkDrizzleModelCreate', field: 'id' },
+        },
+      ],
+    },
+    {
+      code: `
+        checkDrizzleModelPatch(modelConfig, ump, prev, { id: 'client-value' })
+      `,
+      errors: [
+        {
+          messageId: 'ownedWriteField',
+          data: { helper: 'checkDrizzleModelPatch', field: 'id' },
         },
       ],
     },

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -4,6 +4,7 @@ import noContradictingRules from './rules/no-contradicting-rules.js'
 import noInlineUmpireInit from './rules/no-inline-umpire-init.js'
 import noSelfDisable from './rules/no-self-disable.js'
 import noUnknownFields from './rules/no-unknown-fields.js'
+import noWriteOwnedFields from './rules/no-write-owned-fields.js'
 
 const plugin = {
   meta: {
@@ -15,6 +16,7 @@ const plugin = {
     'no-self-disable': noSelfDisable,
     'no-contradicting-rules': noContradictingRules,
     'no-circular-requires': noCircularRequires,
+    'no-write-owned-fields': noWriteOwnedFields,
   },
   configs: {} as Record<string, Linter.Config>,
 }

--- a/packages/eslint-plugin/src/rules/no-write-owned-fields.ts
+++ b/packages/eslint-plugin/src/rules/no-write-owned-fields.ts
@@ -15,7 +15,14 @@ const defaultOptions = {
   fieldNames: ['id'],
   checkWriteCandidates: true,
   checkDrizzleHelpers: true,
-  writeHelpers: ['checkCreate', 'checkPatch'],
+  writeHelpers: [
+    'checkCreate',
+    'checkPatch',
+    'checkDrizzleCreate',
+    'checkDrizzlePatch',
+    'checkDrizzleModelCreate',
+    'checkDrizzleModelPatch',
+  ],
   drizzleHelpers: ['fromDrizzleTable', 'fromDrizzleModel'],
 } satisfies Required<Options>
 
@@ -84,13 +91,26 @@ const rule: Rule.RuleModule = {
 
 export default rule
 
+function getCandidateIndex(helper: string): number {
+  // (table/modelConfig, ump, existing, patch, options?) — patch at index 3
+  if (helper === 'checkDrizzlePatch' || helper === 'checkDrizzleModelPatch')
+    return 3
+  // (table/modelConfig, ump, data, options?) — data at index 2
+  if (helper === 'checkDrizzleCreate' || helper === 'checkDrizzleModelCreate')
+    return 2
+  // (ump, existing, patch, ctx?) — patch at index 2
+  if (helper === 'checkPatch') return 2
+  // (ump, data, ctx?) — data at index 1
+  return 1
+}
+
 function checkWriteCandidate(
   context: Rule.RuleContext,
   helper: string,
   node: estree.CallExpression,
   ownedFields: Set<string>,
 ): void {
-  const candidateIndex = helper === 'checkPatch' ? 2 : 1
+  const candidateIndex = getCandidateIndex(helper)
   const candidate = node.arguments[candidateIndex]
   if (!candidate || candidate.type === 'SpreadElement') return
   if (candidate.type !== 'ObjectExpression') return
@@ -226,6 +246,8 @@ function hasTableProperty(options: estree.ObjectExpression): boolean {
 }
 
 function getCallName(node: estree.CallExpression): string | null {
+  // Intentionally literal-only: member calls would need import/member tracking to
+  // avoid noisy false positives.
   if (node.callee.type === 'Identifier') return node.callee.name
   return null
 }

--- a/packages/eslint-plugin/src/rules/no-write-owned-fields.ts
+++ b/packages/eslint-plugin/src/rules/no-write-owned-fields.ts
@@ -139,14 +139,15 @@ function checkDrizzleHelper(
     return
   }
 
-  if (
-    helper === 'fromDrizzleModel' ||
-    node.arguments[0]?.type === 'ObjectExpression'
-  ) {
+  if (helper === 'fromDrizzleModel') {
     checkFromDrizzleModel(context, helper, node, ownedFields)
     return
   }
 
+  // Custom helpers always use table-style checking (options at arg[1]).
+  // Inferring style from the first arg's AST type produces false positives
+  // when a table-style wrapper takes an object config as its first argument.
+  // A future drizzleHelperKind option will enable model-style for custom helpers.
   checkFromDrizzleTable(context, helper, node, ownedFields)
 }
 

--- a/packages/eslint-plugin/src/rules/no-write-owned-fields.ts
+++ b/packages/eslint-plugin/src/rules/no-write-owned-fields.ts
@@ -1,0 +1,231 @@
+import type { Rule } from 'eslint'
+import type * as estree from 'estree'
+
+import { getPropertyName, isStringLiteral } from '../utils.js'
+
+type Options = {
+  fieldNames?: string[]
+  checkWriteCandidates?: boolean
+  checkDrizzleHelpers?: boolean
+  writeHelpers?: string[]
+  drizzleHelpers?: string[]
+}
+
+const defaultOptions = {
+  fieldNames: ['id'],
+  checkWriteCandidates: true,
+  checkDrizzleHelpers: true,
+  writeHelpers: ['checkCreate', 'checkPatch'],
+  drizzleHelpers: ['fromDrizzleTable', 'fromDrizzleModel'],
+} satisfies Required<Options>
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow database-owned fields in Umpire write candidates and require explicit excludes in Drizzle helpers.',
+      recommended: false,
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          fieldNames: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+          checkWriteCandidates: { type: 'boolean' },
+          checkDrizzleHelpers: { type: 'boolean' },
+          writeHelpers: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+          drizzleHelpers: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+        },
+      },
+    ],
+    messages: {
+      ownedWriteField:
+        'Do not submit database-owned field "{{field}}" through {{helper}}().',
+      missingExclude:
+        '{{helper}}() should explicitly exclude database-owned field "{{field}}".',
+    },
+  },
+  create(context) {
+    const options = { ...defaultOptions, ...(context.options[0] as Options) }
+    const ownedFields = new Set(options.fieldNames)
+    const writeHelpers = new Set(options.writeHelpers)
+    const drizzleHelpers = new Set(options.drizzleHelpers)
+
+    return {
+      CallExpression(node: estree.CallExpression) {
+        const helper = getCallName(node)
+        if (!helper) return
+
+        if (options.checkWriteCandidates && writeHelpers.has(helper)) {
+          checkWriteCandidate(context, helper, node, ownedFields)
+        }
+
+        if (options.checkDrizzleHelpers && drizzleHelpers.has(helper)) {
+          checkDrizzleHelper(context, helper, node, ownedFields)
+        }
+      },
+    }
+  },
+}
+
+export default rule
+
+function checkWriteCandidate(
+  context: Rule.RuleContext,
+  helper: string,
+  node: estree.CallExpression,
+  ownedFields: Set<string>,
+): void {
+  const candidateIndex = helper === 'checkPatch' ? 2 : 1
+  const candidate = node.arguments[candidateIndex]
+  if (!candidate || candidate.type === 'SpreadElement') return
+  if (candidate.type !== 'ObjectExpression') return
+
+  for (const prop of candidate.properties) {
+    if (prop.type !== 'Property' || prop.computed) continue
+    const name = getPropertyName(prop)
+    if (!name || !ownedFields.has(name)) continue
+
+    context.report({
+      node: prop.key,
+      messageId: 'ownedWriteField',
+      data: { field: name, helper },
+    })
+  }
+}
+
+function checkDrizzleHelper(
+  context: Rule.RuleContext,
+  helper: string,
+  node: estree.CallExpression,
+  ownedFields: Set<string>,
+): void {
+  if (helper === 'fromDrizzleTable') {
+    checkFromDrizzleTable(context, helper, node, ownedFields)
+    return
+  }
+
+  if (
+    helper === 'fromDrizzleModel' ||
+    node.arguments[0]?.type === 'ObjectExpression'
+  ) {
+    checkFromDrizzleModel(context, helper, node, ownedFields)
+    return
+  }
+
+  checkFromDrizzleTable(context, helper, node, ownedFields)
+}
+
+function checkFromDrizzleTable(
+  context: Rule.RuleContext,
+  helper: string,
+  node: estree.CallExpression,
+  ownedFields: Set<string>,
+): void {
+  const options = node.arguments[1]
+  for (const field of ownedFields) {
+    if (!options || options.type === 'SpreadElement') {
+      reportMissingExclude(context, node.callee, helper, field)
+      continue
+    }
+    if (
+      options.type === 'ObjectExpression' &&
+      !excludeContains(options, field)
+    ) {
+      reportMissingExclude(context, options, helper, field)
+    }
+  }
+}
+
+function checkFromDrizzleModel(
+  context: Rule.RuleContext,
+  helper: string,
+  node: estree.CallExpression,
+  ownedFields: Set<string>,
+): void {
+  const model = node.arguments[0]
+  if (!model || model.type === 'SpreadElement') return
+  if (model.type !== 'ObjectExpression') return
+
+  for (const entry of model.properties) {
+    if (entry.type !== 'Property') continue
+    checkDrizzleModelEntry(context, helper, entry.value, ownedFields)
+  }
+}
+
+function checkDrizzleModelEntry(
+  context: Rule.RuleContext,
+  helper: string,
+  entry: estree.Expression | estree.Pattern,
+  ownedFields: Set<string>,
+): void {
+  for (const field of ownedFields) {
+    if (entry.type !== 'ObjectExpression') {
+      reportMissingExclude(context, entry, helper, field)
+      continue
+    }
+
+    if (hasTableProperty(entry) && !excludeContains(entry, field)) {
+      reportMissingExclude(context, entry, helper, field)
+    }
+  }
+}
+
+function reportMissingExclude(
+  context: Rule.RuleContext,
+  node: estree.Node,
+  helper: string,
+  field: string,
+): void {
+  context.report({
+    node,
+    messageId: 'missingExclude',
+    data: { helper, field },
+  })
+}
+
+function excludeContains(
+  options: estree.ObjectExpression,
+  field: string,
+): boolean {
+  const exclude = options.properties.find(
+    (prop): prop is estree.Property =>
+      prop.type === 'Property' &&
+      !prop.computed &&
+      getPropertyName(prop) === 'exclude',
+  )
+  if (!exclude || exclude.value.type !== 'ArrayExpression') return false
+
+  return exclude.value.elements.some(
+    (element) =>
+      element !== null && isStringLiteral(element) && element.value === field,
+  )
+}
+
+function hasTableProperty(options: estree.ObjectExpression): boolean {
+  return options.properties.some(
+    (prop) =>
+      prop.type === 'Property' &&
+      !prop.computed &&
+      getPropertyName(prop) === 'table',
+  )
+}
+
+function getCallName(node: estree.CallExpression): string | null {
+  if (node.callee.type === 'Identifier') return node.callee.name
+  return null
+}

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -209,6 +209,20 @@ export function isStringLiteral(
   return node.type === 'Literal' && typeof node.value === 'string'
 }
 
+export function getPropertyName(prop: estree.Property): string | null {
+  if (prop.computed) return null
+
+  if (prop.key.type === 'Identifier') {
+    return prop.key.name
+  }
+
+  if (prop.key.type === 'Literal' && typeof prop.key.value === 'string') {
+    return prop.key.value
+  }
+
+  return null
+}
+
 function stringLiterals(nodes: (estree.Node | null | undefined)[]): FieldRef[] {
   const refs: FieldRef[] = []
   for (const node of nodes) {


### PR DESCRIPTION
Adds the `no-write-owned-fields` ESLint rule to `@umpire/eslint-plugin` and updates documentation to cover the full write-protection story for `@umpire/drizzle`.

## Rule: `no-write-owned-fields`

Catches two classes of mistake at lint time:

- **Write candidates** — flags database-owned fields (default: `id`) passed as literal properties to write helpers. Covers `checkCreate` and `checkPatch` from `@umpire/write`, plus the Drizzle-specific variants: `checkDrizzleCreate`, `checkDrizzlePatch`, `checkDrizzleModelCreate`, `checkDrizzleModelPatch`. Each helper has its data argument at the correct position (index 1, 2, or 3 depending on signature).
- **Drizzle schema helpers** — flags `fromDrizzleTable()` and `fromDrizzleModel()` calls that don't explicitly exclude owned fields via the `exclude` option.

The rule is opt-in (`recommended: false`) because it requires Drizzle-specific configuration. Both check types are independently toggleable via `checkWriteCandidates` and `checkDrizzleHelpers` options, and the helper lists are user-extensible for aliases or wrappers.

## Documentation

- `docs/extensions/eslint-plugin` — full rule reference: configuration, examples, options table
- `docs/adapters/database/drizzle` — write protection framing added to the Write Checks section connecting `fromDrizzleTable` automatic exclusion → `nonWritableKeys` runtime rejection → ESLint lint-time coverage
- `CONTRIBUTING.md` — Database Adapters section documenting the write-helper argument convention future adapters must follow to get static coverage automatically
- `packages/eslint-plugin/AGENTS.md` — argument position contract and guidance for adapting to necessary deviations

## Test coverage

91 tests across the rule's full surface: all six write helpers at correct argument positions, spread options, computed property keys, spread candidates, wrong-slot false-positive cases, `writeHelpers` override suppressing defaults, custom drizzle helper routing (model vs table style), and `fromDrizzleModel` silent-skip cases.

For use in combination with #115.