### PR TITLE
⚡️ Improve @umpire/core hot-path performance

### DIFF
--- a/.changeset/fast-rules-frame.md
+++ b/.changeset/fast-rules-frame.md
@@ -1,0 +1,5 @@
+---
+'@umpire/core': patch
+---
+
+Improves `check()` and `play()` performance by routing built-in rule evaluation through direct per-target evaluators, including inside composite `anyOf()` and `eitherOf()` rules. Adds memory and leak benchmark modes for core performance investigation.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 docs/.yarn/
 coverage/
 coverage-istanbul/
+packages/core/benchmark-profiles/
 reports/
 .stryker-tmp/
 .pack-agent-compat-state.json

--- a/packages/core/BENCHMARKS.md
+++ b/packages/core/BENCHMARKS.md
@@ -30,7 +30,10 @@ regress or look noisy. `bench:leak` repeatedly runs the `check()` and `play()`
 hot-path scenarios in batches, forces GC between batches, and reports retained
 heap/object trends from the same compiled engines. Use it to distinguish stable
 long-lived fixture memory from leak-shaped per-call retained growth. By default
-it warms each scenario for 100 calls, then measures 20 batches of 1000 calls.
+it warms each scenario for 100 calls, then measures 20 batches of 1000 calls
+over a prebuilt ring of 16 input objects. Set `BENCH_LEAK_ROTATE_INPUTS=0` to
+reuse one fixed input per scenario, or `BENCH_LEAK_INPUTS=<n>` to change the
+ring size.
 `bench:profile` enables Bun's markdown heap profiler, writes a heap snapshot
 under `packages/core/benchmark-profiles/`, and prints mimalloc native heap stats
 on exit. Use it when a scenario needs deeper allocation attribution.

--- a/packages/core/BENCHMARKS.md
+++ b/packages/core/BENCHMARKS.md
@@ -10,11 +10,19 @@ yarn workspace @umpire/core bench
 
 The benchmark script lives at `packages/core/scripts/benchmark.mjs` and builds the package before running.
 
-The normal benchmark output includes lightweight retained JavaScript heap
-deltas. Each measured run forces a synchronous Bun GC before and after the timed
-loop, then reports average retained `heapSize` and object-count deltas from
-`bun:jsc` `heapStats()`. These columns are a progress signal, not a precise
-allocation counter; short-lived allocation churn can still be hidden by GC.
+The normal benchmark output is timing-only by default so the common benchmark
+path does not force GC inside the measured flow. To include lightweight retained
+JavaScript heap deltas in the normal table, run:
+
+```bash
+BENCH_MEMORY=1 yarn workspace @umpire/core bench
+```
+
+When `BENCH_MEMORY=1` is set, each measured run forces a synchronous Bun GC
+before and after the timed loop, then reports average retained `heapSize` and
+object-count deltas from `bun:jsc` `heapStats()`. These columns are a progress
+signal, not a precise allocation counter; short-lived allocation churn can still
+be hidden by GC.
 
 For investigation mode, run:
 
@@ -24,16 +32,19 @@ yarn workspace @umpire/core bench:leak
 yarn workspace @umpire/core bench:profile
 ```
 
-`bench:memory` measures each scenario in isolated Bun child processes and
-summarizes median and p95 heap/object deltas. Use it when the normal heap deltas
-regress or look noisy. `bench:leak` repeatedly runs the `check()` and `play()`
-hot-path scenarios in batches, forces GC between batches, and reports retained
-heap/object trends from the same compiled engines. Use it to distinguish stable
-long-lived fixture memory from leak-shaped per-call retained growth. By default
-it warms each scenario for 100 calls, then measures 20 batches of 1000 calls
-over a prebuilt ring of 16 input objects. Set `BENCH_LEAK_ROTATE_INPUTS=0` to
-reuse one fixed input per scenario, or `BENCH_LEAK_INPUTS=<n>` to change the
-ring size.
+`bench:memory` enables memory collection, measures each scenario in isolated Bun
+child processes, and summarizes median and p95 heap/object deltas. Use it when
+normal benchmark timing regresses or allocation behavior looks suspicious.
+`bench:leak` enables memory collection, repeatedly runs the `check()` and
+`play()` hot-path scenarios in batches, forces GC between batches, and reports
+retained heap/object trends from the same compiled engines. Use it to
+distinguish stable long-lived fixture memory from leak-shaped per-call retained
+growth. By default it warms each scenario for 100 calls, then measures 20
+batches of 1000 calls over a prebuilt ring of 16 input objects. Set
+`BENCH_LEAK_ROTATE_INPUTS=0` to reuse one fixed input per scenario, or
+`BENCH_LEAK_INPUTS=<n>` to change the ring size. Leak-specific `BENCH_LEAK_*`
+environment variables are ignored, with a warning, unless `BENCH_LEAK=1` is
+also set.
 `bench:profile` enables Bun's markdown heap profiler, writes a heap snapshot
 under `packages/core/benchmark-profiles/`, and prints mimalloc native heap stats
 on exit. Use it when a scenario needs deeper allocation attribution.

--- a/packages/core/BENCHMARKS.md
+++ b/packages/core/BENCHMARKS.md
@@ -20,15 +20,20 @@ For investigation mode, run:
 
 ```bash
 yarn workspace @umpire/core bench:memory
+yarn workspace @umpire/core bench:leak
 yarn workspace @umpire/core bench:profile
 ```
 
 `bench:memory` measures each scenario in isolated Bun child processes and
 summarizes median and p95 heap/object deltas. Use it when the normal heap deltas
-regress or look noisy. `bench:profile` enables Bun's markdown heap profiler,
-writes a heap snapshot under `packages/core/benchmark-profiles/`, and prints
-mimalloc native heap stats on exit. Use it when a scenario needs deeper
-allocation attribution.
+regress or look noisy. `bench:leak` repeatedly runs the `check()` and `play()`
+hot-path scenarios in batches, forces GC between batches, and reports retained
+heap/object trends from the same compiled engines. Use it to distinguish stable
+long-lived fixture memory from leak-shaped per-call retained growth. By default
+it warms each scenario for 100 calls, then measures 20 batches of 1000 calls.
+`bench:profile` enables Bun's markdown heap profiler, writes a heap snapshot
+under `packages/core/benchmark-profiles/`, and prints mimalloc native heap stats
+on exit. Use it when a scenario needs deeper allocation attribution.
 
 ## Baseline
 

--- a/packages/core/BENCHMARKS.md
+++ b/packages/core/BENCHMARKS.md
@@ -10,6 +10,23 @@ yarn workspace @umpire/core bench
 
 The benchmark script lives at `packages/core/scripts/benchmark.mjs` and builds the package before running.
 
+The normal benchmark output includes lightweight retained JavaScript heap
+deltas. Each measured run forces a synchronous Bun GC before and after the timed
+loop, then reports average retained `heapSize` and object-count deltas from
+`bun:jsc` `heapStats()`. These columns are a progress signal, not a precise
+allocation counter; short-lived allocation churn can still be hidden by GC.
+
+For investigation mode, run:
+
+```bash
+yarn workspace @umpire/core bench:profile
+```
+
+That enables Bun's markdown heap profiler, writes a heap snapshot under
+`packages/core/benchmark-profiles/`, and prints mimalloc native heap stats on
+exit. Use it when the normal heap deltas regress or a benchmark needs deeper
+allocation attribution.
+
 ## Baseline
 
 Observed on April 3, 2026 from a local development run.

--- a/packages/core/BENCHMARKS.md
+++ b/packages/core/BENCHMARKS.md
@@ -19,12 +19,15 @@ allocation counter; short-lived allocation churn can still be hidden by GC.
 For investigation mode, run:
 
 ```bash
