### PR TITLE
🐛 Propagate read bridge dependencies to graph

### DIFF
--- a/.changeset/read-bridges-graph.md
+++ b/.changeset/read-bridges-graph.md
@@ -1,0 +1,8 @@
+---
+"@umpire/core": patch
+"@umpire/reads": patch
+---
+
+Propagate `fairWhenRead()` and `enabledWhenRead()` value-input field dependencies into Umpire graph edges.
+
+Read-backed rules now expose fields touched by their value-input reads as rule sources, so downstream graph consumers can observe upstream dependencies such as `country -> postalCode`. Self-dependencies are excluded, and condition-input or custom-selected reads remain conservative.

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -714,9 +714,11 @@ export function getGraphSourceInfo<
   const metadata = getInternalRuleMetadata(rule)
 
   if (metadata?.kind === 'enabledWhen') {
+    const source = getSourceField(metadata.predicate)
+
     return {
-      ordering: [],
-      informational: getSourceFields(metadata.predicate),
+      ordering: source ? [] : [...rule.sources],
+      informational: source ? [source] : [],
     }
   }
 
@@ -725,7 +727,7 @@ export function getGraphSourceInfo<
 
     return {
       ordering: [],
-      informational: source ? [source] : [],
+      informational: source ? [source] : [...rule.sources],
     }
   }
 

