### PR TITLE
🐶 Dogfood `checkAssert` in Umpire's own tests + add `reason()`/`reasons()` helpers

### DIFF
--- a/.changeset/checkassert-reason-helpers.md
+++ b/.changeset/checkassert-reason-helpers.md
@@ -1,0 +1,5 @@
+---
+'@umpire/testing': minor
+---
+
+Adds `.reason(field, expected)` and `.reasons(field, expectedArray)` to `checkAssert()` chains for asserting reason metadata alongside field availability flags.

--- a/packages/drizzle/__tests__/table.test.ts
+++ b/packages/drizzle/__tests__/table.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { enabledWhen, umpire } from '@umpire/core'
 import { checkCreate, checkPatch } from '@umpire/write'
+import { checkAssert } from '@umpire/testing'
 import * as drizzleAdapter from '@umpire/drizzle'
 import { fromDrizzleModel, fromDrizzleTable } from '@umpire/drizzle'
 import { sql } from 'drizzle-orm'
@@ -413,23 +414,17 @@ describe('fromDrizzleModel', () => {
 
     expect(taxId).toBe('billing.taxId')
     expect(model.fields['billing.taxId']).toMatchObject({ required: false })
-    expect(ump.check({ 'account.accountType': 'personal' })[taxId]).toEqual(
-      expect.objectContaining({
-        enabled: false,
-        reason: 'condition not met',
-      }),
-    )
-    expect(
+    checkAssert(ump.check({ 'account.accountType': 'personal' }))
+      .disabled(taxId)
+      .reason(taxId, 'condition not met')
+    checkAssert(
       ump.check({
         'account.accountType': 'business',
         'billing.taxId': '12-3456789',
-      })[taxId],
-    ).toEqual(
-      expect.objectContaining({
-        enabled: true,
-        satisfied: true,
       }),
     )
+      .enabled(taxId)
+      .satisfied(taxId)
   })
 
   test('throws when dotted namespaces and field names collide', () => {

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -32,6 +32,7 @@
     "drizzle-orm": ">=1.0.0-rc.1 <2"
   },
   "devDependencies": {
+    "@umpire/testing": "workspace:^",
     "drizzle-orm": "1.0.0-rc.1"
   },
   "repository": {

--- a/packages/drizzle/tsconfig.json
+++ b/packages/drizzle/tsconfig.json
@@ -10,7 +10,8 @@
       "@umpire/write": ["../write/src/index.ts"],
       "@umpire/write/*": ["../write/src/*"],
       "@umpire/drizzle": ["./src/index.ts"],
-      "@umpire/drizzle/*": ["./src/*"]
+      "@umpire/drizzle/*": ["./src/*"],
+      "@umpire/testing": ["../testing/src/index.ts"]
     }
   },
   "include": ["src"],

--- a/packages/integration-tests/__tests__/json-zod-pipeline.integration.test.ts
+++ b/packages/integration-tests/__tests__/json-zod-pipeline.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { umpire } from '@umpire/core'
 import { fromJson, toJson, type UmpireJsonSchema } from '@umpire/json'
 import { deriveErrors, deriveSchema, zodErrors } from '@umpire/zod'
+import { checkAssert } from '@umpire/testing'
 import { z } from 'zod'
 
 describe('json + zod pipeline', () => {
@@ -41,11 +42,10 @@ describe('json + zod pipeline', () => {
       { accountType: 'guest' },
     )
 
-    expect(guestAvailability.inviteCode).toMatchObject({
-      enabled: false,
-      required: false,
-      reason: 'Invite codes are only available for members',
-    })
+    checkAssert(guestAvailability)
+      .disabled('inviteCode')
+      .optional('inviteCode')
+      .reason('inviteCode', 'Invite codes are only available for members')
 
     const derived = deriveSchema(guestAvailability, {
       accountType: z.string(),

--- a/packages/integration-tests/__tests__/react-zod-signup.integration.test.ts
+++ b/packages/integration-tests/__tests__/react-zod-signup.integration.test.ts
@@ -7,6 +7,7 @@ import {
   umpire,
 } from '@umpire/core'
 import { createZodAdapter } from '@umpire/zod'
+import { checkAssert } from '@umpire/testing'
 import { z } from 'zod'
 import { useUmpire } from '@umpire/react'
 import { describe, it, expect } from 'bun:test'
@@ -86,8 +87,7 @@ describe('react + zod signup flow', () => {
       conditions: { sso: true },
     })
 
-    expect(result.current.check.password.enabled).toBe(false)
-    expect(result.current.check.confirmPassword.enabled).toBe(false)
+    checkAssert(result.current.check).disabled('password', 'confirmPassword')
     expect(result.current.fouls.map((foul) => foul.field).sort()).toEqual([
       'confirmPassword',
       'password',
@@ -133,7 +133,7 @@ describe('react + zod signup flow', () => {
       confirmPassword: 'mismatch',
     })
 
-    expect(result.current.check.confirmPassword.enabled).toBe(true)
+    checkAssert(result.current.check).enabled('confirmPassword')
     expect(result.current.fouls).toHaveLength(1)
     expect(result.current.fouls[0]?.field).toBe('confirmPassword')
     expect(parsed.result.success).toBe(false)

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -22,6 +22,7 @@
     "@umpire/reads": "workspace:^",
     "@umpire/signals": "workspace:^",
     "@umpire/store": "workspace:^",
+    "@umpire/testing": "workspace:^",
     "@umpire/zod": "workspace:^",
     "bun-types": "^1.3.12",
     "drizzle-orm": "1.0.0-rc.1",

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -25,7 +25,8 @@
       "@umpire/write": ["../write/src/index.ts"],
       "@umpire/write/*": ["../write/src/*"],
       "@umpire/zod": ["../zod/src/index.ts"],
-      "@umpire/zod/*": ["../zod/src/*"]
+      "@umpire/zod/*": ["../zod/src/*"],
+      "@umpire/testing": ["../testing/src/index.ts"]
     }
   },
   "include": ["__tests__", "happydom.ts"]

--- a/packages/reads/__tests__/reads.test.ts
+++ b/packages/reads/__tests__/reads.test.ts
@@ -428,8 +428,8 @@ describe('@umpire/reads', () => {
         .satisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(pass.motherboard.reason).toBeNull()
-      expect(pass.motherboard.reasons).toEqual([])
+        .reason('motherboard', null)
+        .reasons('motherboard', [])
     })
 
     test('fairWhenRead fails with the configured reason when the read returns false', () => {
@@ -454,12 +454,13 @@ describe('@umpire/reads', () => {
         .satisfied('motherboard')
         .foul('motherboard')
         .optional('motherboard')
-      expect(r.motherboard.reason).toBe(
-        'Selected motherboard no longer matches the CPU socket',
-      )
-      expect(r.motherboard.reasons).toEqual([
-        'Selected motherboard no longer matches the CPU socket',
-      ])
+        .reason(
+          'motherboard',
+          'Selected motherboard no longer matches the CPU socket',
+        )
+        .reasons('motherboard', [
+          'Selected motherboard no longer matches the CPU socket',
+        ])
     })
 
     test('fairWhenRead adds value read field dependencies to the umpire graph', () => {
@@ -605,16 +606,16 @@ describe('@umpire/reads', () => {
         .satisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(pass.motherboard.reason).toBeNull()
-      expect(pass.motherboard.reasons).toEqual([])
+        .reason('motherboard', null)
+        .reasons('motherboard', [])
       const r = ump.check({ motherboard: 'am5' })
       checkAssert(r)
         .disabled('motherboard')
         .satisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(r.motherboard.reason).toBe('Pick a CPU first')
-      expect(r.motherboard.reasons).toEqual(['Pick a CPU first'])
+        .reason('motherboard', 'Pick a CPU first')
+        .reasons('motherboard', ['Pick a CPU first'])
     })
 
     test('enabledWhenRead adds value read field dependencies to the umpire graph', () => {
@@ -673,16 +674,16 @@ describe('@umpire/reads', () => {
         .unsatisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(pass.motherboard.reason).toBeNull()
-      expect(pass.motherboard.reasons).toEqual([])
+        .reason('motherboard', null)
+        .reasons('motherboard', [])
       const r = ump.check({}, { allowMotherboard: false })
       checkAssert(r)
         .disabled('motherboard')
         .unsatisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(r.motherboard.reason).toBe('Pick a supported platform first')
-      expect(r.motherboard.reasons).toEqual(['Pick a supported platform first'])
+        .reason('motherboard', 'Pick a supported platform first')
+        .reasons('motherboard', ['Pick a supported platform first'])
     })
 
     test('inputType CONDITIONS does not add read input fields to the umpire graph', () => {
@@ -745,8 +746,8 @@ describe('@umpire/reads', () => {
         .satisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(pass.motherboard.reason).toBeNull()
-      expect(pass.motherboard.reasons).toEqual([])
+        .reason('motherboard', null)
+        .reasons('motherboard', [])
       const r = ump.check(
         { motherboard: 'lga1700' },
         { cpu: 'am5', motherboard: 'lga1700' },
@@ -756,12 +757,13 @@ describe('@umpire/reads', () => {
         .satisfied('motherboard')
         .foul('motherboard')
         .optional('motherboard')
-      expect(r.motherboard.reason).toBe(
-        'Selected motherboard no longer matches the CPU socket',
-      )
-      expect(r.motherboard.reasons).toEqual([
-        'Selected motherboard no longer matches the CPU socket',
-      ])
+        .reason(
+          'motherboard',
+          'Selected motherboard no longer matches the CPU socket',
+        )
+        .reasons('motherboard', [
+          'Selected motherboard no longer matches the CPU socket',
+        ])
     })
 
     test('fairWhenRead supports custom input selection', () => {
@@ -796,20 +798,21 @@ describe('@umpire/reads', () => {
         .satisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(pass.motherboard.reason).toBeNull()
-      expect(pass.motherboard.reasons).toEqual([])
+        .reason('motherboard', null)
+        .reasons('motherboard', [])
       const r = ump.check({ motherboard: 'lga1700' }, { cpu: 'am5' })
       checkAssert(r)
         .enabled('motherboard')
         .satisfied('motherboard')
         .foul('motherboard')
         .optional('motherboard')
-      expect(r.motherboard.reason).toBe(
-        'Selected motherboard no longer matches the CPU socket',
-      )
-      expect(r.motherboard.reasons).toEqual([
-        'Selected motherboard no longer matches the CPU socket',
-      ])
+        .reason(
+          'motherboard',
+          'Selected motherboard no longer matches the CPU socket',
+        )
+        .reasons('motherboard', [
+          'Selected motherboard no longer matches the CPU socket',
+        ])
     })
 
     test('enabledWhenRead supports custom input selection', () => {
@@ -844,16 +847,16 @@ describe('@umpire/reads', () => {
         .unsatisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(pass.motherboard.reason).toBeNull()
-      expect(pass.motherboard.reasons).toEqual([])
+        .reason('motherboard', null)
+        .reasons('motherboard', [])
       const r = ump.check({}, {})
       checkAssert(r)
         .disabled('motherboard')
         .unsatisfied('motherboard')
         .fair('motherboard')
         .optional('motherboard')
-      expect(r.motherboard.reason).toBe('Pick a CPU first')
-      expect(r.motherboard.reasons).toEqual(['Pick a CPU first'])
+        .reason('motherboard', 'Pick a CPU first')
+        .reasons('motherboard', ['Pick a CPU first'])
     })
   })
 

--- a/packages/reads/__tests__/reads.test.ts
+++ b/packages/reads/__tests__/reads.test.ts
@@ -1,4 +1,5 @@
 import { field, umpire } from '@umpire/core'
+import { checkAssert } from '@umpire/testing'
 import {
   ReadInputType,
   createReads,
@@ -421,16 +422,14 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(ump.check({ cpu: 'am5', motherboard: 'am5' }).motherboard).toEqual(
-        {
-          enabled: true,
-          satisfied: true,
-          fair: true,
-          required: false,
-          reason: null,
-          reasons: [],
-        },
-      )
+      const pass = ump.check({ cpu: 'am5', motherboard: 'am5' })
+      checkAssert(pass)
+        .enabled('motherboard')
+        .satisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(pass.motherboard.reason).toBeNull()
+      expect(pass.motherboard.reasons).toEqual([])
     })
 
     test('fairWhenRead fails with the configured reason when the read returns false', () => {
@@ -449,16 +448,18 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(
-        ump.check({ cpu: 'am5', motherboard: 'lga1700' }).motherboard,
-      ).toEqual({
-        enabled: true,
-        satisfied: true,
-        fair: false,
-        required: false,
-        reason: 'Selected motherboard no longer matches the CPU socket',
-        reasons: ['Selected motherboard no longer matches the CPU socket'],
-      })
+      const r = ump.check({ cpu: 'am5', motherboard: 'lga1700' })
+      checkAssert(r)
+        .enabled('motherboard')
+        .satisfied('motherboard')
+        .foul('motherboard')
+        .optional('motherboard')
+      expect(r.motherboard.reason).toBe(
+        'Selected motherboard no longer matches the CPU socket',
+      )
+      expect(r.motherboard.reasons).toEqual([
+        'Selected motherboard no longer matches the CPU socket',
+      ])
     })
 
     test('fairWhenRead adds value read field dependencies to the umpire graph', () => {
@@ -598,24 +599,22 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(ump.check({ cpu: 'am5', motherboard: 'am5' }).motherboard).toEqual(
-        {
-          enabled: true,
-          satisfied: true,
-          fair: true,
-          required: false,
-          reason: null,
-          reasons: [],
-        },
-      )
-      expect(ump.check({ motherboard: 'am5' }).motherboard).toEqual({
-        enabled: false,
-        satisfied: true,
-        fair: true,
-        required: false,
-        reason: 'Pick a CPU first',
-        reasons: ['Pick a CPU first'],
-      })
+      const pass = ump.check({ cpu: 'am5', motherboard: 'am5' })
+      checkAssert(pass)
+        .enabled('motherboard')
+        .satisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(pass.motherboard.reason).toBeNull()
+      expect(pass.motherboard.reasons).toEqual([])
+      const r = ump.check({ motherboard: 'am5' })
+      checkAssert(r)
+        .disabled('motherboard')
+        .satisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(r.motherboard.reason).toBe('Pick a CPU first')
+      expect(r.motherboard.reasons).toEqual(['Pick a CPU first'])
     })
 
     test('enabledWhenRead adds value read field dependencies to the umpire graph', () => {
@@ -668,22 +667,22 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(ump.check({}, { allowMotherboard: true }).motherboard).toEqual({
-        enabled: true,
-        satisfied: false,
-        fair: true,
-        required: false,
-        reason: null,
-        reasons: [],
-      })
-      expect(ump.check({}, { allowMotherboard: false }).motherboard).toEqual({
-        enabled: false,
-        satisfied: false,
-        fair: true,
-        required: false,
-        reason: 'Pick a supported platform first',
-        reasons: ['Pick a supported platform first'],
-      })
+      const pass = ump.check({}, { allowMotherboard: true })
+      checkAssert(pass)
+        .enabled('motherboard')
+        .unsatisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(pass.motherboard.reason).toBeNull()
+      expect(pass.motherboard.reasons).toEqual([])
+      const r = ump.check({}, { allowMotherboard: false })
+      checkAssert(r)
+        .disabled('motherboard')
+        .unsatisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(r.motherboard.reason).toBe('Pick a supported platform first')
+      expect(r.motherboard.reasons).toEqual(['Pick a supported platform first'])
     })
 
     test('inputType CONDITIONS does not add read input fields to the umpire graph', () => {
@@ -737,30 +736,32 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(
-        ump.check({ motherboard: 'am5' }, { cpu: 'am5', motherboard: 'am5' })
-          .motherboard,
-      ).toEqual({
-        enabled: true,
-        satisfied: true,
-        fair: true,
-        required: false,
-        reason: null,
-        reasons: [],
-      })
-      expect(
-        ump.check(
-          { motherboard: 'lga1700' },
-          { cpu: 'am5', motherboard: 'lga1700' },
-        ).motherboard,
-      ).toEqual({
-        enabled: true,
-        satisfied: true,
-        fair: false,
-        required: false,
-        reason: 'Selected motherboard no longer matches the CPU socket',
-        reasons: ['Selected motherboard no longer matches the CPU socket'],
-      })
+      const pass = ump.check(
+        { motherboard: 'am5' },
+        { cpu: 'am5', motherboard: 'am5' },
+      )
+      checkAssert(pass)
+        .enabled('motherboard')
+        .satisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(pass.motherboard.reason).toBeNull()
+      expect(pass.motherboard.reasons).toEqual([])
+      const r = ump.check(
+        { motherboard: 'lga1700' },
+        { cpu: 'am5', motherboard: 'lga1700' },
+      )
+      checkAssert(r)
+        .enabled('motherboard')
+        .satisfied('motherboard')
+        .foul('motherboard')
+        .optional('motherboard')
+      expect(r.motherboard.reason).toBe(
+        'Selected motherboard no longer matches the CPU socket',
+      )
+      expect(r.motherboard.reasons).toEqual([
+        'Selected motherboard no longer matches the CPU socket',
+      ])
     })
 
     test('fairWhenRead supports custom input selection', () => {
@@ -789,26 +790,26 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(
-        ump.check({ motherboard: 'am5' }, { cpu: 'am5' }).motherboard,
-      ).toEqual({
-        enabled: true,
-        satisfied: true,
-        fair: true,
-        required: false,
-        reason: null,
-        reasons: [],
-      })
-      expect(
-        ump.check({ motherboard: 'lga1700' }, { cpu: 'am5' }).motherboard,
-      ).toEqual({
-        enabled: true,
-        satisfied: true,
-        fair: false,
-        required: false,
-        reason: 'Selected motherboard no longer matches the CPU socket',
-        reasons: ['Selected motherboard no longer matches the CPU socket'],
-      })
+      const pass = ump.check({ motherboard: 'am5' }, { cpu: 'am5' })
+      checkAssert(pass)
+        .enabled('motherboard')
+        .satisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(pass.motherboard.reason).toBeNull()
+      expect(pass.motherboard.reasons).toEqual([])
+      const r = ump.check({ motherboard: 'lga1700' }, { cpu: 'am5' })
+      checkAssert(r)
+        .enabled('motherboard')
+        .satisfied('motherboard')
+        .foul('motherboard')
+        .optional('motherboard')
+      expect(r.motherboard.reason).toBe(
+        'Selected motherboard no longer matches the CPU socket',
+      )
+      expect(r.motherboard.reasons).toEqual([
+        'Selected motherboard no longer matches the CPU socket',
+      ])
     })
 
     test('enabledWhenRead supports custom input selection', () => {
@@ -837,22 +838,22 @@ describe('@umpire/reads', () => {
         ],
       })
 
-      expect(ump.check({}, { selectedCpu: 'am5' }).motherboard).toEqual({
-        enabled: true,
-        satisfied: false,
-        fair: true,
-        required: false,
-        reason: null,
-        reasons: [],
-      })
-      expect(ump.check({}, {}).motherboard).toEqual({
-        enabled: false,
-        satisfied: false,
-        fair: true,
-        required: false,
-        reason: 'Pick a CPU first',
-        reasons: ['Pick a CPU first'],
-      })
+      const pass = ump.check({}, { selectedCpu: 'am5' })
+      checkAssert(pass)
+        .enabled('motherboard')
+        .unsatisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(pass.motherboard.reason).toBeNull()
+      expect(pass.motherboard.reasons).toEqual([])
+      const r = ump.check({}, {})
+      checkAssert(r)
+        .disabled('motherboard')
+        .unsatisfied('motherboard')
+        .fair('motherboard')
+        .optional('motherboard')
+      expect(r.motherboard.reason).toBe('Pick a CPU first')
+      expect(r.motherboard.reasons).toEqual(['Pick a CPU first'])
     })
   })
 

--- a/packages/reads/package.json
+++ b/packages/reads/package.json
@@ -27,6 +27,9 @@
   "dependencies": {
     "@umpire/core": "workspace:^"
   },
+  "devDependencies": {
+    "@umpire/testing": "workspace:^"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sdougbrown/umpire.git",

--- a/packages/reads/tsconfig.json
+++ b/packages/reads/tsconfig.json
@@ -6,7 +6,8 @@
     "composite": true,
     "paths": {
       "@umpire/core": ["../core/src/index.ts"],
-      "@umpire/core/*": ["../core/src/*"]
+      "@umpire/core/*": ["../core/src/*"],
+      "@umpire/testing": ["../testing/src/index.ts"]
     }
   },
   "include": ["src"],

--- a/packages/testing/__tests__/check-assert.test.ts
+++ b/packages/testing/__tests__/check-assert.test.ts
@@ -195,6 +195,11 @@ describe('checkAssert', () => {
       )
     })
 
+    test('passes when the field has no reason and null is expected', () => {
+      const result = ump.check({ gate: 'open' })
+      expect(() => checkAssert(result).reason('gate', null)).not.toThrow()
+    })
+
     test('throws for unknown field', () => {
       const result = ump.check({})
       expect(() =>

--- a/packages/testing/__tests__/check-assert.test.ts
+++ b/packages/testing/__tests__/check-assert.test.ts
@@ -171,6 +171,82 @@ describe('checkAssert', () => {
     })
   })
 
+  describe('.reason()', () => {
+    test('passes when the reason matches', () => {
+      const result = ump.check({})
+      expect(() =>
+        checkAssert(result).reason('guarded', 'requires gate'),
+      ).not.toThrow()
+    })
+
+    test('throws when the reason differs', () => {
+      const result = ump.check({})
+      expect(() =>
+        checkAssert(result).reason('guarded', 'wrong reason'),
+      ).toThrow(
+        'checkAssert: expected "guarded" reason to be "wrong reason" — was "requires gate"',
+      )
+    })
+
+    test('throws when the field has no reason but expected a string', () => {
+      const result = ump.check({ gate: 'open' })
+      expect(() => checkAssert(result).reason('gate', 'some reason')).toThrow(
+        'checkAssert: expected "gate" reason to be "some reason" — was null',
+      )
+    })
+
+    test('throws for unknown field', () => {
+      const result = ump.check({})
+      expect(() =>
+        checkAssert(result).reason('nonexistent' as 'gate', 'foo'),
+      ).toThrow('checkAssert: unknown field "nonexistent"')
+    })
+  })
+
+  describe('.reasons()', () => {
+    function multiReasonUmp() {
+      return umpire({
+        fields: { a: {}, b: {}, c: {} },
+        rules: [requires('c', 'a'), requires('c', 'b')],
+      })
+    }
+
+    test('passes when the reasons array matches', () => {
+      const result = multiReasonUmp().check({})
+      expect(() =>
+        checkAssert(result).reasons('c', ['requires a', 'requires b']),
+      ).not.toThrow()
+    })
+
+    test('throws when the reasons array has different length', () => {
+      const result = multiReasonUmp().check({})
+      expect(() => checkAssert(result).reasons('c', ['requires a'])).toThrow(
+        'checkAssert: expected "c" reasons to be ["requires a"] — was ["requires a","requires b"]',
+      )
+    })
+
+    test('throws when the reasons array has different elements', () => {
+      const result = multiReasonUmp().check({})
+      expect(() =>
+        checkAssert(result).reasons('c', ['requires x', 'requires y']),
+      ).toThrow(
+        'checkAssert: expected "c" reasons to be ["requires x","requires y"] — was ["requires a","requires b"]',
+      )
+    })
+
+    test('passes with empty reasons when field has no failing rules', () => {
+      const result = ump.check({ gate: 'open' })
+      expect(() => checkAssert(result).reasons('gate', [])).not.toThrow()
+    })
+
+    test('throws for unknown field', () => {
+      const result = ump.check({})
+      expect(() =>
+        checkAssert(result).reasons('nonexistent' as 'gate', []),
+      ).toThrow('checkAssert: unknown field "nonexistent"')
+    })
+  })
+
   describe('chaining', () => {
     test('multiple assertions can be chained on a single result', () => {
       const result = ump.check({ gate: 'open', flagged: 'good' })
@@ -180,6 +256,16 @@ describe('checkAssert', () => {
           .fair('flagged')
           .optional('gate')
           .required('pinned'),
+      ).not.toThrow()
+    })
+
+    test('reason and reasons can be chained with other assertions', () => {
+      const result = ump.check({})
+      expect(() =>
+        checkAssert(result)
+          .disabled('guarded')
+          .reason('guarded', 'requires gate')
+          .reasons('guarded', ['requires gate']),
       ).not.toThrow()
     })
   })

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -17,7 +17,8 @@ export type CheckAssertChain<K extends string> = {
   optional(...fields: K[]): CheckAssertChain<K>
   satisfied(...fields: K[]): CheckAssertChain<K>
   unsatisfied(...fields: K[]): CheckAssertChain<K>
-  reason(field: K, expected: string): CheckAssertChain<K>
+  reason(field: K, expected: string | null): CheckAssertChain<K>
+  /** Asserts the exact reasons array, including order. */
   reasons(field: K, expected: string[]): CheckAssertChain<K>
 }
 
@@ -251,7 +252,7 @@ export function checkAssert<K extends string>(
       )
       return chain
     },
-    reason(field, expected) {
+    reason(field, expected: string | null) {
       const status = result[field]
 
       if (status === undefined) {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -17,6 +17,8 @@ export type CheckAssertChain<K extends string> = {
   optional(...fields: K[]): CheckAssertChain<K>
   satisfied(...fields: K[]): CheckAssertChain<K>
   unsatisfied(...fields: K[]): CheckAssertChain<K>
+  reason(field: K, expected: string): CheckAssertChain<K>
+  reasons(field: K, expected: string[]): CheckAssertChain<K>
 }
 
 export type ScorecardAssertChain<K extends string> = {
@@ -247,6 +249,39 @@ export function checkAssert<K extends string>(
         'unsatisfied',
         () => 'was satisfied (has a value)',
       )
+      return chain
+    },
+    reason(field, expected) {
+      const status = result[field]
+
+      if (status === undefined) {
+        throw new Error(`checkAssert: unknown field "${field}"`)
+      }
+
+      if (status.reason !== expected) {
+        throw new Error(
+          `checkAssert: expected "${field}" reason to be ${JSON.stringify(expected)} — was ${JSON.stringify(status.reason)}`,
+        )
+      }
+
+      return chain
+    },
+    reasons(field, expected) {
+      const status = result[field]
+
+      if (status === undefined) {
+        throw new Error(`checkAssert: unknown field "${field}"`)
+      }
+
+      if (
+        status.reasons.length !== expected.length ||
+        !expected.every((r, i) => r === status.reasons[i])
+      ) {
+        throw new Error(
+          `checkAssert: expected "${field}" reasons to be ${JSON.stringify(expected)} — was ${JSON.stringify(status.reasons)}`,
+        )
+      }
+
       return chain
     },
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,6 +1842,7 @@ __metadata:
   resolution: "@umpire/drizzle@workspace:packages/drizzle"
   dependencies:
     "@umpire/core": "workspace:^"
+    "@umpire/testing": "workspace:^"
     "@umpire/write": "workspace:^"
     drizzle-orm: "npm:1.0.0-rc.1"
   peerDependencies:
@@ -1903,6 +1904,7 @@ __metadata:
     "@umpire/reads": "workspace:^"
     "@umpire/signals": "workspace:^"
     "@umpire/store": "workspace:^"
+    "@umpire/testing": "workspace:^"
     "@umpire/zod": "workspace:^"
     bun-types: "npm:^1.3.12"
     drizzle-orm: "npm:1.0.0-rc.1"
@@ -1957,6 +1959,7 @@ __metadata:
   resolution: "@umpire/reads@workspace:packages/reads"
   dependencies:
     "@umpire/core": "workspace:^"
+    "@umpire/testing": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -2037,7 +2040,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@umpire/testing@workspace:packages/testing":
+"@umpire/testing@workspace:^, @umpire/testing@workspace:packages/testing":
   version: 0.0.0-use.local
   resolution: "@umpire/testing@workspace:packages/testing"
   peerDependencies:


### PR DESCRIPTION
## Summary

- Adds `.reason(field, expected)` and `.reasons(field, expectedArray)` to `@umpire/testing`'s `checkAssert()` — uncovered by dogfooding real availability assertions in Umpire's own package tests
- Dogfoods `checkAssert()` in `@umpire/reads`, `@umpire/integration-tests`, and `@umpire/drizzle` — converting verbose full-object availability assertions to readable domain-language chains
- Core is intentionally excluded to avoid a circular dep

## Why

`checkAssert()` was designed to make availability assertions read like domain language:

```ts
checkAssert(ump.check(values))
  .enabled('details')
  .foul('password')
  .optional('referralCode')
```

Dogfooding it surfaced that it was missing `.reason()` and `.reasons()` — forcing test authors to fall back to manual `expect(...reason...)` assertions after every `checkAssert()` chain. This PR fills that gap.

## Changes

### Runtime (ships)

**`@umpire/testing`** — `minor`
- `checkAssert().reason(field, expected)` — asserts the primary reason string matches
- `checkAssert().reasons(field, expected)` — asserts the exact reasons array matches
- Both throw descriptive errors with actual vs expected on mismatch
- Unknown field names throw immediately (consistent with existing API)

### Dogfooding (test-only)

| Package | What |
|---|---|
| `@umpire/reads` | 12 full-object availability assertions → `checkAssert()` chains (+ explicit reason checks) |
| `@umpire/integration-tests` | 3 availability assertions → `checkAssert()` chains with `.reason()`, `.disabled()`, `.enabled()` |
| `@umpire/drizzle` | 2 `expect.objectContaining` assertions → `checkAssert()` chains with `.reason()` |