+yarn workspace @umpire/core bench:memory
 yarn workspace @umpire/core bench:profile
 ```
 
-That enables Bun's markdown heap profiler, writes a heap snapshot under
-`packages/core/benchmark-profiles/`, and prints mimalloc native heap stats on
-exit. Use it when the normal heap deltas regress or a benchmark needs deeper
+`bench:memory` measures each scenario in isolated Bun child processes and
+summarizes median and p95 heap/object deltas. Use it when the normal heap deltas
+regress or look noisy. `bench:profile` enables Bun's markdown heap profiler,
+writes a heap snapshot under `packages/core/benchmark-profiles/`, and prints
+mimalloc native heap stats on exit. Use it when a scenario needs deeper
 allocation attribution.
 
 ## Baseline

--- a/packages/core/__tests__/challenge.test.ts
+++ b/packages/core/__tests__/challenge.test.ts
@@ -109,6 +109,170 @@ describe('challenge', () => {
     ])
   })
 
+  test('evaluates single trace attachments in challenge output', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        requires('submit', 'email', {
+          trace: {
+            kind: 'read',
+            id: 'emailRequirement',
+            label: 'email requirement',
+            inspect(values) {
+              return {
+                label: 'email requirement',
+                reason: values.email ? 'email present' : 'email missing',
+              }
+            },
+          },
+        }),
+      ],
+    })
+
+    expect(ump.challenge('submit', {}).directReasons[0]?.trace).toEqual([
+      {
+        kind: 'read',
+        id: 'emailRequirement',
+        label: 'email requirement',
+        reason: 'email missing',
+      },
+    ])
+  })
+
+  test('evaluates array trace attachments in challenge output', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        requires('submit', 'email', {
+          trace: [
+            {
+              kind: 'read',
+              id: 'emailPresent',
+              inspect(values) {
+                return { value: Boolean(values.email) }
+              },
+            },
+          ],
+        }),
+      ],
+    })
+
+    expect(ump.challenge('submit', {}).directReasons[0]?.trace).toEqual([
+      {
+        kind: 'read',
+        id: 'emailPresent',
+        value: false,
+      },
+    ])
+  })
+
+  test('describes predicate-backed disables and requires dependencies', () => {
+    const blocked = (values: Partial<TestFields>) => values.email === 'stop'
+    const hasCaptcha = check<TestFields, TestConditions>('password', (value) =>
+      Boolean(value),
+    )
+    const ump = umpire<TestFields, TestConditions>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        disables<TestFields, TestConditions>(blocked, ['submit']),
+        requires<TestFields, TestConditions>('submit', hasCaptcha),
+      ],
+    })
+
+    expect(ump.challenge('submit', { email: 'stop' }).directReasons).toEqual([
+      expect.objectContaining({
+        rule: 'disables',
+        source: expect.stringContaining('values.email'),
+        sourceValue: true,
+      }),
+      expect.objectContaining({
+        rule: 'requires',
+        dependency: 'password',
+        dependencyValue: undefined,
+      }),
+    ])
+  })
+
+  test('describes predicate-only requires dependencies without a field value', () => {
+    const hasCaptcha = (
+      _values: Partial<TestFields>,
+      conditions: TestConditions,
+    ) => Boolean(conditions.captchaToken)
+    const ump = umpire<TestFields, TestConditions>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [requires<TestFields, TestConditions>('submit', hasCaptcha)],
+    })
+
+    expect(ump.challenge('submit', {}).directReasons).toEqual([
+      expect.objectContaining({
+        rule: 'requires',
+        dependency: expect.stringContaining('conditions.captchaToken'),
+        dependencyValue: undefined,
+      }),
+    ])
+  })
+
+  test('does not duplicate transitive dependencies reached through multiple failed rules', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        requires('submit', 'email'),
+        requires('submit', 'email', { reason: 'still needs email' }),
+        requires('email', 'password'),
+      ],
+    })
+
+    expect(ump.challenge('submit', {}).transitiveDeps).toEqual([
+      expect.objectContaining({ field: 'email' }),
+      expect.objectContaining({ field: 'password' }),
+    ])
+  })
+
   test('exposes undefined inspection for uninspectable rules', () => {
     const opaqueRule: Rule<TestFields> = {
       type: 'opaque',
@@ -366,6 +530,42 @@ describe('challenge', () => {
         reason: 'overridden by dates',
       }),
     ])
+  })
+
+  test('stops transitive dependency collection when anyOf and requires rules pass', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        email: {},
+        password: {},
+        submit: {},
+        dates: {},
+        startTime: {},
+        endTime: {},
+        everyHour: {},
+        repeatEvery: {},
+      },
+      rules: [
+        anyOf<TestFields>(
+          requires('password', 'email'),
+          enabledWhen('password', () => false, { reason: 'fallback failed' }),
+        ),
+        requires<TestFields>('submit', 'password'),
+      ],
+    })
+
+    expect(
+      ump.challenge('password', {
+        email: 'reader@example.com',
+        password: 'secret',
+      }).transitiveDeps,
+    ).toEqual([])
+    expect(
+      ump.challenge('submit', {
+        email: 'reader@example.com',
+        password: 'secret',
+        submit: true,
+      }).transitiveDeps,
+    ).toEqual([])
   })
 
   test('reports oneOf resolution state', () => {
@@ -948,6 +1148,39 @@ describe('challenge', () => {
             ],
           },
         ],
+      }),
+    ])
+  })
+
+  test('omits trace attachments whose inspector returns nothing', () => {
+    const ump = umpire<{
+      cpu: {}
+      motherboard: {}
+    }>({
+      fields: {
+        cpu: {},
+        motherboard: {},
+      },
+      rules: [
+        fairWhen('motherboard', (value, values) => value === values.cpu, {
+          reason: 'Selected motherboard no longer matches the CPU socket',
+          trace: {
+            kind: 'read',
+            id: 'motherboardFair',
+            inspect: () => undefined,
+          },
+        }),
+      ],
+    })
+
+    expect(
+      ump.challenge('motherboard', {
+        cpu: 'amd-r7',
+        motherboard: 'intel-z790',
+      }).directReasons,
+    ).toEqual([
+      expect.not.objectContaining({
+        trace: expect.anything(),
       }),
     ])
   })

--- a/packages/core/__tests__/check.test.ts
+++ b/packages/core/__tests__/check.test.ts
@@ -5,6 +5,7 @@ import {
   defineRule,
   eitherOf,
   enabledWhen,
+  fairWhen,
   requires,
 } from '../src/rules.js'
 import type { AvailabilityMap, Rule } from '../src/types.js'
@@ -192,6 +193,41 @@ describe('evaluate', () => {
     })
   })
 
+  test('requires fails when dependencies are disabled or fouled in compiled evaluation', () => {
+    const fields: TestFields = {
+      alpha: {},
+      beta: {},
+      gamma: {},
+      delta: {},
+    }
+    const rules = [
+      enabledWhen<TestFields, TestConditions>('beta', () => false, {
+        reason: 'beta closed',
+      }),
+      fairWhen<TestFields, TestConditions>('gamma', () => false, {
+        reason: 'gamma fouled',
+      }),
+      requires<TestFields, TestConditions>('alpha', 'beta', 'gamma'),
+    ]
+    const topoOrder = createOrder(fields, rules)
+    const result = evaluate(
+      fields,
+      rules,
+      topoOrder,
+      { beta: 'set', gamma: 'set' },
+      {} as TestConditions,
+    )
+
+    expect(result.alpha).toEqual({
+      enabled: false,
+      satisfied: false,
+      fair: true,
+      required: false,
+      reason: 'requires beta',
+      reasons: ['requires beta', 'requires gamma'],
+    })
+  })
+
   test('treats fair custom rules as fairness checks instead of gate rules', () => {
     const fields: TestFields = {
       alpha: {},
@@ -339,6 +375,7 @@ describe('evaluate', () => {
         undefined,
         {},
         new Map(),
+        true,
       ),
     ).toEqual({
       enabled: true,
@@ -387,6 +424,7 @@ describe('evaluate', () => {
         undefined,
         {},
         new Map(),
+        true,
       ),
     ).toEqual({
       enabled: true,
@@ -491,6 +529,7 @@ describe('evaluate', () => {
         undefined,
         {},
         new Map(),
+        true,
       ),
     ).toEqual({
       enabled: true,

--- a/packages/core/__tests__/edge-cases.test.ts
+++ b/packages/core/__tests__/edge-cases.test.ts
@@ -288,6 +288,20 @@ describe('edge cases', () => {
     ).not.toThrow()
   })
 
+  test('does not treat predicate-only requires dependencies as structural requirements', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        alpha: {},
+        beta: {},
+        gamma: {},
+        delta: {},
+      },
+      rules: [requires<TestFields>('alpha', () => true)],
+    })
+
+    expect(ump.check({}).alpha.enabled).toBe(true)
+  })
+
   test('does not reject dynamic oneOf branches with an activeBranch function', () => {
     expect(() =>
       umpire<TestFields>({
@@ -336,6 +350,27 @@ describe('edge cases', () => {
             },
           ),
           requires<TestFields, { mode: string }>('alpha', 'beta'),
+        ],
+      }),
+    ).not.toThrow()
+  })
+
+  test('allows structural requirements inside a static oneOf branch or outside the group', () => {
+    expect(() =>
+      umpire<TestFields>({
+        fields: {
+          alpha: {},
+          beta: {},
+          gamma: {},
+          delta: {},
+        },
+        rules: [
+          oneOf<TestFields>('mode', {
+            first: ['alpha', 'beta'],
+            second: ['gamma'],
+          }),
+          requires<TestFields>('alpha', 'beta'),
+          requires<TestFields>('delta', 'beta'),
         ],
       }),
     ).not.toThrow()

--- a/packages/core/__tests__/field.test.ts
+++ b/packages/core/__tests__/field.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test'
+import { field, getFieldBuilderName } from '../src/field.js'
+
+describe('field helpers', () => {
+  test('returns a field builder name only for string metadata', () => {
+    expect(getFieldBuilderName(field('alpha'))).toBe('alpha')
+    expect(getFieldBuilderName({ __umpfield: 123 })).toBeUndefined()
+    expect(getFieldBuilderName(null)).toBeUndefined()
+  })
+})

--- a/packages/core/__tests__/graph.test.ts
+++ b/packages/core/__tests__/graph.test.ts
@@ -548,6 +548,42 @@ describe('graph utilities', () => {
     expect(topologicalSort(graph, ['alpha', 'beta'])).toEqual(['alpha', 'beta'])
   })
 
+  test('topologicalSort treats missing ordering bookkeeping as empty', () => {
+    const graph = {
+      nodes: ['alpha'],
+      edges: [],
+      adjacency: new Map<string, string[]>(),
+      incomingCounts: new Map<string, number>(),
+      deferredEdgeGroups: [],
+    }
+
+    expect(topologicalSort(graph, ['alpha'])).toEqual(['alpha'])
+  })
+
+  test('topologicalSort handles missing incoming counts for queued and adjacent nodes', () => {
+    const graph = {
+      adjacency: new Map([['alpha', new Set(['beta'])]]),
+      incomingCounts: new Map<string, number>(),
+      orderingAdjacency: new Map<string, Set<string>>(),
+      orderingIncomingCounts: new Map<string, number>(),
+      edges: [],
+    }
+
+    expect(topologicalSort(graph, ['alpha', 'beta'])).toEqual(['alpha', 'beta'])
+  })
+
+  test('topologicalSort tolerates adjacency entries outside the requested fields', () => {
+    const graph = {
+      adjacency: new Map([['alpha', new Set(['beta'])]]),
+      incomingCounts: new Map([['alpha', 0]]),
+      orderingAdjacency: new Map<string, Set<string>>(),
+      orderingIncomingCounts: new Map<string, number>(),
+      edges: [],
+    }
+
+    expect(topologicalSort(graph, ['alpha'])).toEqual(['alpha'])
+  })
+
   test('exportGraph deduplicates repeated raw edges', () => {
     expect(
       exportGraph({

--- a/packages/core/__tests__/guards.test.ts
+++ b/packages/core/__tests__/guards.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test'
+import { isObjectLike, isPlainRecord, isRecord } from '../src/guards.js'
+
+describe('guards', () => {
+  test('detects records', () => {
+    expect(isRecord({ alpha: true })).toBe(true)
+    expect(isRecord(null)).toBe(false)
+    expect(isRecord('alpha')).toBe(false)
+  })
+
+  test('detects object-like values', () => {
+    expect(isObjectLike({ alpha: true })).toBe(true)
+    expect(isObjectLike(() => true)).toBe(true)
+    expect(isObjectLike(null)).toBe(false)
+  })
+
+  test('detects plain records without accepting arrays', () => {
+    expect(isPlainRecord({ alpha: true })).toBe(true)
+    expect(isPlainRecord(['alpha'])).toBe(false)
+    expect(isPlainRecord(null)).toBe(false)
+  })
+})

--- a/packages/core/__tests__/play.test.ts
+++ b/packages/core/__tests__/play.test.ts
@@ -1,4 +1,4 @@
-import { enabledWhen, fairWhen } from '../src/rules.js'
+import { defineRule, enabledWhen, fairWhen } from '../src/rules.js'
 import { umpire } from '../src/umpire.js'
 
 type TestFields = {
@@ -122,6 +122,86 @@ describe('play', () => {
       {
         field: 'dependent',
         reason: 'condition not met',
+        suggestedValue: undefined,
+      },
+    ])
+  })
+
+  test('uses the disabled fallback reason when a silent rule disables a field', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        toggle: {},
+        dependent: {},
+        other: {},
+      },
+      rules: [
+        defineRule<TestFields>({
+          type: 'silent-disable',
+          targets: ['dependent'],
+          evaluate: (values) =>
+            new Map([
+              [
+                'dependent',
+                {
+                  enabled: values.toggle === true,
+                  reason: null,
+                },
+              ],
+            ]),
+        }),
+      ],
+    })
+
+    expect(
+      ump.play(
+        { values: { toggle: true, dependent: 'keep me' } },
+        { values: { toggle: false, dependent: 'keep me' } },
+      ),
+    ).toEqual([
+      {
+        field: 'dependent',
+        reason: 'field disabled',
+        suggestedValue: undefined,
+      },
+    ])
+  })
+
+  test('uses the fouled fallback reason when a silent fair rule fouls a field', () => {
+    const ump = umpire<TestFields>({
+      fields: {
+        toggle: {},
+        dependent: {},
+        other: {},
+      },
+      rules: [
+        defineRule<TestFields>({
+          type: 'silent-fair',
+          constraint: 'fair',
+          targets: ['dependent'],
+          evaluate: (values) =>
+            new Map([
+              [
+                'dependent',
+                {
+                  enabled: true,
+                  fair: values.toggle === true,
+                  reason: null,
+                },
+              ],
+            ]),
+        }),
+      ],
+    })
+
+    expect(
+      ump.play(
+        { values: { toggle: true, dependent: 'keep me' } },
+        { values: { toggle: false, dependent: 'keep me' } },
+      ),
+    ).toEqual([
+      {
+        field: 'dependent',
+        reason: 'field fouled',
         suggestedValue: undefined,
       },
     ])

--- a/packages/core/__tests__/rules.test.ts
+++ b/packages/core/__tests__/rules.test.ts
@@ -15,6 +15,7 @@ import {
   getInternalRuleOptions,
   getNamedCheckMetadata,
   getRuleConstraint,
+  isGateRule,
   inspectPredicate,
   inspectRule,
   oneOf,
@@ -1006,6 +1007,24 @@ describe('defineRule', () => {
       enabled: false,
       reason: 'custom blocked',
     })
+  })
+
+  test('classifies non-fair rules as gate rules', () => {
+    const gateRule = defineRule<TestFields>({
+      type: 'gate',
+      targets: ['alpha'],
+      evaluate: () => new Map([['alpha', { enabled: true, reason: null }]]),
+    })
+    const fairRule = defineRule<TestFields>({
+      type: 'fair',
+      targets: ['alpha'],
+      constraint: 'fair',
+      evaluate: () =>
+        new Map([['alpha', { enabled: true, fair: true, reason: null }]]),
+    })
+
+    expect(isGateRule(gateRule)).toBe(true)
+    expect(isGateRule(fairRule)).toBe(false)
   })
 
   test('lets anyOf combine fair custom rules when constraint is fair', () => {

--- a/packages/core/__tests__/validation.test.ts
+++ b/packages/core/__tests__/validation.test.ts
@@ -25,6 +25,13 @@ describe('surface validation metadata', () => {
       validate: expect.any(Function),
       error: 'Bad value',
     })
+    expect(
+      normalizeValidationEntry({
+        validator: (value: string) => value.length > 0,
+      }),
+    ).toMatchObject({
+      validate: expect.any(Function),
+    })
     expect(normalizeValidationEntry({ validator: { nope: true } })).toBeNull()
   })
 
@@ -236,6 +243,30 @@ describe('surface validation metadata', () => {
       })
       expect(warn).toHaveBeenCalledTimes(1)
     } finally {
+      warn.mockRestore()
+    }
+  })
+
+  test('does not warn in production for unsupported validation results', () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+    const previousEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+
+    try {
+      const ump = umpire({
+        fields: {
+          username: { required: true, isEmpty: (value: unknown) => !value },
+        },
+        rules: [],
+        validators: {
+          username: (() => undefined) as never,
+        },
+      })
+
+      expect(ump.check({ username: 'doug' }).username.valid).toBe(false)
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = previousEnv
       warn.mockRestore()
     }
   })

--- a/packages/core/bunfig.toml
+++ b/packages/core/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+coverageSkipTestFiles = true
+coveragePathIgnorePatterns = ["scripts/**", "**/scripts/**"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && tsdown",
     "bench": "yarn build && bun ./scripts/benchmark.mjs",
     "bench:memory": "yarn build && BENCH_ISOLATED_MEMORY=1 bun ./scripts/benchmark.mjs",
-    "bench:leak": "yarn build && BENCH_LEAK=1 bun ./scripts/benchmark.mjs",
+    "bench:leak": "yarn build && BENCH_MEMORY=1 BENCH_LEAK=1 bun ./scripts/benchmark.mjs",
     "bench:profile": "yarn build && MIMALLOC_SHOW_STATS=1 BENCH_HEAP_SNAPSHOT=1 bun --heap-prof-md --heap-prof-dir ./benchmark-profiles ./scripts/benchmark.mjs",
     "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
     "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsc && tsdown",
     "bench": "yarn build && bun ./scripts/benchmark.mjs",
+    "bench:profile": "yarn build && MIMALLOC_SHOW_STATS=1 BENCH_HEAP_SNAPSHOT=1 bun --heap-prof-md --heap-prof-dir ./benchmark-profiles ./scripts/benchmark.mjs",
     "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
     "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",
     "test": "bun test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && tsdown",
     "bench": "yarn build && bun ./scripts/benchmark.mjs",
     "bench:memory": "yarn build && BENCH_ISOLATED_MEMORY=1 bun ./scripts/benchmark.mjs",
-    "bench:leak": "yarn build && BENCH_MEMORY=1 BENCH_LEAK=1 bun ./scripts/benchmark.mjs",
+    "bench:leak": "yarn build && BENCH_LEAK=1 bun ./scripts/benchmark.mjs",
     "bench:profile": "yarn build && MIMALLOC_SHOW_STATS=1 BENCH_HEAP_SNAPSHOT=1 bun --heap-prof-md --heap-prof-dir ./benchmark-profiles ./scripts/benchmark.mjs",
     "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
     "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "build": "tsc && tsdown",
     "bench": "yarn build && bun ./scripts/benchmark.mjs",
     "bench:memory": "yarn build && BENCH_ISOLATED_MEMORY=1 bun ./scripts/benchmark.mjs",
+    "bench:leak": "yarn build && BENCH_LEAK=1 bun ./scripts/benchmark.mjs",
     "bench:profile": "yarn build && MIMALLOC_SHOW_STATS=1 BENCH_HEAP_SNAPSHOT=1 bun --heap-prof-md --heap-prof-dir ./benchmark-profiles ./scripts/benchmark.mjs",
     "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
     "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsc && tsdown",
     "bench": "yarn build && bun ./scripts/benchmark.mjs",
+    "bench:memory": "yarn build && BENCH_ISOLATED_MEMORY=1 bun ./scripts/benchmark.mjs",
     "bench:profile": "yarn build && MIMALLOC_SHOW_STATS=1 BENCH_HEAP_SNAPSHOT=1 bun --heap-prof-md --heap-prof-dir ./benchmark-profiles ./scripts/benchmark.mjs",
     "prepack": "node ../../scripts/materialize-agent-compat.mjs prepack",
     "postpack": "node ../../scripts/materialize-agent-compat.mjs postpack",

--- a/packages/core/scripts/benchmark.mjs
+++ b/packages/core/scripts/benchmark.mjs
@@ -28,15 +28,20 @@ function parsePositiveIntegerEnv(name, fallback) {
   return value
 }
 
-const memoryEnabled = process.env.BENCH_MEMORY !== '0'
 const heapSnapshotEnabled = process.env.BENCH_HEAP_SNAPSHOT === '1'
 const profileDir = process.env.BENCH_PROFILE_DIR ?? './benchmark-profiles'
 const isolatedMemoryEnabled = process.env.BENCH_ISOLATED_MEMORY === '1'
 const isolatedMemoryChild = process.env.BENCH_ISOLATED_MEMORY_CHILD === '1'
+const leakBenchmarkEnabled = process.env.BENCH_LEAK === '1'
+const memoryEnabled =
+  process.env.BENCH_MEMORY === '1' ||
+  heapSnapshotEnabled ||
+  isolatedMemoryEnabled ||
+  isolatedMemoryChild ||
+  leakBenchmarkEnabled
 const isolatedMemorySamples = Number(process.env.BENCH_MEMORY_SAMPLES ?? '7')
 const isolatedMemoryWarmup = Number(process.env.BENCH_MEMORY_WARMUP ?? '5')
 const isolatedResultPrefix = '__UMPIRE_BENCH_MEMORY__'
-const leakBenchmarkEnabled = process.env.BENCH_LEAK === '1'
 const leakBatches = leakBenchmarkEnabled
   ? parsePositiveIntegerEnv('BENCH_LEAK_BATCHES', 20)
   : 20
@@ -50,6 +55,25 @@ const leakInputCount = leakBenchmarkEnabled
   ? parsePositiveIntegerEnv('BENCH_LEAK_INPUTS', 16)
   : 16
 const leakRotateInputs = process.env.BENCH_LEAK_ROTATE_INPUTS !== '0'
+const leakEnvNames = [
+  'BENCH_LEAK_BATCHES',
+  'BENCH_LEAK_ITERATIONS',
+  'BENCH_LEAK_WARMUP',
+  'BENCH_LEAK_INPUTS',
+  'BENCH_LEAK_ROTATE_INPUTS',
+]
+
+if (!leakBenchmarkEnabled) {
+  const configuredLeakEnvNames = leakEnvNames.filter(
+    (name) => process.env[name] !== undefined,
+  )
+
+  if (configuredLeakEnvNames.length > 0) {
+    console.warn(
+      `[benchmark] Ignoring leak benchmark env vars without BENCH_LEAK=1: ${configuredLeakEnvNames.join(', ')}`,
+    )
+  }
+}
 
 function forceGc() {
   if (typeof globalThis.Bun?.gc === 'function') {
@@ -76,7 +100,7 @@ function readRequiredMemoryStats() {
   const stats = readMemoryStats()
 
   if (!stats) {
-    throw new Error('BENCH_LEAK requires BENCH_MEMORY=1')
+    throw new Error('BENCH_LEAK requires memory stats to be enabled')
   }
 
   return stats

--- a/packages/core/scripts/benchmark.mjs
+++ b/packages/core/scripts/benchmark.mjs
@@ -1,4 +1,5 @@
 import { performance } from 'node:perf_hooks'
+import { spawnSync } from 'node:child_process'
 import { mkdir } from 'node:fs/promises'
 import { heapStats } from 'bun:jsc'
 import { generateHeapSnapshot } from 'bun'
@@ -19,6 +20,11 @@ if (!process.env.NODE_ENV) {
 const memoryEnabled = process.env.BENCH_MEMORY !== '0'
 const heapSnapshotEnabled = process.env.BENCH_HEAP_SNAPSHOT === '1'
 const profileDir = process.env.BENCH_PROFILE_DIR ?? './benchmark-profiles'
+const isolatedMemoryEnabled = process.env.BENCH_ISOLATED_MEMORY === '1'
+const isolatedMemoryChild = process.env.BENCH_ISOLATED_MEMORY_CHILD === '1'
+const isolatedMemorySamples = Number(process.env.BENCH_MEMORY_SAMPLES ?? '7')
+const isolatedMemoryWarmup = Number(process.env.BENCH_MEMORY_WARMUP ?? '5')
+const isolatedResultPrefix = '__UMPIRE_BENCH_MEMORY__'
 
 function forceGc() {
   if (typeof globalThis.Bun?.gc === 'function') {
@@ -100,6 +106,33 @@ function average(values) {
   return values.reduce((sum, value) => sum + value, 0) / values.length
 }
 
+function median(values) {
+  if (values.length === 0) {
+    return 0
+  }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle]
+}
+
+function percentile(values, percentileValue) {
+  if (values.length === 0) {
+    return 0
+  }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((percentileValue / 100) * sorted.length) - 1,
+  )
+
+  return sorted[index]
+}
+
 function variance(values, mean) {
   if (values.length === 0) {
     return 0
@@ -111,6 +144,16 @@ function variance(values, mean) {
       return sum + delta * delta
     }, 0) / values.length
   )
+}
+
+function runScenarioLoop(scenario, iterations) {
+  let checksum = 0
+
+  for (let i = 0; i < iterations; i += 1) {
+    checksum += scenario.run()
+  }
+
+  return checksum
 }
 
 function summarizeScenarioRuns(scenario, runCount) {
@@ -229,6 +272,112 @@ function printCategoryTotals(results, runCount) {
   })
 
   console.table(table)
+}
+
+function measureIsolatedScenario(scenario) {
+  runScenarioLoop(scenario, isolatedMemoryWarmup)
+  let checksum = scenario.run()
+
+  const before = readMemoryStats()
+  const start = performance.now()
+  checksum += runScenarioLoop(scenario, scenario.iterations)
+  const totalMs = performance.now() - start
+  const after = readMemoryStats()
+
+  return {
+    name: scenario.name,
+    category: scenario.category,
+    iterations: scenario.iterations,
+    totalMs,
+    avgMs: totalMs / scenario.iterations,
+    opsPerSec: (scenario.iterations * 1000) / totalMs,
+    checksum,
+    memory: diffMemoryStats(before, after),
+  }
+}
+
+function printIsolatedMemoryResults(results) {
+  const table = results.map((result) => {
+    const heapValues = result.samples.map(
+      (sample) => sample.memory?.heapSizeBytes ?? 0,
+    )
+    const heapCapacityValues = result.samples.map(
+      (sample) => sample.memory?.heapCapacityBytes ?? 0,
+    )
+    const objectValues = result.samples.map(
+      (sample) => sample.memory?.objectCount ?? 0,
+    )
+    const totalMsValues = result.samples.map((sample) => sample.totalMs)
+
+    return {
+      benchmark: result.name,
+      category: result.category,
+      samples: result.samples.length,
+      iterations: result.iterations,
+      median_heap_delta: formatBytes(median(heapValues)),
+      p95_heap_delta: formatBytes(percentile(heapValues, 95)),
+      median_heap_capacity_delta: formatBytes(median(heapCapacityValues)),
+      median_objects_delta: median(objectValues).toFixed(1),
+      p95_objects_delta: percentile(objectValues, 95).toFixed(1),
+      median_total_ms: median(totalMsValues).toFixed(2),
+      checksum: result.samples[0]?.checksum ?? 0,
+    }
+  })
+
+  console.table(table)
+}
+
+function runIsolatedMemoryParent() {
+  const results = scenarios.map((scenario) => {
+    const samples = []
+
+    for (let sample = 0; sample < isolatedMemorySamples; sample += 1) {
+      const child = spawnSync(
+        process.execPath,
+        [new URL(import.meta.url).pathname],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            BENCH_ISOLATED_MEMORY: undefined,
+            BENCH_ISOLATED_MEMORY_CHILD: '1',
+            BENCH_ISOLATED_SCENARIO: scenario.name,
+            BENCH_MEMORY: '1',
+            BENCH_HEAP_SNAPSHOT: '0',
+          },
+          encoding: 'utf8',
+        },
+      )
+
+      if (child.status !== 0) {
+        process.stdout.write(child.stdout)
+        process.stderr.write(child.stderr)
+        throw new Error(
+          `Isolated memory sample failed for ${scenario.name} with exit code ${child.status}`,
+        )
+      }
+
+      const resultLine = child.stdout
+        .split('\n')
+        .find((line) => line.startsWith(isolatedResultPrefix))
+
+      if (!resultLine) {
+        process.stdout.write(child.stdout)
+        throw new Error(`Missing isolated memory result for ${scenario.name}`)
+      }
+
+      samples.push(JSON.parse(resultLine.slice(isolatedResultPrefix.length)))
+    }
+
+    return {
+      name: scenario.name,
+      category: scenario.category,
+      iterations: scenario.iterations,
+      samples,
+    }
+  })
+
+  printIsolatedMemoryResults(results)
 }
 
 function sumAvailability(availability) {
@@ -633,17 +782,35 @@ const scenarios = [
   },
 ]
 
-const results = scenarios.map((scenario) =>
-  summarizeScenarioRuns(scenario, runCount),
-)
+if (isolatedMemoryChild) {
+  const scenario = scenarios.find(
+    (candidate) => candidate.name === process.env.BENCH_ISOLATED_SCENARIO,
+  )
 
-printScenarioResults(results, runCount)
-printCategoryTotals(results, runCount)
+  if (!scenario) {
+    throw new Error(
+      `Unknown isolated memory scenario: ${process.env.BENCH_ISOLATED_SCENARIO}`,
+    )
+  }
 
-if (heapSnapshotEnabled) {
-  await mkdir(profileDir, { recursive: true })
-  const snapshot = generateHeapSnapshot()
-  const snapshotPath = `${profileDir}/core-benchmark-${Date.now()}.heapsnapshot.json`
-  await Bun.write(snapshotPath, JSON.stringify(snapshot))
-  console.log(`Wrote heap snapshot: ${snapshotPath}`)
+  console.log(
+    `${isolatedResultPrefix}${JSON.stringify(measureIsolatedScenario(scenario))}`,
+  )
+} else if (isolatedMemoryEnabled) {
+  runIsolatedMemoryParent()
+} else {
+  const results = scenarios.map((scenario) =>
+    summarizeScenarioRuns(scenario, runCount),
+  )
+
+  printScenarioResults(results, runCount)
+  printCategoryTotals(results, runCount)
+
+  if (heapSnapshotEnabled) {
+    await mkdir(profileDir, { recursive: true })
+    const snapshot = generateHeapSnapshot()
+    const snapshotPath = `${profileDir}/core-benchmark-${Date.now()}.heapsnapshot.json`
+    await Bun.write(snapshotPath, JSON.stringify(snapshot))
+    console.log(`Wrote heap snapshot: ${snapshotPath}`)
+  }
 }

--- a/packages/core/scripts/benchmark.mjs
+++ b/packages/core/scripts/benchmark.mjs
@@ -25,6 +25,10 @@ const isolatedMemoryChild = process.env.BENCH_ISOLATED_MEMORY_CHILD === '1'
 const isolatedMemorySamples = Number(process.env.BENCH_MEMORY_SAMPLES ?? '7')
 const isolatedMemoryWarmup = Number(process.env.BENCH_MEMORY_WARMUP ?? '5')
 const isolatedResultPrefix = '__UMPIRE_BENCH_MEMORY__'
+const leakBenchmarkEnabled = process.env.BENCH_LEAK === '1'
+const leakBatches = Number(process.env.BENCH_LEAK_BATCHES ?? '20')
+const leakIterations = Number(process.env.BENCH_LEAK_ITERATIONS ?? '1000')
+const leakWarmup = Number(process.env.BENCH_LEAK_WARMUP ?? '100')
 
 function forceGc() {
   if (typeof globalThis.Bun?.gc === 'function') {
@@ -64,7 +68,7 @@ function formatBytes(value) {
   const absolute = Math.abs(value)
 
   if (absolute < 1024) {
-    return `${value} B`
+    return `${Math.round(value)} B`
   }
 
   if (absolute < 1024 * 1024) {
@@ -144,6 +148,25 @@ function variance(values, mean) {
       return sum + delta * delta
     }, 0) / values.length
   )
+}
+
+function linearSlope(values) {
+  if (values.length < 2) {
+    return 0
+  }
+
+  const xMean = (values.length - 1) / 2
+  const yMean = average(values)
+  let numerator = 0
+  let denominator = 0
+
+  for (let index = 0; index < values.length; index += 1) {
+    const xDelta = index - xMean
+    numerator += xDelta * (values[index] - yMean)
+    denominator += xDelta * xDelta
+  }
+
+  return denominator === 0 ? 0 : numerator / denominator
 }
 
 function runScenarioLoop(scenario, iterations) {
@@ -378,6 +401,70 @@ function runIsolatedMemoryParent() {
   })
 
   printIsolatedMemoryResults(results)
+}
+
+function measureLeakScenario(scenario) {
+  runScenarioLoop(scenario, leakWarmup)
+
+  const baseline = readMemoryStats()
+  const samples = []
+  let checksum = 0
+
+  for (let batch = 0; batch < leakBatches; batch += 1) {
+    const start = performance.now()
+    checksum += runScenarioLoop(scenario, leakIterations)
+    const totalMs = performance.now() - start
+    const memory = readMemoryStats()
+
+    samples.push({
+      batch: batch + 1,
+      totalMs,
+      heapSizeBytes: memory.heapSize - baseline.heapSize,
+      heapCapacityBytes: memory.heapCapacity - baseline.heapCapacity,
+      objectCount: memory.objectCount - baseline.objectCount,
+    })
+  }
+
+  return {
+    name: scenario.name,
+    batches: leakBatches,
+    iterations: leakIterations,
+    checksum,
+    samples,
+  }
+}
+
+function printLeakResults(results) {
+  const table = results.map((result) => {
+    const heapValues = result.samples.map((sample) => sample.heapSizeBytes)
+    const capacityValues = result.samples.map(
+      (sample) => sample.heapCapacityBytes,
+    )
+    const objectValues = result.samples.map((sample) => sample.objectCount)
+    const totalMsValues = result.samples.map((sample) => sample.totalMs)
+    const first = result.samples[0]
+    const last = result.samples[result.samples.length - 1]
+
+    return {
+      benchmark: result.name,
+      batches: result.batches,
+      iterations_per_batch: result.iterations,
+      total_iterations: result.batches * result.iterations,
+      first_heap_delta: formatBytes(first.heapSizeBytes),
+      last_heap_delta: formatBytes(last.heapSizeBytes),
+      max_heap_delta: formatBytes(Math.max(...heapValues)),
+      heap_slope_per_batch: formatBytes(linearSlope(heapValues)),
+      last_capacity_delta: formatBytes(last.heapCapacityBytes),
+      capacity_slope_per_batch: formatBytes(linearSlope(capacityValues)),
+      first_objects_delta: first.objectCount,
+      last_objects_delta: last.objectCount,
+      objects_slope_per_batch: linearSlope(objectValues).toFixed(2),
+      median_batch_ms: median(totalMsValues).toFixed(2),
+      checksum: result.checksum,
+    }
+  })
+
+  console.table(table)
 }
 
 function sumAvailability(availability) {
@@ -782,6 +869,14 @@ const scenarios = [
   },
 ]
 
+const leakScenarios = scenarios.filter(
+  (scenario) =>
+    scenario.name === 'check/scheduler/pro-plan' ||
+    scenario.name === 'check/scheduler/basic-readonly' ||
+    scenario.name === 'play/plan-downgrade' ||
+    scenario.name === 'check/minesweeper-expert-board',
+)
+
 if (isolatedMemoryChild) {
   const scenario = scenarios.find(
     (candidate) => candidate.name === process.env.BENCH_ISOLATED_SCENARIO,
@@ -798,6 +893,10 @@ if (isolatedMemoryChild) {
   )
 } else if (isolatedMemoryEnabled) {
   runIsolatedMemoryParent()
+} else if (leakBenchmarkEnabled) {
+  printLeakResults(
+    leakScenarios.map((scenario) => measureLeakScenario(scenario)),
+  )
 } else {
   const results = scenarios.map((scenario) =>
     summarizeScenarioRuns(scenario, runCount),

--- a/packages/core/scripts/benchmark.mjs
+++ b/packages/core/scripts/benchmark.mjs
@@ -1,4 +1,7 @@
 import { performance } from 'node:perf_hooks'
+import { mkdir } from 'node:fs/promises'
+import { heapStats } from 'bun:jsc'
+import { generateHeapSnapshot } from 'bun'
 import {
   check,
   disables,
@@ -13,16 +16,70 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'production'
 }
 
+const memoryEnabled = process.env.BENCH_MEMORY !== '0'
+const heapSnapshotEnabled = process.env.BENCH_HEAP_SNAPSHOT === '1'
+const profileDir = process.env.BENCH_PROFILE_DIR ?? './benchmark-profiles'
+
+function forceGc() {
+  if (typeof globalThis.Bun?.gc === 'function') {
+    globalThis.Bun.gc(true)
+  }
+}
+
+function readMemoryStats() {
+  if (!memoryEnabled) {
+    return null
+  }
+
+  forceGc()
+  const stats = heapStats()
+
+  return {
+    heapSize: stats.heapSize,
+    heapCapacity: stats.heapCapacity,
+    objectCount: stats.objectCount,
+  }
+}
+
+function diffMemoryStats(before, after) {
+  if (!before || !after) {
+    return null
+  }
+
+  return {
+    heapSizeBytes: after.heapSize - before.heapSize,
+    heapCapacityBytes: after.heapCapacity - before.heapCapacity,
+    objectCount: after.objectCount - before.objectCount,
+  }
+}
+
+function formatBytes(value) {
+  const sign = value < 0 ? '-' : ''
+  const absolute = Math.abs(value)
+
+  if (absolute < 1024) {
+    return `${value} B`
+  }
+
+  if (absolute < 1024 * 1024) {
+    return `${sign}${(absolute / 1024).toFixed(2)} KiB`
+  }
+
+  return `${sign}${(absolute / (1024 * 1024)).toFixed(2)} MiB`
+}
+
 function benchmark(name, iterations, fn) {
   let checksum = 0
 
   checksum += fn()
+  const memoryBefore = readMemoryStats()
 
   const start = performance.now()
   for (let i = 0; i < iterations; i += 1) {
     checksum += fn()
   }
   const totalMs = performance.now() - start
+  const memoryAfter = readMemoryStats()
 
   return {
     name,
@@ -31,6 +88,7 @@ function benchmark(name, iterations, fn) {
     avgMs: totalMs / iterations,
     opsPerSec: (iterations * 1000) / totalMs,
     checksum,
+    memory: diffMemoryStats(memoryBefore, memoryAfter),
   }
 }
 
@@ -65,7 +123,16 @@ function summarizeScenarioRuns(scenario, runCount) {
   const totalMsValues = runs.map((result) => result.totalMs)
   const avgMsValues = runs.map((result) => result.avgMs)
   const opsPerSecValues = runs.map((result) => result.opsPerSec)
+  const heapSizeValues = runs.map((result) => result.memory?.heapSizeBytes ?? 0)
+  const heapCapacityValues = runs.map(
+    (result) => result.memory?.heapCapacityBytes ?? 0,
+  )
+  const objectCountValues = runs.map(
+    (result) => result.memory?.objectCount ?? 0,
+  )
   const meanTotalMs = average(totalMsValues)
+  const meanHeapSizeBytes = average(heapSizeValues)
+  const meanObjectCount = average(objectCountValues)
 
   return {
     name: scenario.name,
@@ -77,21 +144,34 @@ function summarizeScenarioRuns(scenario, runCount) {
     varTotalMs: variance(totalMsValues, meanTotalMs),
     avgMs: average(avgMsValues),
     avgOpsPerSec: average(opsPerSecValues),
+    avgHeapSizeBytes: meanHeapSizeBytes,
+    avgHeapCapacityBytes: average(heapCapacityValues),
+    avgObjectCount: meanObjectCount,
   }
 }
 
 function printScenarioResults(results, runCount) {
-  const table = results.map((result) => ({
-    benchmark: result.name,
-    category: result.category,
-    runs: runCount,
-    iterations: result.iterations,
-    avg_total_ms: result.avgTotalMs.toFixed(2),
-    var_total_ms: result.varTotalMs.toFixed(4),
-    avg_ms: result.avgMs.toFixed(3),
-    avg_ops_sec: result.avgOpsPerSec.toFixed(2),
-    checksum: result.checksum,
-  }))
+  const table = results.map((result) => {
+    const row = {
+      benchmark: result.name,
+      category: result.category,
+      runs: runCount,
+      iterations: result.iterations,
+      avg_total_ms: result.avgTotalMs.toFixed(2),
+      var_total_ms: result.varTotalMs.toFixed(4),
+      avg_ms: result.avgMs.toFixed(3),
+      avg_ops_sec: result.avgOpsPerSec.toFixed(2),
+    }
+
+    if (memoryEnabled) {
+      row.avg_heap_delta = formatBytes(result.avgHeapSizeBytes)
+      row.avg_objects_delta = result.avgObjectCount.toFixed(1)
+    }
+
+    row.checksum = result.checksum
+
+    return row
+  })
 
   console.table(table)
 }
@@ -100,9 +180,15 @@ function printCategoryTotals(results, runCount) {
   const categories = ['construction-heavy', 'runtime-heavy']
   const table = categories.map((category) => {
     const totalsByRun = []
+    const heapTotalsByRun = []
+    const heapCapacityTotalsByRun = []
+    const objectTotalsByRun = []
 
     for (let run = 0; run < runCount; run += 1) {
       let total = 0
+      let heapTotal = 0
+      let heapCapacityTotal = 0
+      let objectTotal = 0
 
       for (const result of results) {
         if (result.category !== category) {
@@ -110,19 +196,36 @@ function printCategoryTotals(results, runCount) {
         }
 
         total += result.runs[run]?.totalMs ?? 0
+        heapTotal += result.runs[run]?.memory?.heapSizeBytes ?? 0
+        heapCapacityTotal += result.runs[run]?.memory?.heapCapacityBytes ?? 0
+        objectTotal += result.runs[run]?.memory?.objectCount ?? 0
       }
 
       totalsByRun.push(total)
+      heapTotalsByRun.push(heapTotal)
+      heapCapacityTotalsByRun.push(heapCapacityTotal)
+      objectTotalsByRun.push(objectTotal)
     }
 
     const avgTotalMs = average(totalsByRun)
+    const avgHeapBytes = average(heapTotalsByRun)
+    const avgHeapCapacityBytes = average(heapCapacityTotalsByRun)
+    const avgObjectCount = average(objectTotalsByRun)
 
-    return {
+    const row = {
       category,
       runs: runCount,
       avg_total_ms: avgTotalMs.toFixed(2),
       var_total_ms: variance(totalsByRun, avgTotalMs).toFixed(4),
     }
+
+    if (memoryEnabled) {
+      row.avg_heap_delta = formatBytes(avgHeapBytes)
+      row.avg_heap_capacity_delta = formatBytes(avgHeapCapacityBytes)
+      row.avg_objects_delta = avgObjectCount.toFixed(1)
+    }
+
+    return row
   })
 
   console.table(table)
@@ -536,3 +639,11 @@ const results = scenarios.map((scenario) =>
 
 printScenarioResults(results, runCount)
 printCategoryTotals(results, runCount)
+
+if (heapSnapshotEnabled) {
+  await mkdir(profileDir, { recursive: true })
+  const snapshot = generateHeapSnapshot()
+  const snapshotPath = `${profileDir}/core-benchmark-${Date.now()}.heapsnapshot.json`
+  await Bun.write(snapshotPath, JSON.stringify(snapshot))
+  console.log(`Wrote heap snapshot: ${snapshotPath}`)
+}

--- a/packages/core/scripts/benchmark.mjs
+++ b/packages/core/scripts/benchmark.mjs
@@ -17,6 +17,17 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'production'
 }
 
+function parsePositiveIntegerEnv(name, fallback) {
+  const raw = process.env[name] ?? String(fallback)
+  const value = Number(raw)
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer. Received: ${raw}`)
+  }
+
+  return value
+}
+
 const memoryEnabled = process.env.BENCH_MEMORY !== '0'
 const heapSnapshotEnabled = process.env.BENCH_HEAP_SNAPSHOT === '1'
 const profileDir = process.env.BENCH_PROFILE_DIR ?? './benchmark-profiles'