--- a/packages/reads/__tests__/reads.test.ts
+++ b/packages/reads/__tests__/reads.test.ts
@@ -512,14 +512,20 @@ describe('@umpire/reads', () => {
 
     test('fairWhenRead does not add nested property names as graph dependencies', () => {
       const reads = createReads<
-        { address?: { street?: string }; street?: string },
+        { address?: { street?: string }; quantity?: number; street?: string },
         { addressFair: boolean }
       >({
-        addressFair: ({ input }) => Boolean(input.address?.street),
+        addressFair: ({ input }) =>
+          Boolean(
+            input.address?.street?.toString() ||
+            input.quantity?.valueOf() ||
+            String(input),
+          ),
       })
       const ump = umpire({
         fields: {
           address: {},
+          quantity: {},
           street: {},
           deliveryInstructions: {},
         },
@@ -543,6 +549,34 @@ describe('@umpire/reads', () => {
           }),
         ]),
       )
+    })
+
+    test('fairWhenRead omits graph sources when probe inference cannot evaluate the read', () => {
+      const reads = createReads<
+        { config?: unknown; deliveryInstructions?: string },
+        { configFair: boolean }
+      >({
+        configFair: ({ input }) => {
+          if (!Array.isArray(input.config)) {
+            throw new Error('Expected array config')
+          }
+
+          return true
+        },
+      })
+      const ump = umpire({
+        fields: {
+          config: {},
+          deliveryInstructions: {},
+        },
+        rules: [fairWhenRead('deliveryInstructions', 'configFair', reads)],
+      })
+
+      expect(ump.graph().edges).toEqual([])
+      expect(
+        ump.check({ config: [], deliveryInstructions: 'Leave at door' })
+          .deliveryInstructions.fair,
+      ).toBe(true)
     })
 
     test('enabledWhenRead passes when the read returns true and fails with the configured reason when false', () => {

--- a/packages/reads/__tests__/reads.test.ts
+++ b/packages/reads/__tests__/reads.test.ts
@@ -461,6 +461,55 @@ describe('@umpire/reads', () => {
       })
     })
 
+    test('fairWhenRead adds value read field dependencies to the umpire graph', () => {
+      const reads = createReads<
+        { country?: string; postalCode?: string },
+        { postalCodeFair: boolean }
+      >({
+        postalCodeFair: ({ input }) => {
+          const code = String(input.postalCode ?? '').trim()
+
+          if (!code) {
+            return true
+          }
+
+          switch (input.country) {
+            case 'US':
+              return /^\d{5}(-\d{4})?$/.test(code)
+            case 'CA':
+              return /^[A-Z]\d[A-Z]\s?\d[A-Z]\d$/i.test(code)
+            default:
+              return true
+          }
+        },
+      })
+      const ump = umpire({
+        fields: {
+          country: {},
+          postalCode: {},
+        },
+        rules: [fairWhenRead('postalCode', 'postalCodeFair', reads)],
+      })
+
+      expect(ump.graph().edges).toEqual(
+        expect.arrayContaining([
+          {
+            from: 'country',
+            to: 'postalCode',
+            type: 'fairWhen',
+          },
+        ]),
+      )
+      expect(ump.graph().edges).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            from: 'postalCode',
+            to: 'postalCode',
+          }),
+        ]),
+      )
+    })
+
     test('enabledWhenRead passes when the read returns true and fails with the configured reason when false', () => {
       const reads = createReads<
         { cpu?: string },
@@ -498,6 +547,32 @@ describe('@umpire/reads', () => {
         reason: 'Pick a CPU first',
         reasons: ['Pick a CPU first'],
       })
+    })
+
+    test('enabledWhenRead adds value read field dependencies to the umpire graph', () => {
+      const reads = createReads<
+        { cpu?: string },
+        { canSelectMotherboard: boolean }
+      >({
+        canSelectMotherboard: ({ input }) => Boolean(input.cpu),
+      })
+      const ump = umpire({
+        fields: {
+          cpu: {},
+          motherboard: {},
+        },
+        rules: [enabledWhenRead('motherboard', 'canSelectMotherboard', reads)],
+      })
+
+      expect(ump.graph().edges).toEqual(
+        expect.arrayContaining([
+          {
+            from: 'cpu',
+            to: 'motherboard',
+            type: 'enabledWhen',
+          },
+        ]),
+      )
     })
 
     test('inputType CONDITIONS evaluates reads against conditions instead of values', () => {
@@ -540,6 +615,32 @@ describe('@umpire/reads', () => {
         reason: 'Pick a supported platform first',
         reasons: ['Pick a supported platform first'],
       })
+    })
+
+    test('inputType CONDITIONS does not add read input fields to the umpire graph', () => {
+      const reads = createReads<
+        { allowMotherboard: boolean },
+        { canSelectMotherboard: boolean }
+      >({
+        canSelectMotherboard: ({ input }) => input.allowMotherboard,
+      })
+      const ump = umpire<
+        {
+          motherboard: {}
+        },
+        { allowMotherboard: boolean }
+      >({
+        fields: {
+          motherboard: {},
+        },
+        rules: [
+          enabledWhenRead('motherboard', 'canSelectMotherboard', reads, {
+            inputType: ReadInputType.CONDITIONS,
+          }),
+        ],
+      })
+
+      expect(ump.graph().edges).toEqual([])
     })
 
     test('fairWhenRead supports inputType CONDITIONS with a named field builder', () => {

--- a/packages/reads/__tests__/reads.test.ts
+++ b/packages/reads/__tests__/reads.test.ts
@@ -510,6 +510,41 @@ describe('@umpire/reads', () => {
       )
     })
 
+    test('fairWhenRead does not add nested property names as graph dependencies', () => {
+      const reads = createReads<
+        { address?: { street?: string }; street?: string },
+        { addressFair: boolean }
+      >({
+        addressFair: ({ input }) => Boolean(input.address?.street),
+      })
+      const ump = umpire({
+        fields: {
+          address: {},
+          street: {},
+          deliveryInstructions: {},
+        },
+        rules: [fairWhenRead('deliveryInstructions', 'addressFair', reads)],
+      })
+
+      expect(ump.graph().edges).toEqual(
+        expect.arrayContaining([
+          {
+            from: 'address',
+            to: 'deliveryInstructions',
+            type: 'fairWhen',
+          },
+        ]),
+      )
+      expect(ump.graph().edges).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            from: 'street',
+            to: 'deliveryInstructions',
+          }),
+        ]),
+      )
+    })
+
     test('enabledWhenRead passes when the read returns true and fails with the configured reason when false', () => {
       const reads = createReads<
         { cpu?: string },

--- a/packages/reads/src/reads.ts
+++ b/packages/reads/src/reads.ts
@@ -227,24 +227,32 @@ function mergeReadTrace<T>(trace: T, existing: T | T[] | undefined) {
     : trace
 }
 
-function createDependencyProbe(): Record<string, unknown> {
-  return new Proxy(Object.create(null) as Record<string, unknown>, {
+function getDependencyProbePrimitive(property: string | symbol) {
+  if (property === Symbol.toPrimitive) {
+    return () => 'umpire-read-probe'
+  }
+
+  if (property === 'toString') {
+    return () => 'umpire-read-probe'
+  }
+
+  if (property === 'valueOf') {
+    return () => true
+  }
+}
+
+function createDependencyProbe<Input extends Record<string, unknown>>(): Input {
+  const terminal = new Proxy(Object.create(null) as Record<string, unknown>, {
     get(_target, property, receiver) {
-      if (property === Symbol.toPrimitive) {
-        return () => 'umpire-read-probe'
-      }
-
-      if (property === 'toString') {
-        return () => 'umpire-read-probe'
-      }
-
-      if (property === 'valueOf') {
-        return () => true
-      }
-
-      return receiver
+      return getDependencyProbePrimitive(property) ?? receiver
     },
   })
+
+  return new Proxy(Object.create(null) as Record<string, unknown>, {
+    get(_target, property) {
+      return getDependencyProbePrimitive(property) ?? terminal
+    },
+  }) as Input
 }
 
 function inferValueReadSources<
@@ -262,7 +270,7 @@ function inferValueReadSources<
   }
 
   try {
-    const inspected = table.inspect(createDependencyProbe() as Input)
+    const inspected = table.inspect(createDependencyProbe<Input>())
     const node = inspected.nodes[key]
 
     return [

--- a/packages/reads/src/reads.ts
+++ b/packages/reads/src/reads.ts
@@ -242,13 +242,13 @@ function getDependencyProbePrimitive(property: string | symbol) {
 }
 
 function createDependencyProbe<Input extends Record<string, unknown>>(): Input {
-  const terminal = new Proxy(Object.create(null) as Record<string, unknown>, {
+  const terminal = new Proxy(Object.create(null), {
     get(_target, property, receiver) {
       return getDependencyProbePrimitive(property) ?? receiver
     },
   })
 
-  return new Proxy(Object.create(null) as Record<string, unknown>, {
+  return new Proxy(Object.create(null), {
     get(_target, property) {
       return getDependencyProbePrimitive(property) ?? terminal
     },

--- a/packages/reads/src/reads.ts
+++ b/packages/reads/src/reads.ts
@@ -227,6 +227,52 @@ function mergeReadTrace<T>(trace: T, existing: T | T[] | undefined) {
     : trace
 }
 
+function createDependencyProbe(): Record<string, unknown> {
+  return new Proxy(Object.create(null) as Record<string, unknown>, {
+    get(_target, property, receiver) {
+      if (property === Symbol.toPrimitive) {
+        return () => 'umpire-read-probe'
+      }
+
+      if (property === 'toString') {
+        return () => 'umpire-read-probe'
+      }
+
+      if (property === 'valueOf') {
+        return () => true
+      }
+
+      return receiver
+    },
+  })
+}
+
+function inferValueReadSources<
+  Input extends Record<string, unknown>,
+  Reads extends Record<string, unknown>,
+  K extends PredicateReadKey<Reads>,
+>(
+  table: ReadTable<Input, Reads>,
+  key: K,
+  target: string,
+  shouldInfer: boolean,
+): string[] {
+  if (!shouldInfer) {
+    return []
+  }
+
+  try {
+    const inspected = table.inspect(createDependencyProbe() as Input)
+    const node = inspected.nodes[key]
+
+    return [
+      ...new Set(node.dependsOnFields.filter((source) => source !== target)),
+    ]
+  } catch {
+    return []
+  }
+}
+
 export function fromRead<
   Input extends Record<string, unknown>,
   Reads extends Record<string, unknown>,
@@ -362,10 +408,18 @@ export function fairWhenRead<
     typeof fairWhen<F, C, unknown>
   >[1]
 
-  return fairWhen(field, predicate, {
+  const rule = fairWhen(field, predicate, {
     ...ruleOptions,
     trace: mergedTrace,
   })
+  rule.sources = inferValueReadSources(
+    table,
+    key,
+    fieldName,
+    !selectInput && inputType === ReadInputType.VALUES,
+  ) as Array<keyof F & string>
+
+  return rule
 }
 
 export function enabledWhenRead<
@@ -471,10 +525,18 @@ export function enabledWhenRead<
     typeof enabledWhen<F, C>
   >[1]
 
-  return enabledWhen(field, predicate, {
+  const rule = enabledWhen(field, predicate, {
     ...ruleOptions,
     trace: mergedTrace,
   })
+  rule.sources = inferValueReadSources(
+    table,
+    key,
+    fieldName,
+    !selectInput && inputType === ReadInputType.VALUES,
+  ) as Array<keyof F & string>
+
+  return rule
 }
 
 export function createReads<


### PR DESCRIPTION
## Summary
- infer value-input field dependencies for `fairWhenRead()` and `enabledWhenRead()` bridges
- expose those dependencies as Umpire graph edges while excluding self-dependencies
- add read bridge graph regressions and a changeset for `@umpire/core` / `@umpire/reads`

This should fix the issue encountered in #120, where downstream graph consumers could miss upstream fields read by a read-backed rule.

## Verification
- `yarn workspace @umpire/reads test`
- `yarn workspace @umpire/reads typecheck`
- `yarn workspace @umpire/core typecheck`
- `yarn workspace @umpire/core test -- graph`
- pre-push typecheck/build hook passed