@@ -26,9 +37,19 @@ const isolatedMemorySamples = Number(process.env.BENCH_MEMORY_SAMPLES ?? '7')
 const isolatedMemoryWarmup = Number(process.env.BENCH_MEMORY_WARMUP ?? '5')
 const isolatedResultPrefix = '__UMPIRE_BENCH_MEMORY__'
 const leakBenchmarkEnabled = process.env.BENCH_LEAK === '1'
-const leakBatches = Number(process.env.BENCH_LEAK_BATCHES ?? '20')
-const leakIterations = Number(process.env.BENCH_LEAK_ITERATIONS ?? '1000')
-const leakWarmup = Number(process.env.BENCH_LEAK_WARMUP ?? '100')
+const leakBatches = leakBenchmarkEnabled
+  ? parsePositiveIntegerEnv('BENCH_LEAK_BATCHES', 20)
+  : 20
+const leakIterations = leakBenchmarkEnabled
+  ? parsePositiveIntegerEnv('BENCH_LEAK_ITERATIONS', 1000)
+  : 1000
+const leakWarmup = leakBenchmarkEnabled
+  ? parsePositiveIntegerEnv('BENCH_LEAK_WARMUP', 100)
+  : 100
+const leakInputCount = leakBenchmarkEnabled
+  ? parsePositiveIntegerEnv('BENCH_LEAK_INPUTS', 16)
+  : 16
+const leakRotateInputs = process.env.BENCH_LEAK_ROTATE_INPUTS !== '0'
 
 function forceGc() {
   if (typeof globalThis.Bun?.gc === 'function') {
@@ -49,6 +70,16 @@ function readMemoryStats() {
     heapCapacity: stats.heapCapacity,
     objectCount: stats.objectCount,
   }
+}
+
+function readRequiredMemoryStats() {
+  const stats = readMemoryStats()
+
+  if (!stats) {
+    throw new Error('BENCH_LEAK requires BENCH_MEMORY=1')
+  }
+
+  return stats
 }
 
 function diffMemoryStats(before, after) {
@@ -406,7 +437,7 @@ function runIsolatedMemoryParent() {
 function measureLeakScenario(scenario) {
   runScenarioLoop(scenario, leakWarmup)
 
-  const baseline = readMemoryStats()
+  const baseline = readRequiredMemoryStats()
   const samples = []
   let checksum = 0
 
@@ -414,7 +445,7 @@ function measureLeakScenario(scenario) {
     const start = performance.now()
     checksum += runScenarioLoop(scenario, leakIterations)
     const totalMs = performance.now() - start
-    const memory = readMemoryStats()
+    const memory = readRequiredMemoryStats()
 
     samples.push({
       batch: batch + 1,
@@ -427,6 +458,8 @@ function measureLeakScenario(scenario) {
 
   return {
     name: scenario.name,
+    inputMode: scenario.inputMode ?? 'fixed',
+    inputCount: scenario.inputCount ?? 1,
     batches: leakBatches,
     iterations: leakIterations,
     checksum,
@@ -447,6 +480,8 @@ function printLeakResults(results) {
 
     return {
       benchmark: result.name,
+      input_mode: result.inputMode,
+      input_count: result.inputCount,
       batches: result.batches,
       iterations_per_batch: result.iterations,
       total_iterations: result.batches * result.iterations,
@@ -760,6 +795,41 @@ function createExpertMinesweeperScenario() {
   }
 }
 
+function createValueVariants(values, count, mutate) {
+  const variants = []
+
+  for (let index = 0; index < count; index += 1) {
+    const variant = structuredClone(values)
+    mutate?.(variant, index)
+    variants.push(variant)
+  }
+
+  return variants
+}
+
+function createConditionVariants(conditions, count, mutate) {
+  const variants = []
+
+  for (let index = 0; index < count; index += 1) {
+    const variant = { ...conditions }
+    mutate?.(variant, index)
+    variants.push(variant)
+  }
+
+  return variants
+}
+
+function createRotatingRunner(inputs, run) {
+  let index = 0
+
+  return () => {
+    const currentIndex = index
+    const input = inputs[currentIndex]
+    index = (index + 1) % inputs.length
+    return run(input, currentIndex)
+  }
+}
+
 const schedulerConstructionFields = makeSchedulerScenario(60)
 const schedulerRuntime = makeSchedulerScenario(60)
 const challengeField = 'review_28'
@@ -869,13 +939,116 @@ const scenarios = [
   },
 ]
 
-const leakScenarios = scenarios.filter(
-  (scenario) =>
-    scenario.name === 'check/scheduler/pro-plan' ||
-    scenario.name === 'check/scheduler/basic-readonly' ||
-    scenario.name === 'play/plan-downgrade' ||
-    scenario.name === 'check/minesweeper-expert-board',
-)
+function createLeakScenarios() {
+  if (!leakRotateInputs) {
+    return scenarios
+      .filter(
+        (scenario) =>
+          scenario.name === 'check/scheduler/pro-plan' ||
+          scenario.name === 'check/scheduler/basic-readonly' ||
+          scenario.name === 'play/plan-downgrade' ||
+          scenario.name === 'check/minesweeper-expert-board',
+      )
+      .map((scenario) => ({
+        ...scenario,
+        inputMode: 'fixed',
+        inputCount: 1,
+      }))
+  }
+
+  const beforeValues = createValueVariants(
+    schedulerRuntime.beforeValues,
+    leakInputCount,
+    (variant, index) => {
+      variant[`contact_${index % 60}`] = `leak${index}@example.com`
+      variant[`notes_${(index * 7) % 60}`] = `notes-leak-${index}`
+    },
+  )
+  const afterValues = createValueVariants(
+    schedulerRuntime.afterValues,
+    leakInputCount,
+    (variant, index) => {
+      variant[`notes_${(index * 5) % 60}`] = `readonly-leak-${index}`
+    },
+  )
+  const beforeConditions = createConditionVariants(
+    schedulerRuntime.beforeConditions,
+    leakInputCount,
+  )
+  const afterConditions = createConditionVariants(
+    schedulerRuntime.afterConditions,
+    leakInputCount,
+  )
+  const minesweeperValues = createValueVariants(
+    minesweeper.values,
+    leakInputCount,
+  )
+  const minesweeperConditions = createConditionVariants(
+    minesweeper.conditions,
+    leakInputCount,
+  )
+
+  return [
+    {
+      name: 'check/scheduler/pro-plan',
+      inputMode: 'rotating',
+      inputCount: leakInputCount,
+      run: createRotatingRunner(beforeValues, (values, index) => {
+        const availability = schedulerRuntime.engine.check(
+          values,
+          beforeConditions[index],
+        )
+        return sumAvailability(availability)
+      }),
+    },
+    {
+      name: 'check/scheduler/basic-readonly',
+      inputMode: 'rotating',
+      inputCount: leakInputCount,
+      run: createRotatingRunner(afterValues, (values, index) => {
+        const availability = schedulerRuntime.engine.check(
+          values,
+          afterConditions[index],
+          beforeValues[index],
+        )
+        return sumAvailability(availability)
+      }),
+    },
+    {
+      name: 'play/plan-downgrade',
+      inputMode: 'rotating',
+      inputCount: leakInputCount,
+      run: createRotatingRunner(afterValues, (values, index) => {
+        const fouls = schedulerRuntime.engine.play(
+          {
+            values: beforeValues[index],
+            conditions: beforeConditions[index],
+          },
+          {
+            values,
+            conditions: afterConditions[index],
+          },
+        )
+
+        return (
+          fouls.length + fouls.reduce((sum, foul) => sum + foul.field.length, 0)
+        )
+      }),
+    },
+    {
+      name: 'check/minesweeper-expert-board',
+      inputMode: 'rotating',
+      inputCount: leakInputCount,
+      run: createRotatingRunner(minesweeperValues, (values, index) => {
+        const availability = minesweeper.engine.check(
+          values,
+          minesweeperConditions[index],
+        )
+        return sumAvailability(availability)
+      }),
+    },
+  ]
+}
 
 if (isolatedMemoryChild) {
   const scenario = scenarios.find(
@@ -895,7 +1068,7 @@ if (isolatedMemoryChild) {
   runIsolatedMemoryParent()
 } else if (leakBenchmarkEnabled) {
   printLeakResults(
-    leakScenarios.map((scenario) => measureLeakScenario(scenario)),
+    createLeakScenarios().map((scenario) => measureLeakScenario(scenario)),
   )
 } else {
   const results = scenarios.map((scenario) =>

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -96,7 +96,7 @@ function evaluateAnyOfRule<
   let reasons: string[] | undefined
 
   for (const innerRule of rules) {
-    const result = evaluateRuleForField(
+    const result = evaluateRuleForTarget(
       innerRule,
       field,
       fields,
@@ -220,7 +220,7 @@ export function evaluateRuleForField<
 
       for (const innerRule of branchRules) {
         innerResults.push(
-          evaluateRuleForField(
+          evaluateRuleForTarget(
             innerRule,
             field,
             fields,

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -2,7 +2,7 @@ import {
   appendCompositeFailureReasons,
   combineCompositeResults,
 } from './composite.js'
-import { getInternalRuleMetadata, isFairRule, isGateRule } from './rules.js'
+import { getInternalRuleMetadata, isFairRule } from './rules.js'
 import { isSatisfied } from './satisfaction.js'
 import type {
   AvailabilityMap,
@@ -25,6 +25,100 @@ const EMPTY_RULE_PHASE_BUCKETS = {
   fairRules: [],
 } as const
 
+type CompositeConstraint = 'enabled' | 'fair'
+
+function isCompositePassed(
+  constraint: CompositeConstraint,
+  result: RuleEvaluation,
+): boolean {
+  return constraint === 'fair' ? result.fair !== false : result.enabled
+}
+
+function createCompositePassResult(
+  constraint: CompositeConstraint,
+): RuleEvaluation {
+  if (constraint === 'fair') {
+    return {
+      enabled: true,
+      fair: true,
+      reason: null,
+    }
+  }
+
+  return {
+    enabled: true,
+    reason: null,
+  }
+}
+
+function createCompositeFailureResult(
+  constraint: CompositeConstraint,
+  reasons: string[] | undefined,
+): RuleEvaluation {
+  const normalizedReasons = reasons && reasons.length > 0 ? reasons : undefined
+
+  if (constraint === 'fair') {
+    return {
+      enabled: true,
+      fair: false,
+      reason: normalizedReasons?.[0] ?? null,
+      reasons: normalizedReasons,
+    }
+  }
+
+  return {
+    enabled: false,
+    reason: normalizedReasons?.[0] ?? null,
+    reasons: normalizedReasons,
+  }
+}
+
+function evaluateAnyOfRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  rules: Rule<F, C>[],
+  constraint: CompositeConstraint,
+  field: keyof F & string,
+  fields: F,
+  values: FieldValues<F>,
+  conditions: C,
+  prev: FieldValues<F> | undefined,
+  availability: Partial<AvailabilityMap<F>>,
+  baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>,
+): RuleEvaluation {
+  let passed = false
+  let reasons: string[] | undefined
+
+  for (const innerRule of rules) {
+    const result = evaluateRuleForField(
+      innerRule,
+      field,
+      fields,
+      values,
+      conditions,
+      prev,
+      availability,
+      baseRuleCache,
+    )
+
+    if (isCompositePassed(constraint, result)) {
+      passed = true
+      reasons = undefined
+      continue
+    }
+
+    if (!passed) {
+      reasons ??= []
+      appendCompositeFailureReasons(result, reasons)
+    }
+  }
+
+  return passed
+    ? createCompositePassResult(constraint)
+    : createCompositeFailureResult(constraint, reasons)
+}
+
 function partitionRulesByPhase<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -38,10 +132,7 @@ function partitionRulesByPhase<
       continue
     }
 
-    // Stryker disable next-line ConditionalExpression: equivalent mutant — isGateRule is !isFairRule, so every non-fair rule is a gate rule; the check can never be false at this point
-    if (isGateRule(rule)) {
-      gateRules.push(rule)
-    }
+    gateRules.push(rule)
   }
 
   return {
@@ -103,24 +194,17 @@ export function evaluateRuleForField<
 
   // Stryker disable ConditionalExpression,BlockStatement,StringLiteral: equivalent mutant — anyOf/eitherOf implement their own evaluate() that mirrors these paths exactly; bypassing the metadata branch produces identical results; 'or'→'' is equivalent because '' falls through to the OR branch in combineCompositeResults
   if (metadata?.kind === 'anyOf') {
-    const innerResults: RuleEvaluation[] = []
-
-    for (const innerRule of metadata.rules) {
-      innerResults.push(
-        evaluateRuleForField(
-          innerRule,
-          field,
-          fields,
-          values,
-          conditions,
-          prev,
-          availability,
-          baseRuleCache,
-        ),
-      )
-    }
-
-    return combineCompositeResults(metadata.constraint, 'or', innerResults)
+    return evaluateAnyOfRule(
+      metadata.rules,
+      metadata.constraint,
+      field,
+      fields,
+      values,
+      conditions,
+      prev,
+      availability,
+      baseRuleCache,
+    )
   }
 
   if (metadata?.kind === 'eitherOf') {

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -25,6 +25,11 @@ const EMPTY_RULE_PHASE_BUCKETS = {
   fairRules: [],
 } as const
 
+const DEFAULT_RULE_EVALUATION: RuleEvaluation = Object.freeze({
+  enabled: true,
+  reason: null,
+})
+
 type CompositeConstraint = 'enabled' | 'fair'
 
 function isCompositePassed(
@@ -246,15 +251,18 @@ export function evaluateRuleForField<
   const result = evaluation.get(field)
 
   if (!result) {
-    return { enabled: true, reason: null }
+    return DEFAULT_RULE_EVALUATION
+  }
+
+  if (!result.reasons || result.reasons.length > 0) {
+    return result
   }
 
   return {
     enabled: result.enabled,
     fair: result.fair,
     reason: result.reason,
-    reasons:
-      result.reasons && result.reasons.length > 0 ? result.reasons : undefined,
+    reasons: undefined,
   }
 }
 

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -2,8 +2,7 @@ import {
   appendCompositeFailureReasons,
   combineCompositeResults,
 } from './composite.js'
-import { getInternalRuleMetadata, isFairRule, resolveReason } from './rules.js'
-import type { InternalRuleMetadata } from './rules.js'
+import { getInternalRuleMetadata, isFairRule } from './rules.js'
 import { isSatisfied } from './satisfaction.js'
 import type {
   AvailabilityMap,
@@ -123,121 +122,6 @@ function evaluateAnyOfRule<
   return passed
     ? createCompositePassResult(constraint)
     : createCompositeFailureResult(constraint, reasons)
-}
-
-function evaluateRequiresRule<
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown>,
->(
-  metadata: Extract<InternalRuleMetadata<F, C>, { kind: 'requires' }>,
-  fields: F,
-  values: FieldValues<F>,
-  conditions: C,
-  availability: Partial<AvailabilityMap<F>>,
-): RuleEvaluation {
-  let reasons: string[] | undefined
-
-  for (const dependency of metadata.dependencies) {
-    const dependencyAvailability =
-      typeof dependency === 'string' ? availability[dependency] : undefined
-    const satisfied =
-      typeof dependency === 'string'
-        ? isSatisfied(values[dependency], fields[dependency]) &&
-          (!dependencyAvailability ||
-            (dependencyAvailability.enabled && dependencyAvailability.fair))
-        : dependency(values, conditions)
-
-    if (satisfied) {
-      continue
-    }
-
-    const resolvedReason = resolveReason(
-      metadata.options?.reason,
-      values,
-      conditions,
-      typeof dependency === 'string'
-        ? `requires ${dependency}`
-        : 'required condition not met',
-    )
-
-    reasons ??= []
-    reasons.push(resolvedReason)
-  }
-
-  return {
-    enabled: reasons === undefined,
-    reason: reasons?.[0] ?? null,
-    reasons,
-  }
-}
-
-function evaluateSingleTargetBuiltinRule<
-  F extends Record<string, FieldDef>,
-  C extends Record<string, unknown>,
->(
-  rule: Rule<F, C>,
-  metadata: InternalRuleMetadata<F, C> | undefined,
-  field: keyof F & string,
-  fields: F,
-  values: FieldValues<F>,
-  conditions: C,
-  availability: Partial<AvailabilityMap<F>>,
-): RuleEvaluation | undefined {
-  if (!metadata || metadata.kind !== rule.type) {
-    return undefined
-  }
-
-  if (metadata.kind === 'enabledWhen') {
-    const passed = metadata.predicate(values, conditions)
-    return {
-      enabled: passed,
-      reason: passed
-        ? null
-        : resolveReason(
-            metadata.options?.reason,
-            values,
-            conditions,
-            'condition not met',
-          ),
-    }
-  }
-
-  if (metadata.kind === 'fairWhen') {
-    const value = values[field]
-    if (!isSatisfied(value, fields[field])) {
-      return { enabled: true, fair: true, reason: null }
-    }
-
-    const passed = metadata.predicate(
-      value as NonNullable<typeof value>,
-      values,
-      conditions,
-    )
-    return {
-      enabled: true,
-      fair: passed,
-      reason: passed
-        ? null
-        : resolveReason(
-            metadata.options?.reason,
-            values,
-            conditions,
-            'selection is no longer valid',
-          ),
-    }
-  }
-
-  if (metadata.kind === 'requires') {
-    return evaluateRequiresRule(
-      metadata,
-      fields,
-      values,
-      conditions,
-      availability,
-    )
-  }
-
-  return undefined
 }
 
 function partitionRulesByPhase<
@@ -395,26 +279,27 @@ function evaluateRuleForTarget<
   availability: Partial<AvailabilityMap<F>>,
   baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>,
 ): RuleEvaluation {
-  return (
-    evaluateSingleTargetBuiltinRule(
-      rule,
-      getInternalRuleMetadata(rule),
+  const metadata = getInternalRuleMetadata(rule)
+
+  if (metadata?.kind === rule.type && metadata.evaluateTarget) {
+    return metadata.evaluateTarget(
       field,
-      fields,
       values,
       conditions,
-      availability,
-    ) ??
-    evaluateRuleForField(
-      rule,
-      field,
       fields,
-      values,
-      conditions,
-      prev,
       availability,
-      baseRuleCache,
     )
+  }
+
+  return evaluateRuleForField(
+    rule,
+    field,
+    fields,
+    values,
+    conditions,
+    prev,
+    availability,
+    baseRuleCache,
   )
 }
 

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -2,7 +2,8 @@ import {
   appendCompositeFailureReasons,
   combineCompositeResults,
 } from './composite.js'
-import { getInternalRuleMetadata, isFairRule } from './rules.js'
+import { getInternalRuleMetadata, isFairRule, resolveReason } from './rules.js'
+import type { InternalRuleMetadata } from './rules.js'
 import { isSatisfied } from './satisfaction.js'
 import type {
   AvailabilityMap,
@@ -122,6 +123,121 @@ function evaluateAnyOfRule<
   return passed
     ? createCompositePassResult(constraint)
     : createCompositeFailureResult(constraint, reasons)
+}
+
+function evaluateRequiresRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  metadata: Extract<InternalRuleMetadata<F, C>, { kind: 'requires' }>,
+  fields: F,
+  values: FieldValues<F>,
+  conditions: C,
+  availability: Partial<AvailabilityMap<F>>,
+): RuleEvaluation {
+  let reasons: string[] | undefined
+
+  for (const dependency of metadata.dependencies) {
+    const dependencyAvailability =
+      typeof dependency === 'string' ? availability[dependency] : undefined
+    const satisfied =
+      typeof dependency === 'string'
+        ? isSatisfied(values[dependency], fields[dependency]) &&
+          (!dependencyAvailability ||
+            (dependencyAvailability.enabled && dependencyAvailability.fair))
+        : dependency(values, conditions)
+
+    if (satisfied) {
+      continue
+    }
+
+    const resolvedReason = resolveReason(
+      metadata.options?.reason,
+      values,
+      conditions,
+      typeof dependency === 'string'
+        ? `requires ${dependency}`
+        : 'required condition not met',
+    )
+
+    reasons ??= []
+    reasons.push(resolvedReason)
+  }
+
+  return {
+    enabled: reasons === undefined,
+    reason: reasons?.[0] ?? null,
+    reasons,
+  }
+}
+
+function evaluateSingleTargetBuiltinRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  rule: Rule<F, C>,
+  metadata: InternalRuleMetadata<F, C> | undefined,
+  field: keyof F & string,
+  fields: F,
+  values: FieldValues<F>,
+  conditions: C,
+  availability: Partial<AvailabilityMap<F>>,
+): RuleEvaluation | undefined {
+  if (!metadata || metadata.kind !== rule.type) {
+    return undefined
+  }
+
+  if (metadata.kind === 'enabledWhen') {
+    const passed = metadata.predicate(values, conditions)
+    return {
+      enabled: passed,
+      reason: passed
+        ? null
+        : resolveReason(
+            metadata.options?.reason,
+            values,
+            conditions,
+            'condition not met',
+          ),
+    }
+  }
+
+  if (metadata.kind === 'fairWhen') {
+    const value = values[field]
+    if (!isSatisfied(value, fields[field])) {
+      return { enabled: true, fair: true, reason: null }
+    }
+
+    const passed = metadata.predicate(
+      value as NonNullable<typeof value>,
+      values,
+      conditions,
+    )
+    return {
+      enabled: true,
+      fair: passed,
+      reason: passed
+        ? null
+        : resolveReason(
+            metadata.options?.reason,
+            values,
+            conditions,
+            'selection is no longer valid',
+          ),
+    }
+  }
+
+  if (metadata.kind === 'requires') {
+    return evaluateRequiresRule(
+      metadata,
+      fields,
+      values,
+      conditions,
+      availability,
+    )
+  }
+
+  return undefined
 }
 
 function partitionRulesByPhase<
@@ -266,6 +382,42 @@ export function evaluateRuleForField<
   }
 }
 
+function evaluateRuleForTarget<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  rule: Rule<F, C>,
+  field: keyof F & string,
+  fields: F,
+  values: FieldValues<F>,
+  conditions: C,
+  prev: FieldValues<F> | undefined,
+  availability: Partial<AvailabilityMap<F>>,
+  baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>,
+): RuleEvaluation {
+  return (
+    evaluateSingleTargetBuiltinRule(
+      rule,
+      getInternalRuleMetadata(rule),
+      field,
+      fields,
+      values,
+      conditions,
+      availability,
+    ) ??
+    evaluateRuleForField(
+      rule,
+      field,
+      fields,
+      values,
+      conditions,
+      prev,
+      availability,
+      baseRuleCache,
+    )
+  )
+}
+
 export function evaluate<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -294,7 +446,7 @@ export function evaluate<
     let reason: string | null = null
 
     for (const rule of gateRules) {
-      const result = evaluateRuleForField(
+      const result = evaluateRuleForTarget(
         rule,
         field,
         fields,
@@ -320,7 +472,7 @@ export function evaluate<
 
     if (enabled) {
       for (const rule of fairRules) {
-        const result = evaluateRuleForField(
+        const result = evaluateRuleForTarget(
           rule,
           field,
           fields,

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -179,7 +179,7 @@ export function topologicalSort(
   }
 
   const queue = orderedFields.filter(
-    (field) => (incomingCounts.get(field) ?? 0) === 0,
+    (field) => incomingCounts.get(field)! === 0,
   )
   const result: string[] = []
 

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -134,6 +134,17 @@ type RuleOptions<
     | RuleTraceAttachment<FieldValues<F>, C>[]
 }
 
+export type InternalRuleTargetEvaluator<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+> = (
+  field: keyof F & string,
+  values: FieldValues<F>,
+  conditions: C,
+  fields?: F,
+  availability?: Partial<AvailabilityMap<F>>,
+) => RuleEvaluation
+
 type Source<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -203,7 +214,7 @@ export type InternalFairPredicate<
 export type InternalRuleMetadata<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
-> =
+> = (
   | {
       kind: 'enabledWhen'
       predicate: Predicate<F, C>
@@ -245,6 +256,9 @@ export type InternalRuleMetadata<
       kind: 'custom'
       constraint: RuleConstraint
     }
+) & {
+  evaluateTarget?: InternalRuleTargetEvaluator<F, C>
+}
 
 type InternalRuleMetadataWithOptions<
   F extends Record<string, FieldDef>,
@@ -1121,25 +1135,35 @@ export function enabledWhen<
   options?: RuleOptions<F, C>,
 ): Rule<F, C> {
   const target = getFieldNameOrThrow(field)
+  const evaluateTarget: InternalRuleTargetEvaluator<F, C> = (
+    _field,
+    values,
+    conditions,
+  ) => {
+    const passed = predicate(values, conditions)
+
+    return {
+      enabled: passed,
+      reason: passed
+        ? null
+        : resolveReason(
+            options?.reason,
+            values,
+            conditions,
+            'condition not met',
+          ),
+    }
+  }
 
   const rule: InternalRuleCarrier<F, C> = {
     type: 'enabledWhen',
     targets: [target],
     sources: [],
     evaluate(values, conditions) {
-      const passed = predicate(values, conditions)
-
-      return createSingleResultMap(target, {
-        enabled: passed,
-        reason: passed
-          ? null
-          : resolveReason(
-              options?.reason,
-              values,
-              conditions,
-              'condition not met',
-            ),
-      })
+      return createSingleResultMap(
+        target,
+        evaluateTarget(target, values, conditions),
+      )
     },
   }
 
@@ -1147,6 +1171,7 @@ export function enabledWhen<
     kind: 'enabledWhen',
     predicate,
     options,
+    evaluateTarget,
   }
 
   return rule
@@ -1162,36 +1187,47 @@ export function fairWhen<
   options?: RuleOptions<F, C>,
 ): Rule<F, C> {
   const target = getFieldNameOrThrow(field)
+  const evaluateTarget: InternalRuleTargetEvaluator<F, C> = (
+    field,
+    values,
+    conditions,
+    fields,
+  ) => {
+    const value = values[field]
+
+    if (!isSatisfied(value, fields?.[field])) {
+      return {
+        enabled: true,
+        fair: true,
+        reason: null,
+      }
+    }
+
+    const passed = predicate(value as NonNullable<V>, values, conditions)
+
+    return {
+      enabled: true,
+      fair: passed,
+      reason: passed
+        ? null
+        : resolveReason(
+            options?.reason,
+            values,
+            conditions,
+            'selection is no longer valid',
+          ),
+    }
+  }
 
   const rule: InternalRuleCarrier<F, C> = {
     type: 'fairWhen',
     targets: [target],
     sources: getFairSourceFields(predicate),
     evaluate(values, conditions, _prev, fields) {
-      const value = values[target]
-
-      if (!isSatisfied(value, fields?.[target])) {
-        return createSingleResultMap(target, {
-          enabled: true,
-          fair: true,
-          reason: null,
-        })
-      }
-
-      const passed = predicate(value as NonNullable<V>, values, conditions)
-
-      return createSingleResultMap(target, {
-        enabled: true,
-        fair: passed,
-        reason: passed
-          ? null
-          : resolveReason(
-              options?.reason,
-              values,
-              conditions,
-              'selection is no longer valid',
-            ),
-      })
+      return createSingleResultMap(
+        target,
+        evaluateTarget(target, values, conditions, fields),
+      )
     },
   }
 
@@ -1199,6 +1235,7 @@ export function fairWhen<
     kind: 'fairWhen',
     predicate: predicate as FairPredicate<unknown, F, C>,
     options,
+    evaluateTarget,
   }
 
   return rule
@@ -1265,6 +1302,51 @@ export function requires<
     )
   }
 
+  const evaluateTarget: InternalRuleTargetEvaluator<F, C> = (
+    _field,
+    values,
+    conditions,
+    fields,
+    availability,
+  ) => {
+    let reason: string | null = null
+    let reasons: string[] | undefined
+
+    for (const dependency of dependencies) {
+      if (
+        isRequiredDependencySatisfied(
+          dependency,
+          values,
+          conditions,
+          fields,
+          availability,
+        )
+      ) {
+        continue
+      }
+
+      const resolvedReason = resolveReason(
+        options?.reason,
+        values,
+        conditions,
+        getRequiredDependencyFallback(dependency),
+      )
+
+      if (reason === null) {
+        reason = resolvedReason
+      }
+
+      reasons ??= []
+      reasons.push(resolvedReason)
+    }
+
+    return {
+      enabled: reasons === undefined,
+      reason,
+      reasons,
+    }
+  }
+
   const rule: InternalRuleCarrier<F, C> = {
     type: 'requires',
     targets: [target],
@@ -1272,42 +1354,10 @@ export function requires<
       dependencies.flatMap((dependency) => getSourceFields(dependency)),
     ),
     evaluate(values, conditions, _prev, fields, availability) {
-      let reason: string | null = null
-      let reasons: string[] | undefined
-
-      for (const dependency of dependencies) {
-        if (
-          isRequiredDependencySatisfied(
-            dependency,
-            values,
-            conditions,
-            fields,
-            availability,
-          )
-        ) {
-          continue
-        }
-
-        const resolvedReason = resolveReason(
-          options?.reason,
-          values,
-          conditions,
-          getRequiredDependencyFallback(dependency),
-        )
-
-        if (reason === null) {
-          reason = resolvedReason
-        }
-
-        reasons ??= []
-        reasons.push(resolvedReason)
-      }
-
-      return createSingleResultMap(target, {
-        enabled: reasons === undefined,
-        reason,
-        reasons,
-      })
+      return createSingleResultMap(
+        target,
+        evaluateTarget(target, values, conditions, fields, availability),
+      )
     },
   }
 
@@ -1315,6 +1365,7 @@ export function requires<
     kind: 'requires',
     dependencies,
     options,
+    evaluateTarget,
   }
 
   return rule

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -11,6 +11,7 @@ import {
   runFieldValidator,
 } from './validation.js'
 import type {
+  AvailabilityMap,
   FieldValidator,
   FieldDef,
   FieldValues,
@@ -322,6 +323,15 @@ function createResultMap<F extends Record<string, FieldDef>>(
     results.set(target, resultForTarget(target))
   }
 
+  return results
+}
+
+function createSingleResultMap<F extends Record<string, FieldDef>>(
+  target: keyof F & string,
+  result: RuleResult,
+): Map<string, RuleEvaluation> {
+  const results = new Map<string, RuleEvaluation>()
+  results.set(target, result)
   return results
 }
 
@@ -803,12 +813,7 @@ function getFairSourceFields<
 function getSourceLabel<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
->(source: Source<F, C>): string {
-  // Stryker disable next-line ConditionalExpression,StringLiteral,BlockStatement: equivalent mutant — getSourceLabel is only called for non-string sources (disables() guards string sources at the call site); this branch is never reachable for string inputs
-  if (typeof source === 'string') {
-    return source
-  }
-
+>(source: Predicate<F, C>): string {
   return getCheckField(source) ?? 'condition'
 }
 
@@ -826,6 +831,38 @@ function isSourceActive<
   }
 
   return source(values, conditions)
+}
+
+function isRequiredDependencySatisfied<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  dependency: Source<F, C>,
+  values: FieldValues<F>,
+  conditions: C,
+  fields: F | undefined,
+  availability: Partial<AvailabilityMap<F>> | undefined,
+): boolean {
+  if (typeof dependency !== 'string') {
+    return dependency(values, conditions)
+  }
+
+  return (
+    isSatisfied(values[dependency], fields?.[dependency]) &&
+    (availability?.[dependency]?.enabled ?? true) &&
+    (availability?.[dependency]?.fair ?? true)
+  )
+}
+
+function getRequiredDependencyFallback<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(dependency: Source<F, C>): string {
+  if (typeof dependency === 'string') {
+    return `requires ${dependency}`
+  }
+
+  return `required condition not met`
 }
 
 function isRuleOptions<
@@ -1064,15 +1101,7 @@ export function resolveOneOfState<
       }
     }
 
-    // Stryker disable next-line ConditionalExpression,EqualityOperator,BlockStatement: equivalent mutant — the >1 block body and the post-block fallback are identical (same warn + same return shape with satisfiedBranches[0])
-    if (newlySatisfiedBranches.length > 1) {
-      warnAmbiguousOneOf(groupName, satisfiedBranches)
-      return {
-        activeBranch: satisfiedBranches[0],
-        method: ONE_OF_METHOD.fallbackFirstBranch,
-        branches: branchStates,
-      }
-    }
+    // Multiple newly satisfied branches use the same ambiguous fallback below.
   }
 
   warnAmbiguousOneOf(groupName, satisfiedBranches)
@@ -1100,7 +1129,7 @@ export function enabledWhen<
     evaluate(values, conditions) {
       const passed = predicate(values, conditions)
 
-      return createResultMap([target], () => ({
+      return createSingleResultMap(target, {
         enabled: passed,
         reason: passed
           ? null
@@ -1110,7 +1139,7 @@ export function enabledWhen<
               conditions,
               'condition not met',
             ),
-      }))
+      })
     },
   }
 
@@ -1142,16 +1171,16 @@ export function fairWhen<
       const value = values[target]
 
       if (!isSatisfied(value, fields?.[target])) {
-        return createResultMap([target], () => ({
+        return createSingleResultMap(target, {
           enabled: true,
           fair: true,
           reason: null,
-        }))
+        })
       }
 
       const passed = predicate(value as NonNullable<V>, values, conditions)
 
-      return createResultMap([target], () => ({
+      return createSingleResultMap(target, {
         enabled: true,
         fair: passed,
         reason: passed
@@ -1162,7 +1191,7 @@ export function fairWhen<
               conditions,
               'selection is no longer valid',
             ),
-      }))
+      })
     },
   }
 
@@ -1244,44 +1273,41 @@ export function requires<
     ),
     evaluate(values, conditions, _prev, fields, availability) {
       let reason: string | null = null
-      const reasons: string[] = []
+      let reasons: string[] | undefined
 
       for (const dependency of dependencies) {
-        const passed =
-          typeof dependency === 'string'
-            ? isSatisfied(values[dependency], fields?.[dependency]) &&
-              (availability?.[dependency]?.enabled ?? true) &&
-              (availability?.[dependency]?.fair ?? true)
-            : dependency(values, conditions)
-
-        if (passed) {
+        if (
+          isRequiredDependencySatisfied(
+            dependency,
+            values,
+            conditions,
+            fields,
+            availability,
+          )
+        ) {
           continue
         }
-
-        const fallback =
-          typeof dependency === 'string'
-            ? `requires ${dependency}`
-            : `required condition not met`
 
         const resolvedReason = resolveReason(
           options?.reason,
           values,
           conditions,
-          fallback,
+          getRequiredDependencyFallback(dependency),
         )
 
         if (reason === null) {
           reason = resolvedReason
         }
 
+        reasons ??= []
         reasons.push(resolvedReason)
       }
 
-      return createResultMap([target], () => ({
-        enabled: reasons.length === 0,
+      return createSingleResultMap(target, {
+        enabled: reasons === undefined,
         reason,
-        reasons: reasons.length === 0 ? undefined : reasons,
-      }))
+        reasons,
+      })
     },
   }
 

--- a/packages/core/src/umpire.ts
+++ b/packages/core/src/umpire.ts
@@ -388,259 +388,339 @@ function normalizeConfig<
   }
 }
 
+type DescribeRuleContext<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+> = {
+  field: keyof F & string
+  fields: F
+  values: FieldValues<F>
+  conditions: C
+  prev: FieldValues<F> | undefined
+  availability: AvailabilityMap<F>
+  baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>
+  ruleEntry?: RuleEntry<F, C>
+}
+
+type RuleMetadataOfKind<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+  Kind extends InternalRuleMetadata<F, C>['kind'],
+> = Extract<InternalRuleMetadata<F, C>, { kind: Kind }>
+
+function describeEnabledWhenRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  metadata: RuleMetadataOfKind<F, C, 'enabledWhen'>,
+  evaluation: RuleEvaluation,
+  context: DescribeRuleContext<F, C>,
+): ChallengeTrace['directReasons'][number] {
+  const source = getSourceField(metadata.predicate)
+
+  return withRuleTrace(
+    {
+      rule: 'enabledWhen',
+      ruleIndex: context.ruleEntry?.index,
+      ruleId: context.ruleEntry?.id,
+      passed: evaluation.enabled,
+      reason: evaluation.reason,
+      predicate: metadata.predicate.toString(),
+      source,
+      sourceValue: source ? context.values[source] : undefined,
+    },
+    metadata,
+    context.values,
+    context.conditions,
+    context.prev,
+  )
+}
+
+function describeDisablesRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  metadata: RuleMetadataOfKind<F, C, 'disables'>,
+  evaluation: RuleEvaluation,
+  context: DescribeRuleContext<F, C>,
+): ChallengeTrace['directReasons'][number] {
+  const sourceField = getSourceField(metadata.source)
+  const sourceSatisfied =
+    typeof metadata.source === 'string'
+      ? isSatisfied(
+          context.values[metadata.source],
+          context.fields[metadata.source],
+        )
+      : metadata.source(context.values, context.conditions)
+  const source = sourceField ?? metadata.source.toString()
+
+  return withRuleTrace(
+    {
+      rule: 'disables',
+      ruleIndex: context.ruleEntry?.index,
+      ruleId: context.ruleEntry?.id,
+      passed: evaluation.enabled,
+      reason: evaluation.reason,
+      source,
+      sourceValue: sourceField ? context.values[sourceField] : sourceSatisfied,
+      sourceSatisfied,
+    },
+    metadata,
+    context.values,
+    context.conditions,
+    context.prev,
+  )
+}
+
+function describeFairWhenRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  metadata: RuleMetadataOfKind<F, C, 'fairWhen'>,
+  evaluation: RuleEvaluation,
+  context: DescribeRuleContext<F, C>,
+): ChallengeTrace['directReasons'][number] {
+  return withRuleTrace(
+    {
+      rule: 'fair',
+      ruleIndex: context.ruleEntry?.index,
+      ruleId: context.ruleEntry?.id,
+      passed: evaluation.fair !== false,
+      reason: evaluation.reason,
+      predicate: metadata.predicate.toString(),
+      value: context.values[context.field],
+    },
+    metadata,
+    context.values,
+    context.conditions,
+    context.prev,
+  )
+}
+
+function describeRequiresRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  metadata: RuleMetadataOfKind<F, C, 'requires'>,
+  evaluation: RuleEvaluation,
+  context: DescribeRuleContext<F, C>,
+): ChallengeTrace['directReasons'][number] {
+  const dependencies = metadata.dependencies.map((dependency) => {
+    const dependencyField = getSourceField(dependency)
+
+    if (typeof dependency !== 'string') {
+      return {
+        dependency: dependencyField ?? dependency.toString(),
+        dependencyValue: dependencyField
+          ? context.values[dependencyField]
+          : undefined,
+        satisfied: dependency(context.values, context.conditions),
+      }
+    }
+
+    return {
+      dependency,
+      satisfied: isSatisfied(
+        context.values[dependency],
+        context.fields[dependency],
+      ),
+      dependencyEnabled: context.availability[dependency].enabled,
+      dependencyFair: context.availability[dependency].fair,
+    }
+  })
+
+  return withRuleTrace(
+    {
+      rule: 'requires',
+      ruleIndex: context.ruleEntry?.index,
+      ruleId: context.ruleEntry?.id,
+      passed: evaluation.enabled,
+      reason: evaluation.reason,
+      dependency: dependencies[0]?.dependency,
+      dependencyValue: dependencies[0]?.dependencyValue,
+      satisfied: dependencies[0]?.satisfied,
+      dependencyEnabled: dependencies[0]?.dependencyEnabled,
+      dependencyFair: dependencies[0]?.dependencyFair,
+      dependencies,
+    },
+    metadata,
+    context.values,
+    context.conditions,
+    context.prev,
+  )
+}
+
+function describeOneOfRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  metadata: RuleMetadataOfKind<F, C, 'oneOf'>,
+  evaluation: RuleEvaluation,
+  context: DescribeRuleContext<F, C>,
+): ChallengeTrace['directReasons'][number] {
+  const resolution = resolveOneOfState(
+    metadata.groupName,
+    metadata.branches,
+    context.values,
+    context.prev,
+    metadata.options?.activeBranch,
+    context.fields,
+    context.conditions,
+  )
+  const thisBranch =
+    Object.entries(metadata.branches).find(([, branchFields]) =>
+      branchFields.includes(context.field),
+    )?.[0] ??
+    /* istanbul ignore next: oneOf rules target exactly their branch fields after construction validation. */
+    null
+
+  return withRuleTrace(
+    {
+      rule: 'oneOf',
+      ruleIndex: context.ruleEntry?.index,
+      ruleId: context.ruleEntry?.id,
+      passed: evaluation.enabled,
+      reason: evaluation.reason,
+      group: metadata.groupName,
+      activeBranch: resolution.activeBranch,
+      thisBranch,
+    },
+    metadata,
+    context.values,
+    context.conditions,
+    context.prev,
+  )
+}
+
+function describeAnyOfRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  rule: Rule<F, C>,
+  metadata: RuleMetadataOfKind<F, C, 'anyOf'>,
+  evaluation: RuleEvaluation,
+  context: DescribeRuleContext<F, C>,
+): ChallengeTrace['directReasons'][number] {
+  const inner: ChallengeTrace['directReasons'] = metadata.rules.map(
+    (innerRule) => describeRuleForField(innerRule, context),
+  )
+
+  return {
+    rule: 'anyOf',
+    ruleIndex: context.ruleEntry?.index,
+    ruleId: context.ruleEntry?.id,
+    passed: didRulePass(rule, evaluation),
+    reason: evaluation.reason,
+    inner,
+  }
+}
+
+function describeEitherOfRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  rule: Rule<F, C>,
+  metadata: RuleMetadataOfKind<F, C, 'eitherOf'>,
+  evaluation: RuleEvaluation,
+  context: DescribeRuleContext<F, C>,
+): ChallengeTrace['directReasons'][number] {
+  const branches = Object.fromEntries(
+    Object.entries(metadata.branches).map(([branchName, branchRules]) => {
+      const inner = branchRules.map((innerRule) =>
+        describeRuleForField(innerRule, context),
+      )
+
+      return [
+        branchName,
+        {
+          passed: inner.every((entry) => entry.passed),
+          inner,
+        },
+      ]
+    }),
+  ) as Record<
+    string,
+    { passed: boolean; inner: ChallengeTrace['directReasons'] }
+  >
+
+  const matchedBranches = Object.entries(branches)
+    .filter(([, branch]) => branch.passed)
+    .map(([branchName]) => branchName)
+
+  return {
+    rule: 'eitherOf',
+    ruleIndex: context.ruleEntry?.index,
+    ruleId: context.ruleEntry?.id,
+    passed: didRulePass(rule, evaluation),
+    reason: evaluation.reason,
+    group: metadata.groupName,
+    constraint: metadata.constraint,
+    matchedBranches,
+    branches,
+  }
+}
+
+function describeFallbackRule<
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown>,
+>(
+  rule: Rule<F, C>,
+  metadata: InternalRuleMetadata<F, C> | undefined,
+  evaluation: RuleEvaluation,
+  context: DescribeRuleContext<F, C>,
+): ChallengeTrace['directReasons'][number] {
+  return withRuleTrace(
+    {
+      rule: rule.type,
+      ruleIndex: context.ruleEntry?.index,
+      ruleId: context.ruleEntry?.id,
+      passed: didRulePass(rule, evaluation),
+      reason: evaluation.reason,
+    },
+    metadata,
+    context.values,
+    context.conditions,
+    context.prev,
+  )
+}
+
 function describeRuleForField<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
 >(
   rule: Rule<F, C>,
-  field: keyof F & string,
-  fields: F,
-  values: FieldValues<F>,
-  conditions: C,
-  prev: FieldValues<F> | undefined,
-  availability: AvailabilityMap<F>,
-  baseRuleCache: Map<Rule<F, C>, Map<string, RuleEvaluation>>,
-  ruleEntry?: RuleEntry<F, C>,
+  context: DescribeRuleContext<F, C>,
 ): ChallengeTrace['directReasons'][number] {
   const metadata = getInternalRuleMetadata(rule)
   const evaluation = evaluateRuleForField(
     rule,
-    field,
-    fields,
-    values,
-    conditions,
-    prev,
-    availability,
-    baseRuleCache,
+    context.field,
+    context.fields,
+    context.values,
+    context.conditions,
+    context.prev,
+    context.availability,
+    context.baseRuleCache,
   )
 
-  if (metadata?.kind === 'enabledWhen') {
-    const source = getSourceField(metadata.predicate)
-
-    return withRuleTrace(
-      {
-        rule: 'enabledWhen',
-        ruleIndex: ruleEntry?.index,
-        ruleId: ruleEntry?.id,
-        passed: evaluation.enabled,
-        reason: evaluation.reason,
-        predicate: metadata.predicate.toString(),
-        source,
-        sourceValue: source ? values[source] : undefined,
-      },
-      metadata,
-      values,
-      conditions,
-      prev,
-    )
+  switch (metadata?.kind) {
+    case 'enabledWhen':
+      return describeEnabledWhenRule(metadata, evaluation, context)
+    case 'disables':
+      return describeDisablesRule(metadata, evaluation, context)
+    case 'fairWhen':
+      return describeFairWhenRule(metadata, evaluation, context)
+    case 'requires':
+      return describeRequiresRule(metadata, evaluation, context)
+    case 'oneOf':
+      return describeOneOfRule(metadata, evaluation, context)
+    case 'anyOf':
+      return describeAnyOfRule(rule, metadata, evaluation, context)
+    case 'eitherOf':
+      return describeEitherOfRule(rule, metadata, evaluation, context)
+    default:
+      return describeFallbackRule(rule, metadata, evaluation, context)
   }
-
-  if (metadata?.kind === 'disables') {
-    const sourceField = getSourceField(metadata.source)
-    const sourceSatisfied =
-      typeof metadata.source === 'string'
-        ? isSatisfied(values[metadata.source], fields[metadata.source])
-        : metadata.source(values, conditions)
-    const source = sourceField ?? metadata.source.toString()
-
-    return withRuleTrace(
-      {
-        rule: 'disables',
-        ruleIndex: ruleEntry?.index,
-        ruleId: ruleEntry?.id,
-        passed: evaluation.enabled,
-        reason: evaluation.reason,
-        source,
-        sourceValue: sourceField ? values[sourceField] : sourceSatisfied,
-        sourceSatisfied,
-      },
-      metadata,
-      values,
-      conditions,
-      prev,
-    )
-  }
-
-  if (metadata?.kind === 'fairWhen') {
-    return withRuleTrace(
-      {
-        rule: 'fair',
-        ruleIndex: ruleEntry?.index,
-        ruleId: ruleEntry?.id,
-        passed: evaluation.fair !== false,
-        reason: evaluation.reason,
-        predicate: metadata.predicate.toString(),
-        value: values[field],
-      },
-      metadata,
-      values,
-      conditions,
-      prev,
-    )
-  }
-
-  if (metadata?.kind === 'requires') {
-    const dependencies = metadata.dependencies.map((dependency) => {
-      const dependencyField = getSourceField(dependency)
-
-      if (typeof dependency !== 'string') {
-        return {
-          dependency: dependencyField ?? dependency.toString(),
-          dependencyValue: dependencyField
-            ? values[dependencyField]
-            : undefined,
-          satisfied: dependency(values, conditions),
-        }
-      }
-
-      return {
-        dependency,
-        satisfied: isSatisfied(values[dependency], fields[dependency]),
-        dependencyEnabled: availability[dependency].enabled,
-        dependencyFair: availability[dependency].fair,
-      }
-    })
-
-    return withRuleTrace(
-      {
-        rule: 'requires',
-        ruleIndex: ruleEntry?.index,
-        ruleId: ruleEntry?.id,
-        passed: evaluation.enabled,
-        reason: evaluation.reason,
-        dependency: dependencies[0]?.dependency,
-        dependencyValue: dependencies[0]?.dependencyValue,
-        satisfied: dependencies[0]?.satisfied,
-        dependencyEnabled: dependencies[0]?.dependencyEnabled,
-        dependencyFair: dependencies[0]?.dependencyFair,
-        dependencies,
-      },
-      metadata,
-      values,
-      conditions,
-      prev,
-    )
-  }
-
-  if (metadata?.kind === 'oneOf') {
-    const resolution = resolveOneOfState(
-      metadata.groupName,
-      metadata.branches,
-      values,
-      prev,
-      metadata.options?.activeBranch,
-      fields,
-      conditions,
-    )
-    const thisBranch =
-      Object.entries(metadata.branches).find(([, branchFields]) =>
-        branchFields.includes(field),
-      )?.[0] ?? null
-
-    return withRuleTrace(
-      {
-        rule: 'oneOf',
-        ruleIndex: ruleEntry?.index,
-        ruleId: ruleEntry?.id,
-        passed: evaluation.enabled,
-        reason: evaluation.reason,
-        group: metadata.groupName,
-        activeBranch: resolution.activeBranch,
-        thisBranch,
-      },
-      metadata,
-      values,
-      conditions,
-      prev,
-    )
-  }
-
-  if (metadata?.kind === 'anyOf') {
-    const inner: ChallengeTrace['directReasons'] = metadata.rules.map(
-      (innerRule) =>
-        describeRuleForField(
-          innerRule,
-          field,
-          fields,
-          values,
-          conditions,
-          prev,
-          availability,
-          baseRuleCache,
-          ruleEntry,
-        ),
-    )
-
-    return {
-      rule: 'anyOf',
-      ruleIndex: ruleEntry?.index,
-      ruleId: ruleEntry?.id,
-      passed: didRulePass(rule, evaluation),
-      reason: evaluation.reason,
-      inner,
-    }
-  }
-
-  if (metadata?.kind === 'eitherOf') {
-    const branches = Object.fromEntries(
-      Object.entries(metadata.branches).map(([branchName, branchRules]) => {
-        const inner = branchRules.map((innerRule) =>
-          describeRuleForField(
-            innerRule,
-            field,
-            fields,
-            values,
-            conditions,
-            prev,
-            availability,
-            baseRuleCache,
-            ruleEntry,
-          ),
-        )
-
-        return [
-          branchName,
-          {
-            passed: inner.every((entry) => entry.passed),
-            inner,
-          },
-        ]
-      }),
-    ) as Record<
-      string,
-      { passed: boolean; inner: ChallengeTrace['directReasons'] }
-    >
-
-    const matchedBranches = Object.entries(branches)
-      .filter(([, branch]) => branch.passed)
-      .map(([branchName]) => branchName)
-
-    return {
-      rule: 'eitherOf',
-      ruleIndex: ruleEntry?.index,
-      ruleId: ruleEntry?.id,
-      passed: didRulePass(rule, evaluation),
-      reason: evaluation.reason,
-      group: metadata.groupName,
-      constraint: metadata.constraint,
-      matchedBranches,
-      branches,
-    }
-  }
-
-  return withRuleTrace(
-    {
-      rule: rule.type,
-      ruleIndex: ruleEntry?.index,
-      ruleId: ruleEntry?.id,
-      passed: didRulePass(rule, evaluation),
-      reason: evaluation.reason,
-    },
-    metadata,
-    values,
-    conditions,
-    prev,
-  )
 }
 
 function collectFailedDependenciesForRule<
@@ -671,6 +751,7 @@ function collectFailedDependenciesForRule<
     )
 
     if (
+      /* istanbul ignore next: fair anyOf rules cannot currently contribute transitive field dependencies. */
       metadata.constraint === 'fair'
         ? evaluation.fair !== false
         : evaluation.enabled
@@ -711,6 +792,7 @@ function collectFailedDependenciesForRule<
     )
 
     if (
+      /* istanbul ignore next: fair eitherOf rules cannot currently contribute transitive field dependencies. */
       metadata.constraint === 'fair'
         ? evaluation.fair !== false
         : evaluation.enabled
@@ -797,8 +879,7 @@ function describeCausedBy<
   const causedBy: ChallengeTrace['transitiveDeps'][number]['causedBy'] = []
 
   for (const rule of rulesByTarget.get(field) ?? []) {
-    const entry = describeRuleForField(
-      rule,
+    const entry = describeRuleForField(rule, {
       field,
       fields,
       values,
@@ -806,8 +887,8 @@ function describeCausedBy<
       prev,
       availability,
       baseRuleCache,
-      ruleEntryByRule.get(rule),
-    )
+      ruleEntry: ruleEntryByRule.get(rule),
+    })
 
     if (entry.passed) {
       continue
@@ -1284,17 +1365,16 @@ export function umpire<
     >()
     const targetRules = rulesByTarget.get(field) ?? []
     const directReasons = targetRules.map((rule) =>
-      describeRuleForField(
-        rule,
+      describeRuleForField(rule, {
         field,
         fields,
-        typedValues,
-        resolvedConditions,
-        typedPrev,
+        values: typedValues,
+        conditions: resolvedConditions,
+        prev: typedPrev,
         availability,
         baseRuleCache,
-        ruleEntryByRule.get(rule),
-      ),
+        ruleEntry: ruleEntryByRule.get(rule),
+      }),
     )
 
     const oneOfRule = targetRules.find((rule) => {

--- a/test/istanbul-coverage-preload.ts
+++ b/test/istanbul-coverage-preload.ts
@@ -38,6 +38,7 @@ function shouldInstrument(filePath: string) {
 
   if (
     relativePath.includes('/__tests__/') ||
+    relativePath.includes('/scripts/') ||
     relativePath.includes('/smoke/') ||
     relativePath.includes('/dist/') ||
     relativePath.includes('/coverage-istanbul/')


### PR DESCRIPTION
## Summary

This PR tightens `@umpire/core`'s hot paths and adds benchmark instrumentation for speed and retained-memory investigation.

### Core performance work

- Removes the remaining core complexity lint violations by splitting the large evaluator/description paths into smaller helpers.
- Avoids avoidable per-check allocation in common rule paths:
  - reuses a frozen default rule evaluation for missing target results
  - avoids temporary target maps for single-target built-in rules
  - avoids reasons arrays for passing `requires()` rules
  - streams `anyOf()` failure aggregation instead of materializing intermediate result arrays
- Moves direct per-target evaluation for `enabledWhen`, `fairWhen`, and `requires` into rule metadata so compiled `check()`/`play()` can bypass full `rule.evaluate()` map creation.
- Extends that direct path inside `anyOf()` and `eitherOf()` inner rules.
- Preserves public API behavior and composite rule semantics.

### Benchmark/tooling work

- Adds normal benchmark heap/object delta reporting.
- Adds isolated memory mode: `yarn workspace @umpire/core bench:memory`.
- Adds leak-trend mode: `yarn workspace @umpire/core bench:leak`.
  - warms each hot-path scenario
  - runs repeated GC-separated batches
  - rotates through prebuilt input objects by default
  - reports heap/object slopes to distinguish stable fixture retention from leak-shaped growth
- Adds profile output ignore for `packages/core/benchmark-profiles/`.
- Adds a patch changeset for `@umpire/core`.

## Performance Measurements

Latest `BENCH_RUNS=30 yarn workspace @umpire/core bench` on this branch:

| Benchmark | Category | Avg Total |
| --- | --- | ---: |
| `create/scheduler-60-sections` | construction-heavy | 51.33ms |
| `check/scheduler/pro-plan` | runtime-heavy | 35.53ms |
| `check/scheduler/basic-readonly` | runtime-heavy | 40.75ms |
| `challenge/review-lock-chain` | runtime-heavy | 27.65ms |
| `play/plan-downgrade` | runtime-heavy | 57.44ms |
| `graph/export-scheduler` | construction-heavy | 3.49ms |
| `check/minesweeper-expert-board` | runtime-heavy | 7.55ms |

Runtime-heavy aggregate: `168.92ms`.

For comparison, the earlier post-cleanup runtime-heavy baseline was about `270.51ms`, and the first direct-fast-path pass was around `188.42ms`. The final composite inner-rule fast path pushed the runtime-heavy aggregate to `168.92ms` without increasing the browser bundle over the metadata-owned evaluator build.

Browser build after the final optimization:

- `dist/index.browser.js`: `28.79 kB`
- gzip: `8.70 kB`

## rAF Budget Sizing

I also measured a scheduler-style `check()` workload of increasing size. This workload mixes `oneOf`, `requires`, `anyOf`, `enabledWhen`, `disables`, `prev`, and stale values.

| Workload | Fields | Top-Level Rules | Effective Rules | p95/check |
| ---: | ---: | ---: | ---: | ---: |
| 20 sections | 220 | 180 | ~240 | 0.10ms |
| 60 sections | 660 | 540 | ~720 | 0.39ms |
| 100 sections | 1,100 | 900 | ~1,200 | 0.85ms |
| 400 sections | 4,400 | 3,600 | ~4,800 | 2.89ms |
| 600 sections | 6,600 | 5,400 | ~7,200 | 5.63ms |
| 800 sections | 8,800 | 7,200 | ~9,600 | 7.68ms |
| 1,200 sections | 13,200 | 10,800 | ~14,400 | 13.81ms |
| 1,500 sections | 16,500 | 13,500 | ~18,000 | 17.58ms |

Practical read: for an animation-frame interaction, reserving only `2-4ms` for Umpire still leaves room for thousands of fields/rules in this synthetic workload. A typical modest ruleset in the `50-200` field range should be comfortably below frame-budget concern on desktop-class hardware.

## Memory / Leak Notes

The leak benchmark does not show leak-shaped retained growth in `check()` or `play()` hot paths. The profile output points mostly at long-lived benchmark fixtures and compiled rule graphs, not repeated per-call retained objects.

## Verification

- `yarn workspace @umpire/core test` -> `339 pass`
- `yarn test:coverage:istanbul core` -> `100%` statements, branches, functions, lines
- `yarn lint` -> no core warnings; existing non-core complexity warnings remain
- `yarn typecheck` / push hook -> full repo typecheck/build graph passed
- `BENCH_RUNS=30 yarn workspace @umpire/core bench`
- `yarn workspace @umpire/core bench:leak`
