### PR TITLE
🌎 Full `Effect` v4 Integration

### DIFF
--- a/.changeset/effect-full-integ.md
+++ b/.changeset/effect-full-integ.md
@@ -1,5 +1,7 @@
 ---
-'@umpire/effect': patch
+'@umpire/effect': minor
 ---
 
-Adds Effect-native adapter methods (`runEffect`, `runValidate`) for composable validation in `Effect.gen` flows, a `UmpireValidationError` tagged error for the Effect error channel, an `availabilityStream` over `SubscriptionRef` for composable availability in stream programs, and an `umpireLayer` factory for injecting umpire instances as Effect services via `Context.Service`.
+Effect-native validation with full service/context support: `runEffect` and `runValidate` now use Effect Schema's effectful decode path, supporting service-requiring schemas (R ≠ never) through the Effect `R` channel. Sync APIs (`run`, `validators`) are conditionally available only for context-free schemas via `SyncAdapterMembers`.
+
+New `decodeEffectSchemaEffect` helper for effectful schema decoding. New `availabilityStreamAsync` and `umpireAsyncLayer` for `@umpire/async` instances. Also includes `UmpireValidationError` tagged error, `availabilityStream`, and `umpireLayer` for `@umpire/core`.

--- a/.changeset/effect-full-integ.md
+++ b/.changeset/effect-full-integ.md
@@ -4,4 +4,4 @@
 
 Effect-native validation with full service/context support: `runEffect` and `runValidate` now use Effect Schema's effectful decode path, supporting service-requiring schemas (R ≠ never) through the Effect `R` channel. Sync APIs (`run`, `validators`) are conditionally available only for context-free schemas via `SyncAdapterMembers`.
 
-New `decodeEffectSchemaEffect` helper for effectful schema decoding. New `availabilityStreamAsync` and `umpireAsyncLayer` for `@umpire/async` instances. Also includes `UmpireValidationError` tagged error, `availabilityStream`, and `umpireLayer` for `@umpire/core`.
+New `decodeEffectSchema` helper for effectful schema decoding and `decodeEffectSchemaSync` for context-free sync decoding. New `availabilityStreamAsync` and `umpireAsyncLayer` for `@umpire/async` instances. Also includes `UmpireValidationError` tagged error, `availabilityStream`, and `umpireLayer` for `@umpire/core`.

--- a/.changeset/effect-full-integ.md
+++ b/.changeset/effect-full-integ.md
@@ -1,0 +1,5 @@
+---
+'@umpire/effect': patch
+---
+
+Adds Effect-native adapter methods (`runEffect`, `runValidate`) for composable validation in `Effect.gen` flows, a `UmpireValidationError` tagged error for the Effect error channel, an `availabilityStream` over `SubscriptionRef` for composable availability in stream programs, and an `umpireLayer` factory for injecting umpire instances as Effect services via `Context.Service`.

--- a/.changeset/effect-full-integ.md
+++ b/.changeset/effect-full-integ.md
@@ -4,4 +4,4 @@
 
 Effect-native validation with full service/context support: `runEffect` and `runValidate` now use Effect Schema's effectful decode path, supporting service-requiring schemas (R ≠ never) through the Effect `R` channel. Sync APIs (`run`, `validators`) are conditionally available only for context-free schemas via `SyncAdapterMembers`.
 
-New `decodeEffectSchema` helper for effectful schema decoding and `decodeEffectSchemaSync` for context-free sync decoding. New `availabilityStreamAsync` and `umpireAsyncLayer` for `@umpire/async` instances. Also includes `UmpireValidationError` tagged error, `availabilityStream`, and `umpireLayer` for `@umpire/core`.
+New `decodeEffectSchema` helper for effectful schema decoding and `decodeEffectSchemaSync` for context-free sync decoding. New `availabilityStreamAsync` and `umpireAsyncLayer` for `@umpire/async` instances, plus `toAsyncWriteValidationAdapter` for bridging Effect validation into async write/Drizzle flows. Also includes `UmpireValidationError` tagged error, `availabilityStream`, and `umpireLayer` for `@umpire/core`.

--- a/.changeset/store-destroy-guard.md
+++ b/.changeset/store-destroy-guard.md
@@ -1,0 +1,5 @@
+---
+'@umpire/store': patch
+---
+
+Ensure `fromStore().destroy()` immediately suppresses late adapter emissions before calling the underlying unsubscribe.

--- a/docs/src/content/docs/adapters/validation/effect.md
+++ b/docs/src/content/docs/adapters/validation/effect.md
@@ -3,7 +3,7 @@ title: '@umpire/effect'
 description: Build availability-aware Effect schemas from an Umpire availability map, plus a SubscriptionRef bridge for reactive state.
 ---
 
-`@umpire/effect` bridges Umpire's availability map and Effect's Schema system. Disabled fields are excluded from validation. Required/optional follows Umpire's output, not your schema definitions. It also provides `fromSubscriptionRef` for connecting an Effect `SubscriptionRef` to the `@umpire/store` reactive adapter.
+`@umpire/effect` bridges Umpire's availability map and Effect's Schema system. Disabled fields are excluded from validation. Required/optional follows Umpire's output, not your schema definitions. It provides two validation paths — sync APIs for context-free schemas and effectful APIs for schemas that require services. It also offers a `SubscriptionRef` bridge, reactive `Stream` generators, and `Layer` constructors for wiring Umpire into the Effect service environment.
 
 ## Install
 
@@ -52,9 +52,9 @@ const schema = deriveSchema(availability, fieldSchemas)
 const result = decodeEffectSchema(schema, values)
 ```
 
-`decodeEffectSchema()` returns a convenient `{ _tag: 'Right' | 'Left' }` result. If you call Effect directly, use Effect v4's native `Schema.decodeUnknownResult()` API.
+`deriveSchema` **preserves the `R` parameter** from your field schemas. If any field schema requires a service, the returned struct schema carries that requirement. Use `decodeEffectSchema()` to decode it synchronously (requires `R = never`), or `decodeEffectSchemaEffect()` to decode it with full service support.
 
-Schemas must have no service/context dependencies.
+`decodeEffectSchema()` returns a convenient `{ _tag: 'Right' | 'Left' }` result. If you call Effect directly, use Effect v4's native `Schema.decodeUnknownResult()` API.
 
 #### `rejectFoul` option
 
@@ -68,6 +68,28 @@ const result = decodeEffectSchema(schema, body)
 ```
 
 When `rejectFoul: true`, a foul field with a present value fails with the field's `reason` as the error message. If the field is optional and absent, it passes — only submissions that *contain* a foul value are rejected.
+
+### `decodeEffectSchemaEffect(schema, input, options?)`
+
+The effectful variant of `decodeEffectSchema`. Use this when your schema has service dependencies (`R ≠ never`):
+
+```ts
+import { Effect } from 'effect'
+import { decodeEffectSchemaEffect, deriveSchema } from '@umpire/effect'
+
+const schema = deriveSchema(availability, fieldSchemas)
+// schema may carry R from field schemas with service dependencies
+
+const program = Effect.gen(function* () {
+  const result = yield* decodeEffectSchemaEffect(schema, values, { errors: 'all' })
+  if (result._tag === 'Left') {
+    // handle errors
+  }
+  return result
+})
+```
+
+The sync `decodeEffectSchema` requires `R = never` — it cannot handle service-requiring schemas. `decodeEffectSchemaEffect` supports the full Effect Schema `R` channel.
 
 ### `effectErrors(parseError)`
 
@@ -93,10 +115,19 @@ const errors = deriveErrors(availability, effectErrors(result.error))
 
 ### `createEffectAdapter()({ schemas, build?, valueShape?, namespace?, rejectFoul? })`
 
-Convenience adapter that bundles the `deriveSchema → decode → deriveErrors` flow:
+Convenience adapter that bundles the `deriveSchema → decode → deriveErrors` flow. The adapter provides different members depending on whether your schemas have service dependencies.
 
+**When all schemas are context-free** (`R = never`):
 - `validators` — per-field validators for `umpire({ validators })`, surfacing the first parse issue as `error`
 - `run(availability, values)` — full validation returning `{ errors, normalizedErrors, result, schemaFields }`
+
+**Always available:**
+- `runEffect(availability, values)` — returns `Effect<EffectAdapterRunResult, never, R>`. Works with any `R`.
+- `runValidate(availability, values)` — returns `Effect<Out, UmpireValidationError, R>`. Succeeds with the parsed output, fails with `UmpireValidationError` on failure. Works with any `R`.
+
+When your schemas have service dependencies (`R ≠ never`), `validators` and `run` are **not present** on the returned adapter. You get a TypeScript error at the call site. Use `runEffect` or `runValidate` instead.
+
+#### Sync example (context-free schemas)
 
 ```ts
 const validation = createEffectAdapter()({
@@ -113,13 +144,49 @@ const ump = umpire({
   validators: validation.validators,
 })
 
-// Full derived-schema validation
+// Full derived-schema validation (sync)
 const result = validation.run(availability, values)
 if (result.result._tag === 'Left') {
   console.log(result.errors)       // { email: 'Enter a valid email' }
   console.log(result.schemaFields)  // ['email'] — disabled fields excluded
 }
 ```
+
+#### Effectful example (service-requiring schemas)
+
+```ts
+import { Effect, Schema } from 'effect'
+import { createEffectAdapter, UmpireValidationError } from '@umpire/effect'
+
+const fieldSchemas = {
+  username: Schema.String,
+  email: Schema.String.pipe(
+    Schema.filterEffect((s: string) =>
+      Effect.gen(function* () {
+        const repo = yield* UserRepo
+        const exists = yield* repo.findByEmail(s)
+        return !exists
+      }),
+    ),
+    { message: () => 'Email already taken' },
+  ),
+}
+
+const validation = createEffectAdapter()({ schemas: fieldSchemas })
+// validation.validators — not available (R ≠ never)
+// validation.run — not available (R ≠ never)
+
+// Use the effectful methods instead
+const program = validation.runValidate(availability, values).pipe(
+  Effect.catchTag('UmpireValidationError', (error) =>
+    Effect.succeed({ errors: error.errors }),
+  ),
+)
+
+Effect.runPromise(program.pipe(Effect.provideService(UserRepo, myRepo)))
+```
+
+#### Build option
 
 Use `build` to add cross-field refinements on the derived schema:
 
@@ -143,7 +210,7 @@ const validation = createEffectAdapter()({
 
 The root-level refinement error surfaces under `result.errors._root`.
 
-If you need every issue or deeper control, use `deriveSchema()` with either `decodeEffectSchema()` or Effect v4's native decode API.
+If you need every issue or deeper control, use `deriveSchema()` with either `decodeEffectSchema()` (sync) or `decodeEffectSchemaEffect()` (effectful).
 
 #### Nested value shape
 
@@ -180,7 +247,155 @@ When `valueShape` is `'nested'`:
 
 `namespace.separator` controls which character splits field names into path segments and defaults to `'.'`.
 
-## `fromSubscriptionRef()`
+### `UmpireValidationError`
+
+A tagged error class thrown by `runValidate` on validation failure. It carries the structured error information from the failed validation run:
+
+```ts
+import { Data } from 'effect'
+import type { NormalizedFieldError } from '@umpire/effect'
+
+// The shape
+class UmpireValidationError extends Data.TaggedError('UmpireValidationError')<{
+  readonly errors: Record<string, string | undefined>
+  readonly message: string
+  readonly normalizedErrors: NormalizedFieldError[]
+}>
+```
+
+Use `Effect.catchTag` to handle it:
+
+```ts
+validation.runValidate(availability, values).pipe(
+  Effect.catchTag('UmpireValidationError', (error) => {
+    console.log(error.message)           // 'Validation failed: email, password'
+    console.log(error.errors)             // { email: 'Enter a valid email', password: undefined }
+    console.log(error.normalizedErrors)   // [{ field: 'email', message: '...' }, ...]
+    return Effect.succeed({ errors: error.errors })
+  }),
+)
+```
+
+`error.errors` is a `Record<string, string | undefined>` — one entry per field. A field that passed validation has `undefined` as its value. Only fields with errors get message strings.
+
+### `availabilityStream(ump, ref, options)`
+
+Returns an Effect `Stream<AvailabilityMap<F>, never, never>` from a `SubscriptionRef`. Each time the ref changes, the stream emits a fresh availability map computed by `ump.check()`. The stream's error channel is `never` because `@umpire/core` checks are synchronous and never reject.
+
+```ts
+import { Effect, Stream, SubscriptionRef } from 'effect'
+import { enabledWhen, umpire } from '@umpire/core'
+import { availabilityStream } from '@umpire/effect'
+
+const ump = umpire({
+  fields: { name: {}, email: {} },
+  rules: [enabledWhen('email', (_v, c: { showEmail: boolean }) => c.showEmail)],
+})
+
+const ref = Effect.runSync(SubscriptionRef.make({ showEmail: false }))
+
+const stream = availabilityStream(ump, ref, {
+  select: () => ({}),
+  conditions: (state) => state,
+})
+
+// The first emission is a fresh check (no previous values).
+// Subsequent emissions use the previous values for diff-aware rules.
+const history = Effect.runSync(Stream.runCollect(stream.pipe(Stream.take(2))))
+// history has 2 availability snapshots: [initial, after-first-change]
+```
+
+The `select` and `conditions` options follow the same contract as `@umpire/store`. See [Selection](/concepts/selection/).
+
+### `availabilityStreamAsync(ump, ref, options)`
+
+Same as `availabilityStream` but for `@umpire/async` instances. The stream's error channel is `unknown` because `@umpire/async` checks are promise-based and can reject:
+
+```ts
+import { availabilityStreamAsync } from '@umpire/effect'
+import { umpire as asyncUmpire } from '@umpire/async'
+
+const asyncUmp = asyncUmpire({
+  fields: { name: {}, email: {} },
+  rules: [enabledWhen('email', (_v, c: { showEmail: boolean }) => c.showEmail)],
+})
+
+const stream = availabilityStreamAsync(asyncUmp, ref, {
+  select: () => ({}),
+  conditions: (state) => state,
+})
+// Stream<AvailabilityMap<F>, unknown, never>
+```
+
+If a check rejects, the stream fails with that error. Handle it with `Stream.catchAll` or `Stream.orElse`.
+
+### `umpireLayer(tag, definition)`
+
+Creates an Effect `Layer` that provides an `@umpire/core` `Umpire` instance as a service. Use this to wire Umpire into your Effect service environment for dependency injection:
+
+```ts
+import { Context, Effect, Layer } from 'effect'
+import { enabledWhen } from '@umpire/core'
+import { umpireLayer } from '@umpire/effect'
+
+class UmpireService extends Context.Tag('UmpireService')<
+  UmpireService,
+  ReturnType<typeof umpire>
+>() {}
+
+const layer = umpireLayer(UmpireService, {
+  fields: { name: {}, email: {} },
+  rules: [
+    enabledWhen('email', (_v, c: { showEmail: boolean }) => c.showEmail),
+  ],
+})
+
+const program = Effect.gen(function* () {
+  const ump = yield* UmpireService
+  const availability = ump.check({ name: 'Jane' }, { showEmail: true })
+  // ...
+})
+
+Effect.runPromise(program.pipe(Effect.provide(layer)))
+```
+
+The layer is built with `Layer.sync` — the Umpire instance is constructed eagerly when the layer is provided.
+
+### `umpireAsyncLayer(tag, definition)`
+
+Same as `umpireLayer` but for `@umpire/async` instances:
+
+```ts
+import { umpireAsyncLayer } from '@umpire/effect'
+
+const asyncLayer = umpireAsyncLayer(AsyncUmpireService, {
+  fields: { name: {}, email: {} },
+  rules: [enabledWhen('email', (_v, c: { showEmail: boolean }) => c.showEmail)],
+})
+```
+
+### Sync-vs-effect boundary
+
+`@umpire/effect` draws a clean line between sync and effectful APIs. This table summarizes which APIs handle service-requiring Effect schemas:
+
+| API | Requires `R = never`? | Handles service-requiring schemas? |
+|---|---|---|
+| `deriveSchema()` | No — preserves `R` | Yes |
+| `decodeEffectSchema()` | Yes | No |
+| `decodeEffectSchemaEffect()` | No | Yes |
+| `createEffectAdapter().validators` | Yes | No |
+| `createEffectAdapter().run()` | Yes | No |
+| `createEffectAdapter().runEffect()` | No | Yes |
+| `createEffectAdapter().runValidate()` | No | Yes |
+| `availabilityStream()` | N/A (no schemas) | N/A |
+| `availabilityStreamAsync()` | N/A (no schemas) | N/A |
+| `umpireLayer()` / `umpireAsyncLayer()` | N/A (no schemas) | N/A |
+
+`deriveSchema` itself preserves the `R` parameter from your field schemas. If a field schema requires a service (e.g. a repository for uniqueness checks), the struct schema returned by `deriveSchema` will require it too. You can feed that schema directly to `decodeEffectSchemaEffect`, `runEffect`, or `runValidate` — all of which support the full `R` channel.
+
+The sync APIs (`decodeEffectSchema`, `validators`, `run`) are available only when all schemas are context-free. When you use a service-requiring schema, those members are not present on the adapter — you get a TypeScript error at the call site rather than a runtime failure.
+
+### `fromSubscriptionRef()`
 
 Bridges an Effect `SubscriptionRef<S>` to the `@umpire/store` contract. It runs a background fiber to track changes and interrupts it on `destroy()`.
 
@@ -254,7 +469,9 @@ That keeps blank strings in the "not yet validateable" lane until the field is a
 
 ## When to use the manual pattern instead
 
-`@umpire/effect` handles the common case. If you need finer control — async validation, nested schemas, custom transformations, or custom error formatting — the manual intersection approach in [Composing with Validation](/concepts/validation/) gives you full flexibility.
+`@umpire/effect` handles the common case — both sync and effectful. If you need finer control — custom transformations, custom error formatting, or patterns the adapter doesn't cover — the manual approach in [Composing with Validation](/concepts/validation/) using `deriveSchema` directly gives you full flexibility.
+
+If you're unsure which decode variant to use: reach for `decodeEffectSchemaEffect` when your schema has service dependencies, and `decodeEffectSchema` when it doesn't. The `createEffectAdapter` surfaces the right methods for your schema context automatically.
 
 ## See also
 

--- a/docs/src/content/docs/adapters/validation/effect.md
+++ b/docs/src/content/docs/adapters/validation/effect.md
@@ -228,6 +228,30 @@ The root-level refinement error surfaces under `result.errors._root`.
 
 For manual composition, build the availability-aware schema with `deriveSchema()`. Decode it with `decodeEffectSchema()` inside an Effect workflow. If the schema has no service requirement and you need a plain result, use `decodeEffectSchemaSync()`.
 
+### `toAsyncWriteValidationAdapter(adapter, run)`
+
+Adapts an Effect validation adapter to `@umpire/write`'s async validation protocol. Use this when serviceful Effect schemas need to participate in async write or Drizzle checks:
+
+```ts
+import { Effect } from 'effect'
+import {
+  createEffectAdapter,
+  toAsyncWriteValidationAdapter,
+} from '@umpire/effect'
+
+const validation = createEffectAdapter()({ schemas })
+
+const writeValidation = toAsyncWriteValidationAdapter(validation, (effect) =>
+  Effect.runPromise(Effect.provide(effect, LiveLayer)),
+)
+
+await policy.checkCreateAsync(data, {
+  validation: writeValidation,
+})
+```
+
+The runner is supplied by your app so you control service provisioning. For context-free schemas, `Effect.runPromise` is enough.
+
 #### Nested value shape
 
 When field keys are namespaced with a separator — for example `account.email` and `account.name` from Drizzle models — the flat key-value record does not match the nested object structure a schema expects. Set `valueShape: 'nested'` to restructure values before validation:

--- a/docs/src/content/docs/adapters/validation/effect.md
+++ b/docs/src/content/docs/adapters/validation/effect.md
@@ -3,7 +3,7 @@ title: '@umpire/effect'
 description: Build availability-aware Effect schemas from an Umpire availability map, plus a SubscriptionRef bridge for reactive state.
 ---
 
-`@umpire/effect` bridges Umpire's availability map and Effect's Schema system. Disabled fields are excluded from validation. Required/optional follows Umpire's output, not your schema definitions. It provides two validation paths — sync APIs for context-free schemas and effectful APIs for schemas that require services. It also offers a `SubscriptionRef` bridge, reactive `Stream` generators, and `Layer` constructors for wiring Umpire into the Effect service environment.
+`@umpire/effect` bridges Umpire's availability map and Effect's Schema system. Disabled fields are excluded from validation. Required/optional follows Umpire's output, not your schema definitions. The adapter is Effect-first: use `runValidate(...)`, `runEffect(...)`, or manual `decodeEffectSchema(...)` inside `Effect.gen`. Sync APIs are available only for context-free schemas. It also offers a `SubscriptionRef` bridge, reactive `Stream` generators, and `Layer` constructors for wiring Umpire into the Effect service environment.
 
 ## Install
 
@@ -25,9 +25,10 @@ Builds a `Schema.Struct` from the availability map:
 - **Foul fields** — see `rejectFoul` below
 
 ```ts
-import { Schema } from 'effect'
+import { Effect, Schema } from 'effect'
 import {
   decodeEffectSchema,
+  decodeEffectSchemaSync,
   deriveSchema,
 } from '@umpire/effect'
 
@@ -49,12 +50,14 @@ const fieldSchemas = {
 
 const availability = ump.check(values, conditions)
 const schema = deriveSchema(availability, fieldSchemas)
-const result = decodeEffectSchema(schema, values)
+const program = Effect.gen(function* () {
+  return yield* decodeEffectSchema(schema, values)
+})
 ```
 
-`deriveSchema` **preserves the `R` parameter** from your field schemas. If any field schema requires a service, the returned struct schema carries that requirement. Use `decodeEffectSchema()` to decode it synchronously (requires `R = never`), or `decodeEffectSchemaEffect()` to decode it with full service support.
+`deriveSchema` **preserves the `R` parameter** from your field schemas. If any field schema requires a service, the returned struct schema carries that requirement.
 
-`decodeEffectSchema()` returns a convenient `{ _tag: 'Right' | 'Left' }` result. If you call Effect directly, use Effect v4's native `Schema.decodeUnknownResult()` API.
+For manual composition, build the availability-aware schema with `deriveSchema()`. Decode it with `decodeEffectSchema()` inside an Effect workflow. If the schema has no service requirement and you need a plain result, use `decodeEffectSchemaSync()`.
 
 #### `rejectFoul` option
 
@@ -64,24 +67,26 @@ Fields where `fair: false` hold values that were once valid but are now contextu
 // Server handler — rejects any submission containing a foul value
 const availability = engine.check(body)
 const schema = deriveSchema(availability, fieldSchemas, { rejectFoul: true })
-const result = decodeEffectSchema(schema, body)
+const program = Effect.gen(function* () {
+  return yield* decodeEffectSchema(schema, body)
+})
 ```
 
 When `rejectFoul: true`, a foul field with a present value fails with the field's `reason` as the error message. If the field is optional and absent, it passes — only submissions that *contain* a foul value are rejected.
 
-### `decodeEffectSchemaEffect(schema, input, options?)`
+### `decodeEffectSchema(schema, input, options?)`
 
-The effectful variant of `decodeEffectSchema`. Use this when your schema has service dependencies (`R ≠ never`):
+Effect-first schema decoding. Use this in `Effect.gen` with the schema returned by `deriveSchema()`, including schemas with service dependencies (`R ≠ never`):
 
 ```ts
 import { Effect } from 'effect'
-import { decodeEffectSchemaEffect, deriveSchema } from '@umpire/effect'
+import { decodeEffectSchema, deriveSchema } from '@umpire/effect'
 
 const schema = deriveSchema(availability, fieldSchemas)
 // schema may carry R from field schemas with service dependencies
 
 const program = Effect.gen(function* () {
-  const result = yield* decodeEffectSchemaEffect(schema, values, { errors: 'all' })
+  const result = yield* decodeEffectSchema(schema, values, { errors: 'all' })
   if (result._tag === 'Left') {
     // handle errors
   }
@@ -89,14 +94,25 @@ const program = Effect.gen(function* () {
 })
 ```
 
-The sync `decodeEffectSchema` requires `R = never` — it cannot handle service-requiring schemas. `decodeEffectSchemaEffect` supports the full Effect Schema `R` channel.
+### `decodeEffectSchemaSync(schema, input, options?)`
+
+Plain synchronous schema decoding for context-free schemas only. Use this only when you explicitly need a plain result and the schema has no Effect service requirement (`R = never`):
+
+```ts
+import { decodeEffectSchemaSync, deriveSchema } from '@umpire/effect'
+
+const schema = deriveSchema(availability, fieldSchemas)
+const result = decodeEffectSchemaSync(schema, values, { errors: 'all' })
+```
+
+`decodeEffectSchemaSync` cannot handle service-requiring schemas. Serviceful Effect schemas should use `decodeEffectSchema`, `runEffect`, or `runValidate`.
 
 ### `effectErrors(parseError)`
 
 Normalizes an Effect schema parse error or issue into `{ field, message }[]` pairs.
 
 ```ts
-const result = decodeEffectSchema(schema, values)
+const result = decodeEffectSchemaSync(schema, values)
 if (result._tag === 'Left') {
   const pairs = effectErrors(result.error)
   // [{ field: 'email', message: 'Enter a valid email' }, ...]
@@ -210,7 +226,7 @@ const validation = createEffectAdapter()({
 
 The root-level refinement error surfaces under `result.errors._root`.
 
-If you need every issue or deeper control, use `deriveSchema()` with either `decodeEffectSchema()` (sync) or `decodeEffectSchemaEffect()` (effectful).
+For manual composition, build the availability-aware schema with `deriveSchema()`. Decode it with `decodeEffectSchema()` inside an Effect workflow. If the schema has no service requirement and you need a plain result, use `decodeEffectSchemaSync()`.
 
 #### Nested value shape
 
@@ -381,8 +397,8 @@ const asyncLayer = umpireAsyncLayer(AsyncUmpireService, {
 | API | Requires `R = never`? | Handles service-requiring schemas? |
 |---|---|---|
 | `deriveSchema()` | No — preserves `R` | Yes |
-| `decodeEffectSchema()` | Yes | No |
-| `decodeEffectSchemaEffect()` | No | Yes |
+| `decodeEffectSchema()` | No | Yes |
+| `decodeEffectSchemaSync()` | Yes | No |
 | `createEffectAdapter().validators` | Yes | No |
 | `createEffectAdapter().run()` | Yes | No |
 | `createEffectAdapter().runEffect()` | No | Yes |
@@ -391,9 +407,9 @@ const asyncLayer = umpireAsyncLayer(AsyncUmpireService, {
 | `availabilityStreamAsync()` | N/A (no schemas) | N/A |
 | `umpireLayer()` / `umpireAsyncLayer()` | N/A (no schemas) | N/A |
 
-`deriveSchema` itself preserves the `R` parameter from your field schemas. If a field schema requires a service (e.g. a repository for uniqueness checks), the struct schema returned by `deriveSchema` will require it too. You can feed that schema directly to `decodeEffectSchemaEffect`, `runEffect`, or `runValidate` — all of which support the full `R` channel.
+`deriveSchema` itself preserves the `R` parameter from your field schemas. If a field schema requires a service (e.g. a repository for uniqueness checks), the struct schema returned by `deriveSchema` will require it too. You can feed that schema directly to `decodeEffectSchema`, `runEffect`, or `runValidate` — all of which support the full `R` channel.
 
-The sync APIs (`decodeEffectSchema`, `validators`, `run`) are available only when all schemas are context-free. When you use a service-requiring schema, those members are not present on the adapter — you get a TypeScript error at the call site rather than a runtime failure.
+The sync APIs (`decodeEffectSchemaSync`, `validators`, `run`) are available only when all schemas are context-free. When you use a service-requiring schema, those members are not present on the adapter — you get a TypeScript error at the call site rather than a runtime failure.
 
 ### `fromSubscriptionRef()`
 
@@ -471,7 +487,7 @@ That keeps blank strings in the "not yet validateable" lane until the field is a
 
 `@umpire/effect` handles the common case — both sync and effectful. If you need finer control — custom transformations, custom error formatting, or patterns the adapter doesn't cover — the manual approach in [Composing with Validation](/concepts/validation/) using `deriveSchema` directly gives you full flexibility.
 
-If you're unsure which decode variant to use: reach for `decodeEffectSchemaEffect` when your schema has service dependencies, and `decodeEffectSchema` when it doesn't. The `createEffectAdapter` surfaces the right methods for your schema context automatically.
+If you're unsure which decode variant to use: reach for `decodeEffectSchema` in Effect workflows, and `decodeEffectSchemaSync` only when you explicitly need a plain synchronous result from a context-free schema. The `createEffectAdapter` surfaces the right methods for your schema context automatically.
 
 ## See also
 

--- a/docs/src/content/docs/adapters/validation/effect.md
+++ b/docs/src/content/docs/adapters/validation/effect.md
@@ -91,7 +91,7 @@ const errors = deriveErrors(availability, effectErrors(result.error))
 // companyName omitted if disabled on the current plan
 ```
 
-### `createEffectAdapter({ schemas, build?, valueShape?, namespace?, rejectFoul? })`
+### `createEffectAdapter()({ schemas, build?, valueShape?, namespace?, rejectFoul? })`
 
 Convenience adapter that bundles the `deriveSchema → decode → deriveErrors` flow:
 
@@ -99,7 +99,7 @@ Convenience adapter that bundles the `deriveSchema → decode → deriveErrors` 
 - `run(availability, values)` — full validation returning `{ errors, normalizedErrors, result, schemaFields }`
 
 ```ts
-const validation = createEffectAdapter({
+const validation = createEffectAdapter()({
   schemas: {
     email:       Schema.String,
     companyName: Schema.String,
@@ -124,7 +124,7 @@ if (result.result._tag === 'Left') {
 Use `build` to add cross-field refinements on the derived schema:
 
 ```ts
-const validation = createEffectAdapter({
+const validation = createEffectAdapter()({
   schemas: {
     password:        Schema.String,
     confirmPassword: Schema.String,
@@ -153,7 +153,7 @@ When field keys are namespaced with a separator — for example `account.email` 
 import { createEffectAdapter } from '@umpire/effect'
 import { Schema } from 'effect'
 
-const adapter = createEffectAdapter({
+const adapter = createEffectAdapter()({
   schemas: {
     'account.email': Schema.String,
     'account.name':  Schema.String,
@@ -244,7 +244,7 @@ const ump = umpire({
     email: { required: true, isEmpty: isEmptyString },
   },
   rules: [],
-  validators: createEffectAdapter({
+  validators: createEffectAdapter()({
     schemas: { email: Schema.String },
   }).validators,
 })

--- a/docs/src/content/docs/adapters/validation/effect.md
+++ b/docs/src/content/docs/adapters/validation/effect.md
@@ -61,7 +61,7 @@ For manual composition, build the availability-aware schema with `deriveSchema()
 
 #### `rejectFoul` option
 
-Fields where `fair: false` hold values that were once valid but are now contextually wrong — a selection that no longer fits the current state. By default these pass through with their base schema (useful on the client where the user is still editing). On a **server**, you may want to reject them outright:
+Fields where `fair: false` hold values that were once valid but are now contextually wrong — a selection that no longer fits the current state. By default these pass through with their base schema (useful on the client while the form is active). On a **server**, you may want to reject them outright:
 
 ```ts
 // Server handler — rejects any submission containing a foul value
@@ -234,6 +234,7 @@ Adapts an Effect validation adapter to `@umpire/write`'s async validation protoc
 
 ```ts
 import { Effect } from 'effect'
+import { checkCreateAsync, runWriteValidationAdapterAsync, composeWriteResult } from '@umpire/write'
 import {
   createEffectAdapter,
   toAsyncWriteValidationAdapter,
@@ -245,9 +246,13 @@ const writeValidation = toAsyncWriteValidationAdapter(validation, (effect) =>
   Effect.runPromise(Effect.provide(effect, LiveLayer)),
 )
 
-await policy.checkCreateAsync(data, {
-  validation: writeValidation,
-})
+const write = await checkCreateAsync(policy, data)
+const validationRun = await runWriteValidationAdapterAsync(
+  writeValidation, 
+  write.availability, 
+  write.candidate
+)
+const result = composeWriteResult({ write, validation: validationRun })
 ```
 
 The runner is supplied by your app so you control service provisioning. For context-free schemas, `Effect.runPromise` is enough.
@@ -484,6 +489,90 @@ store.destroy() // interrupts the background fiber
 `select` and `conditions` follow the same contract as [`@umpire/store`](/adapters/store/). See [Selection](/concepts/selection/) for the full breakdown of patterns.
 
 The returned `UmpireStore` surface is the same as all store adapters: `field(name)`, `fouls`, `getAvailability()`, `subscribe(listener)`, and `destroy()`.
+
+## End-to-end flow: Server endpoint
+
+When building an API endpoint, you often need to evaluate Umpire availability rules and structural Effect schemas in one pass before writing to your database. `@umpire/write` handles the policy; `@umpire/effect` handles the schema. The two libraries combine to give you a single result object.
+
+Consider a database provisioning endpoint where certain configuration fields only apply to specific database engines, and some fields require asynchronous verification:
+
+```ts
+import { Effect, Schema } from 'effect'
+import { checkCreateAsync, composeWriteResult, runWriteValidationAdapterAsync } from '@umpire/write'
+import { createEffectAdapter, toAsyncWriteValidationAdapter } from '@umpire/effect'
+import { umpire, enabledWhen } from '@umpire/async'
+import { CloudApi, LiveCloudApiLayer } from './services'
+
+// 1. Define your effectful schemas
+// Notice how Schema.optional() is not used here. Umpire determines whether 
+// a field is required or excluded entirely based on current state.
+const schemas = {
+  engine: Schema.Literal('postgres', 'mysql', 'sqlite'),
+  version: Schema.String,
+  customParameters: Schema.Boolean,
+  replicaCount: Schema.Number.pipe(Schema.int(), Schema.nonNegative()),
+  parameterGroupId: Schema.String.pipe(
+    Schema.filterEffect((id) => Effect.gen(function*() {
+      const api = yield* CloudApi
+      // Async check that requires a service dependency
+      return yield* api.verifyParameterGroup(id)
+    }), { message: () => 'Parameter group not found or incompatible' })
+  )
+}
+
+// 2. Create the Umpire instance for your policy
+const ump = umpire({
+  fields: {
+    engine: { required: true },
+    version: { required: true },
+    customParameters: { },
+    replicaCount: { }, 
+    parameterGroupId: { required: true } // Required, but only when enabled
+  },
+  rules: [
+    enabledWhen('replicaCount', (v) => v.engine !== 'sqlite', { 
+      reason: 'SQLite does not support read replicas' 
+    }),
+    enabledWhen('parameterGroupId', (v) => v.customParameters === true, {
+      reason: 'Parameter group is only applicable when customParameters is true'
+    })
+  ]
+})
+
+// 3. Create the adapter and adapt it for async write checks
+const validation = createEffectAdapter()({ schemas })
+const writeValidation = toAsyncWriteValidationAdapter(validation, (effect) => 
+  Effect.runPromise(Effect.provide(effect, LiveCloudApiLayer))
+)
+
+// 4. In your route handler
+export async function provisionDatabase(req, res) {
+  // First evaluate the policy...
+  const write = await checkCreateAsync(ump, req.body)
+  
+  // Then evaluate the schema against the availability map...
+  const validationRun = await runWriteValidationAdapterAsync(
+    writeValidation, 
+    write.availability, 
+    write.candidate
+  )
+  
+  // Combine both into a single result...
+  const result = composeWriteResult({ write, validation: validationRun })
+  
+  if (!result.ok) {
+    // result.issues.rules contains policy failures (e.g. parameterGroupId missing when customParameters=true)
+    // result.issues.schema contains validation failures (e.g. parameterGroupId not found in cloud api)
+    return res.status(422).json({ issues: result.issues })
+  }
+  
+  // result.debug.candidate is the fully normalized and validated payload
+  await db.insert(databases).values(result.debug.candidate)
+  return res.status(201).json({ ok: true })
+}
+```
+
+This pattern keeps policy checks, schema validation, and persistence distinct while letting them fail together before your database throws constraints. Umpire cleanly separates the "should this field exist at all?" policy from the "is this value well-formed?" structural validation.
 
 ## Blank strings and `isEmpty`
 

--- a/docs/src/content/docs/extensions/async.md
+++ b/docs/src/content/docs/extensions/async.md
@@ -219,9 +219,9 @@ export async function createUser(req, res) {
 }
 ```
 
-`fairWhen` is the right rule for a uniqueness check: the field is enabled, the user has provided a value, and the question is whether that value is appropriate for the current state. If the email is taken, the field is marked foul and `availability.email.reason` carries the message — no ad-hoc error tracking needed.
+`fairWhen` is the right rule for a uniqueness check: the field is enabled, a value has been provided, and the question is whether that value is appropriate for the current state. If the email is taken, the field is marked foul and `availability.email.reason` carries the message — no ad-hoc error tracking needed.
 
-The `fromDrizzleTable` call is unchanged. `@umpire/async` accepts the same `fields` and `rules` shape as `@umpire/core`; you're just switching the `umpire()` import.
+The `fromDrizzleTable` call is unchanged. `@umpire/async` accepts the same `fields` and `rules` shape as `@umpire/core`; you are only switching the `umpire()` import.
 
 ## Cancellation
 

--- a/docs/src/content/docs/extensions/write.md
+++ b/docs/src/content/docs/extensions/write.md
@@ -113,7 +113,7 @@ When you pair write-policy checks with a schema validation library (Zod, Effect,
 
 `WriteValidationAdapter<F>` is a structural protocol. Any object with a `run(availability, values)` method that returns normalized field-level errors satisfies it. `@umpire/zod` (`createZodAdapter`) satisfies this protocol out of the box. `@umpire/effect` (`createEffectAdapter`) satisfies it only for context-free Effect schemas where sync `run` / `validators` are exposed.
 
-Serviceful Effect schemas cannot satisfy `WriteValidationAdapter` because they do not expose sync `run`. Use async/effectful write paths for those schemas. Until an explicit Effect-to-Promise write adapter bridge exists, compose `runValidate(...)`, `runEffect(...)`, or `decodeEffectSchema(...)` in your own Effect workflow rather than treating the bridge as automatic.
+Serviceful Effect schemas cannot satisfy the sync `WriteValidationAdapter` because they do not expose sync `run`. Use `toAsyncWriteValidationAdapter(...)` from `@umpire/effect` with async write/Drizzle paths for those schemas.
 
 ```ts
 import type { WriteValidationAdapter } from '@umpire/write'

--- a/docs/src/content/docs/extensions/write.md
+++ b/docs/src/content/docs/extensions/write.md
@@ -91,7 +91,7 @@ type WriteIssue<F extends Record<string, FieldDef>> = {
 Issues are derived only from fields declared in the Umpire instance. At most one issue is emitted per field, checked in this order:
 
 1. **`required`** — the field is enabled, required, and unsatisfied.
-2. **`disabled`** — the field has a value and is disabled. Empty disabled fields are not issues; a field that is disabled and unsatisfied is simply not in play.
+2. **`disabled`** — the field has a value and is disabled. Empty disabled fields are not issues; a field that is disabled and unsatisfied is not in play.
 3. **`foul`** — the field has a value, is enabled, and `fair` is `false`.
 
 The `message` for each issue comes from the field's `reason` in the availability status, falling back to the first entry in `reasons`, then to a generated fallback (`"${field} is required"`, `"${field} is disabled"`, or `"${field} is foul"`).

--- a/docs/src/content/docs/extensions/write.md
+++ b/docs/src/content/docs/extensions/write.md
@@ -111,7 +111,9 @@ When you pair write-policy checks with a schema validation library (Zod, Effect,
 
 ### WriteValidationAdapter protocol
 
-`WriteValidationAdapter<F>` is a structural protocol. Any object with a `run(availability, values)` method that returns normalized field-level errors satisfies it. The adapters exported by `@umpire/zod` (`createZodAdapter`) and `@umpire/effect` (`createEffectAdapter`) satisfy this protocol out of the box.
+`WriteValidationAdapter<F>` is a structural protocol. Any object with a `run(availability, values)` method that returns normalized field-level errors satisfies it. `@umpire/zod` (`createZodAdapter`) satisfies this protocol out of the box. `@umpire/effect` (`createEffectAdapter`) satisfies it only for context-free Effect schemas where sync `run` / `validators` are exposed.
+
+Serviceful Effect schemas cannot satisfy `WriteValidationAdapter` because they do not expose sync `run`. Use async/effectful write paths for those schemas. Until an explicit Effect-to-Promise write adapter bridge exists, compose `runValidate(...)`, `runEffect(...)`, or `decodeEffectSchema(...)` in your own Effect workflow rather than treating the bridge as automatic.
 
 ```ts
 import type { WriteValidationAdapter } from '@umpire/write'
@@ -255,4 +257,4 @@ In all cases, the pattern is the same: Umpire first, ORM second. Reject early on
 - [Composing Validation](/concepts/validation/) — where Umpire fits in a layered validation strategy
 - [`@umpire/drizzle`](/adapters/database/drizzle/) — Drizzle-aware write checks and policy creation
 - [`@umpire/zod`](/adapters/validation/zod/) — Zod adapter satisfying the `WriteValidationAdapter` protocol
-- [`@umpire/effect`](/adapters/validation/effect/) — Effect adapter satisfying the same protocol
+- [`@umpire/effect`](/adapters/validation/effect/) — Effect-first adapter; context-free schemas can satisfy the sync `WriteValidationAdapter` protocol through `validation.run`

--- a/packages/core/__tests__/check.test.ts
+++ b/packages/core/__tests__/check.test.ts
@@ -375,7 +375,6 @@ describe('evaluate', () => {
         undefined,
         {},
         new Map(),
-        true,
       ),
     ).toEqual({
       enabled: true,
@@ -385,7 +384,7 @@ describe('evaluate', () => {
     })
   })
 
-  test('evaluates every anyOf inner rule before OR-combining results', () => {
+  test('stops evaluating anyOf inner rules after the first pass', () => {
     const fields: TestFields = {
       alpha: {},
       beta: {},
@@ -424,7 +423,6 @@ describe('evaluate', () => {
         undefined,
         {},
         new Map(),
-        true,
       ),
     ).toEqual({
       enabled: true,
@@ -432,7 +430,7 @@ describe('evaluate', () => {
       reasons: undefined,
     })
     expect(firstCalls).toBe(1)
-    expect(secondCalls).toBe(1)
+    expect(secondCalls).toBe(0)
   })
 
   test('keeps fair rules out of the gate phase when a field is already disabled', () => {
@@ -529,7 +527,6 @@ describe('evaluate', () => {
         undefined,
         {},
         new Map(),
-        true,
       ),
     ).toEqual({
       enabled: true,

--- a/packages/core/__tests__/check.test.ts
+++ b/packages/core/__tests__/check.test.ts
@@ -433,6 +433,59 @@ describe('evaluate', () => {
     expect(secondCalls).toBe(0)
   })
 
+  test('evaluates each anyOf inner rule once for multi-target rules', () => {
+    const fields: TestFields = {
+      alpha: {},
+      beta: {},
+      gamma: {},
+      delta: {},
+    }
+    let firstCalls = 0
+    let secondCalls = 0
+    const firstRule: Rule<TestFields, TestConditions> = {
+      type: 'first',
+      targets: ['alpha', 'beta'],
+      sources: [],
+      evaluate: () => {
+        firstCalls += 1
+        return new Map([
+          ['alpha', { enabled: true, reason: null }],
+          ['beta', { enabled: false, reason: 'first failed beta' }],
+        ])
+      },
+    }
+    const secondRule: Rule<TestFields, TestConditions> = {
+      type: 'second',
+      targets: ['alpha', 'beta'],
+      sources: [],
+      evaluate: () => {
+        secondCalls += 1
+        return new Map([
+          ['alpha', { enabled: true, reason: null }],
+          ['beta', { enabled: true, reason: null }],
+        ])
+      },
+    }
+    const rule = anyOf(firstRule, secondRule)
+    const result = rule.evaluate(
+      fields,
+      {} as TestConditions,
+      undefined,
+      fields,
+    )
+
+    expect(result.get('alpha')).toEqual({
+      enabled: true,
+      reason: null,
+    })
+    expect(result.get('beta')).toEqual({
+      enabled: true,
+      reason: null,
+    })
+    expect(firstCalls).toBe(1)
+    expect(secondCalls).toBe(1)
+  })
+
   test('keeps fair rules out of the gate phase when a field is already disabled', () => {
     const fields: TestFields = {
       alpha: {},

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -110,7 +110,7 @@ function evaluateAnyOfRule<
     if (isCompositePassed(constraint, result)) {
       passed = true
       reasons = undefined
-      continue
+      break
     }
 
     if (!passed) {

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -179,7 +179,7 @@ export function topologicalSort(
   }
 
   const queue = orderedFields.filter(
-    (field) => incomingCounts.get(field)! === 0,
+    (field) => (incomingCounts.get(field) ?? 0) === 0,
   )
   const result: string[] = []
 

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -1488,16 +1488,25 @@ export function anyOf<
     targets,
     sources,
     evaluate(values, conditions, prev, fields, availability) {
-      const evaluations = rules.map((rule) =>
-        rule.evaluate(values, conditions, prev, fields, availability),
-      )
-
       return createResultMap(targets, (target) => {
-        const targetResults = evaluations.map((evaluation) =>
-          getCompositeTargetEvaluation(evaluation, target),
-        )
+        const targetResults: RuleResult[] = []
 
-        // Stryker disable next-line StringLiteral: equivalent mutant — combineCompositeResults only checks mode === 'and'; any other value including '' follows the OR path
+        for (const rule of rules) {
+          const evaluation = rule.evaluate(
+            values,
+            conditions,
+            prev,
+            fields,
+            availability,
+          )
+          const targetResult = getCompositeTargetEvaluation(evaluation, target)
+          targetResults.push(targetResult)
+
+          if (targetResult.enabled && targetResult.fair) {
+            break
+          }
+        }
+
         return combineCompositeResults(constraint, 'or', targetResults)
       })
     },

--- a/packages/core/src/rules.ts
+++ b/packages/core/src/rules.ts
@@ -349,6 +349,13 @@ function createSingleResultMap<F extends Record<string, FieldDef>>(
   return results
 }
 
+function compositeResultPasses(
+  constraint: RuleConstraint,
+  result: RuleEvaluation,
+): boolean {
+  return constraint === 'fair' ? result.fair !== false : result.enabled
+}
+
 export function resolveReason<
   F extends Record<string, FieldDef>,
   C extends Record<string, unknown>,
@@ -1488,26 +1495,44 @@ export function anyOf<
     targets,
     sources,
     evaluate(values, conditions, prev, fields, availability) {
-      return createResultMap(targets, (target) => {
-        const targetResults: RuleResult[] = []
+      const targetResults = new Map<string, RuleResult[]>(
+        targets.map((target) => [target, []]),
+      )
+      const passedTargets = new Set<string>()
 
-        for (const rule of rules) {
-          const evaluation = rule.evaluate(
-            values,
-            conditions,
-            prev,
-            fields,
-            availability,
-          )
+      for (const rule of rules) {
+        const evaluation = rule.evaluate(
+          values,
+          conditions,
+          prev,
+          fields,
+          availability,
+        )
+
+        for (const target of targets) {
+          if (passedTargets.has(target)) {
+            continue
+          }
+
           const targetResult = getCompositeTargetEvaluation(evaluation, target)
-          targetResults.push(targetResult)
+          targetResults.get(target)!.push(targetResult)
 
-          if (targetResult.enabled && targetResult.fair) {
-            break
+          if (compositeResultPasses(constraint, targetResult)) {
+            passedTargets.add(target)
           }
         }
 
-        return combineCompositeResults(constraint, 'or', targetResults)
+        if (passedTargets.size === targets.length) {
+          break
+        }
+      }
+
+      return createResultMap(targets, (target) => {
+        return combineCompositeResults(
+          constraint,
+          'or',
+          targetResults.get(target)!,
+        )
       })
     },
   }

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -157,9 +157,10 @@ availability policy.
 Context-free Effect schemas can use these sync Drizzle/write paths through
 `validation.run`. Serviceful Effect schemas cannot satisfy
 `WriteValidationAdapter` because they do not expose sync `run`; use
-async/effectful paths for them. Until there is an explicit Effect-to-Promise
-write adapter bridge, compose `runValidate(...)`, `runEffect(...)`, or
-`decodeEffectSchema(...)` in your own Effect workflow.
+async/effectful paths for them. `@umpire/effect` provides
+`toAsyncWriteValidationAdapter(...)` to bridge serviceful Effect validation into
+Drizzle's async write helpers while letting your app decide how to provide
+Effect services.
 
 Drizzle owns column shaping and write-payload concerns; generic validation
 result composition lives in `@umpire/write`.

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -154,6 +154,13 @@ helpers (`createDrizzlePolicy`, `checkDrizzleCreate`, etc.) accept a
 `WriteValidationAdapter` to integrate schema checks alongside column-derived
 availability policy.
 
+Context-free Effect schemas can use these sync Drizzle/write paths through
+`validation.run`. Serviceful Effect schemas cannot satisfy
+`WriteValidationAdapter` because they do not expose sync `run`; use
+async/effectful paths for them. Until there is an explicit Effect-to-Promise
+write adapter bridge, compose `runValidate(...)`, `runEffect(...)`, or
+`decodeEffectSchema(...)` in your own Effect workflow.
+
 Drizzle owns column shaping and write-payload concerns; generic validation
 result composition lives in `@umpire/write`.
 

--- a/packages/effect/CHANGELOG.md
+++ b/packages/effect/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - 95ea3e3: Add `@umpire/effect` — Effect v4 Schema adapter and SubscriptionRef store bridge for `@umpire/core`.
   - Supports the Effect v4 beta/stable line via a prerelease-aware peer dependency range.
-  - `decodeEffectSchema(schema, input, options?)` normalizes Effect v4 `Result` values into a stable `{ _tag: "Right" | "Left" }` shape for adapter internals and manual `deriveSchema()` usage.
+  - `decodeEffectSchemaSync(schema, input, options?)` normalizes Effect v4 `Result` values into a stable `{ _tag: "Right" | "Left" }` shape for sync adapter internals and manual context-free `deriveSchema()` usage.
   - `createEffectAdapter()({ schemas, rejectFoul?, build? })` mirrors `createZodAdapter` using Effect Schema. Per-field schemas drive both the per-field validators wired into `umpire()` and a full availability-aware struct schema used by `run()`. Schemas with service/context dependencies are not supported in the synchronous evaluation model.
   - `deriveSchema(availability, schemas, options?)` builds an availability-aware `Schema.Struct` from field-level schemas: disabled fields are excluded, optional fields get `Schema.optional()`, and `rejectFoul: true` injects an always-failing refinement (using the field's `reason`) for foul fields.
   - `effectErrors(parseError)` flattens Effect schema parse errors or issues into `{ field, message }[]`.

--- a/packages/effect/CHANGELOG.md
+++ b/packages/effect/CHANGELOG.md
@@ -18,7 +18,7 @@
 - 95ea3e3: Add `@umpire/effect` — Effect v4 Schema adapter and SubscriptionRef store bridge for `@umpire/core`.
   - Supports the Effect v4 beta/stable line via a prerelease-aware peer dependency range.
   - `decodeEffectSchema(schema, input, options?)` normalizes Effect v4 `Result` values into a stable `{ _tag: "Right" | "Left" }` shape for adapter internals and manual `deriveSchema()` usage.
-  - `createEffectAdapter({ schemas, rejectFoul?, build? })` mirrors `createZodAdapter` using Effect Schema. Per-field schemas drive both the per-field validators wired into `umpire()` and a full availability-aware struct schema used by `run()`. Schemas with service/context dependencies are not supported in the synchronous evaluation model.
+  - `createEffectAdapter()({ schemas, rejectFoul?, build? })` mirrors `createZodAdapter` using Effect Schema. Per-field schemas drive both the per-field validators wired into `umpire()` and a full availability-aware struct schema used by `run()`. Schemas with service/context dependencies are not supported in the synchronous evaluation model.
   - `deriveSchema(availability, schemas, options?)` builds an availability-aware `Schema.Struct` from field-level schemas: disabled fields are excluded, optional fields get `Schema.optional()`, and `rejectFoul: true` injects an always-failing refinement (using the field's `reason`) for foul fields.
   - `effectErrors(parseError)` flattens Effect schema parse errors or issues into `{ field, message }[]`.
   - `fromSubscriptionRef(ump, ref, options)` bridges an Effect `SubscriptionRef<S>` to the `@umpire/store` contract, running a background fiber over the ref changes stream to track state transitions and compute fouls.

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -1,6 +1,6 @@
 # @umpire/effect
 
-Availability-aware Effect Schema validation and SubscriptionRef bridge for [@umpire/core](https://www.npmjs.com/package/@umpire/core)-powered state. Disabled fields produce no validation errors. Required/optional follows Umpire's availability map.
+Availability-aware Effect Schema validation, SubscriptionRef bridge, Stream utilities, and Layer wiring for [@umpire/core](https://www.npmjs.com/package/@umpire/core)-powered state. Disabled fields produce no validation errors. Required/optional follows Umpire's availability map.
 
 [Docs](https://umpire.tools/adapters/validation/effect/) · [Quick Start](https://umpire.tools/learn/)
 
@@ -13,6 +13,8 @@ npm install @umpire/core @umpire/effect effect
 `effect` is a peer dependency — bring your own Effect v4 beta/stable release.
 
 ## Usage
+
+### Sync validation (schemas without service dependencies)
 
 ```ts
 import { Schema } from 'effect'
@@ -38,7 +40,7 @@ const ump = umpire({
   ],
 })
 
-// 2. Define per-field Effect schemas with no service/context dependencies
+// 2. Define per-field Effect schemas
 const fieldSchemas = {
   email: Schema.String.check(
     Schema.makeFilter((s) =>
@@ -83,17 +85,69 @@ const umpWithValidation = umpire({
 })
 ```
 
+### Effectful validation (schemas with service dependencies)
+
+When your Effect schemas require services (e.g. a repository or external API), use `runEffect` and `runValidate` instead of the sync `run` / `validators`:
+
+```ts
+import { Effect, Schema } from 'effect'
+import { createEffectAdapter } from '@umpire/effect'
+
+// fieldSchemas can have service dependencies
+const fieldSchemas = {
+  username: Schema.String.pipe(
+    Schema.filter((s: string) => s.length >= 3, { message: () => 'Too short' }),
+  ),
+  // This schema needs a UserRepo to check uniqueness
+  email: Schema.String.pipe(
+    Schema.filterEffect((s: string) =>
+      Effect.gen(function* () {
+        const repo = yield* UserRepo
+        const exists = yield* repo.findByEmail(s)
+        return !exists
+      }),
+    ),
+    { message: () => 'Email already taken' },
+  ),
+}
+
+const validation = createEffectAdapter()({ schemas: fieldSchemas })
+// note: validation.validators and validation.run are NOT available here
+// because the schemas have service dependencies (R ≠ never)
+
+// Use runEffect for full result inspection
+const program = Effect.gen(function* () {
+  const result = yield* validation.runEffect(availability, values)
+  if (result.result._tag === 'Left') {
+    console.log(result.errors)
+  }
+  return result
+})
+
+// Or runValidate — succeeds with the parsed output, fails with UmpireValidationError
+const program2 = validation
+  .runValidate(availability, values)
+  .pipe(
+    Effect.catchTag('UmpireValidationError', (error) =>
+      Effect.succeed({ errors: error.errors }),
+    ),
+  )
+
+// Provide your services
+Effect.runPromise(program.pipe(Effect.provideService(UserRepo, myRepo)))
+```
+
 ## API
 
 ### `deriveSchema(availability, schemas, options?)`
 
 Builds a `Schema.Struct` from the availability map:
 
-- **Disabled fields** are excluded entirely
-- **Enabled + required** fields use the base schema
-- **Enabled + optional** fields get `Schema.optional()`
+- **Disabled fields** — excluded from the schema entirely
+- **Enabled + required** — field uses the base schema as-is
+- **Enabled + optional** — field is wrapped with `Schema.optional()`
 
-Pass per-field schemas with no service/context dependencies.
+`deriveSchema` **preserves the `R` parameter** from your field schemas. If any field schema requires a service, the returned struct schema requires it too. This means you can pass the result to either `decodeEffectSchema` (sync, `R = never` required) or `decodeEffectSchemaEffect` (effectful, any `R`).
 Use `decodeEffectSchema()` for convenience, or call Effect v4's native `Schema.decodeUnknownResult()` directly.
 
 #### `rejectFoul` option
@@ -114,12 +168,21 @@ Normalizes an Effect schema parse error or issue into `{ field, message }[]` pai
 
 Filters normalized field errors to only include enabled fields and keeps the first message per field. Returns `Partial<Record<field, message>>`. Root-level errors (from cross-field refinements) are keyed under `'_root'`.
 
-### `createEffectAdapter()({ schemas, build?, rejectFoul? })`
+### `createEffectAdapter()({ schemas, build?, valueShape?, namespace?, rejectFoul? })`
 
-Creates a convenience adapter with:
+Creates a convenience adapter that bundles the `deriveSchema → decode → deriveErrors` flow. The adapter provides different members depending on whether your schemas have service dependencies:
 
-- `validators` for `umpire({ validators })`, surfacing the first field-level parse issue as `error`
-- `run(availability, values)` for the full `deriveSchema() → decode → deriveErrors()` flow, returning `{ errors, normalizedErrors, result, schemaFields }`
+**When all schemas are context-free** (`R = never`):
+
+- `validators` — per-field validators for `umpire({ validators })`, surfacing the first field-level parse issue as `error`
+- `run(availability, values)` — full validation returning `{ errors, normalizedErrors, result, schemaFields }`
+
+**Always available:**
+
+- `runEffect(availability, values)` — effectful validation returning `Effect<EffectAdapterRunResult, never, R>`. Works with any `R`.
+- `runValidate(availability, values)` — effectful validation returning `Effect<Out, UmpireValidationError, R>`. Succeeds with the parsed output, fails with an `UmpireValidationError` on validation failure. Works with any `R`.
+
+When your schemas have service dependencies (`R ≠ never`), `validators` and `run` are **not available** on the adapter — use `runEffect` and `runValidate` instead.
 
 Use `build` to add cross-field refinements:
 
@@ -139,9 +202,149 @@ const validation = createEffectAdapter()({
       ),
     ),
 })
+
+// Sync use (schemas must be context-free)
+const { errors } = validation.run(availability, values)
+
+// Or effectful (any R)
+const result = yield * validation.runEffect(availability, values)
 ```
 
-If you need every issue or deeper control, you can use `deriveSchema()` with either `decodeEffectSchema()` or Effect v4's native decode API.
+If you need every issue or deeper control, you can use `deriveSchema()` with either `decodeEffectSchema()` (sync) or `decodeEffectSchemaEffect()` (effectful).
+
+### `UmpireValidationError`
+
+A tagged error class thrown by `runValidate` on validation failure. Use `Effect.catchTag` to handle it:
+
+```ts
+import { UmpireValidationError } from '@umpire/effect'
+
+validation.runValidate(availability, values).pipe(
+  Effect.catchTag('UmpireValidationError', (error) => {
+    console.log(error.message) // 'Validation failed: email, password'
+    console.log(error.errors) // { email: 'Enter a valid email', password: undefined }
+    console.log(error.normalizedErrors) // [{ field: 'email', message: '...' }]
+    return Effect.succeed({ errors: error.errors })
+  }),
+)
+```
+
+`error.errors` is a `Record<string, string | undefined>` — one entry per field, `undefined` when that field passed validation.
+
+### `decodeEffectSchemaEffect(schema, input, options?)`
+
+The effectful variant of `decodeEffectSchema`. Use this when your schema has service dependencies (`R ≠ never`):
+
+```ts
+import { decodeEffectSchemaEffect, deriveSchema } from '@umpire/effect'
+
+const schema = deriveSchema(availability, fieldSchemas)
+// schema may carry R from field schemas with service dependencies
+
+const program = Effect.gen(function* () {
+  const result = yield* decodeEffectSchemaEffect(schema, values, {
+    errors: 'all',
+  })
+  if (result._tag === 'Left') {
+    // handle errors
+  }
+  return result
+})
+```
+
+The sync `decodeEffectSchema` requires `R = never` — it cannot handle service-requiring schemas.
+
+### `availabilityStream(ump, ref, options)`
+
+Returns an Effect `Stream<AvailabilityMap<F>, never, never>` from a `SubscriptionRef`. Each time the ref changes, the stream emits a fresh availability map computed by `ump.check()`:
+
+```ts
+import { SubscriptionRef, Stream } from 'effect'
+import { availabilityStream } from '@umpire/effect'
+
+const stream = availabilityStream(ump, ref, {
+  select: () => ({}),
+  conditions: (state) => state,
+})
+
+// Collect all availability snapshots
+const history = yield * Stream.runCollect(stream)
+```
+
+The first emission is a fresh check (no previous values). Subsequent emissions pass the previous values to `ump.check()` so rules that depend on prior state can diff.
+
+### `availabilityStreamAsync(ump, ref, options)`
+
+Same as `availabilityStream` but for `@umpire/async` instances. The stream's error channel is `unknown` because `@umpire/async` checks are promise-based and can reject:
+
+```ts
+import { availabilityStreamAsync } from '@umpire/effect'
+
+const stream = availabilityStreamAsync(asyncUmp, ref, options)
+// Stream<AvailabilityMap<F>, unknown, never>
+```
+
+If a check rejects, the stream fails with that error. Handle it with `Stream.catchAll` or `Stream.orElse`.
+
+### `umpireLayer(tag, definition)`
+
+Creates an Effect `Layer` that provides an `@umpire/core` `Umpire` instance as a service:
+
+```ts
+import { Context, Effect } from 'effect'
+import { umpireLayer } from '@umpire/effect'
+import { enabledWhen } from '@umpire/core'
+
+class UmpireService extends Context.Tag('UmpireService')<
+  UmpireService,
+  ReturnType<typeof umpire>
+>() {}
+
+const layer = umpireLayer(UmpireService, {
+  fields: { name: {}, email: {} },
+  rules: [enabledWhen('email', (_v, c: { showEmail: boolean }) => c.showEmail)],
+})
+
+// Use it in your program
+const program = Effect.gen(function* () {
+  const ump = yield* UmpireService
+  const availability = ump.check({ name: 'Jane' }, { showEmail: true })
+  // ...
+})
+
+Effect.runPromise(program.pipe(Effect.provide(layer)))
+```
+
+### `umpireAsyncLayer(tag, definition)`
+
+Same as `umpireLayer` but for `@umpire/async` instances:
+
+```ts
+import { umpireAsyncLayer } from '@umpire/effect'
+
+const asyncLayer = umpireAsyncLayer(AsyncUmpireService, {
+  fields: { name: {}, email: {} },
+  rules: [enabledWhen('email', (_v, c: { showEmail: boolean }) => c.showEmail)],
+})
+```
+
+### Sync-vs-effect boundary
+
+Umpire's Effect package draws a clean line between sync and effectful APIs:
+
+| API                                   | Requires `R = never`? | Handles service-requiring schemas? |
+| ------------------------------------- | --------------------- | ---------------------------------- |
+| `deriveSchema()`                      | No — preserves `R`    | Yes                                |
+| `decodeEffectSchema()`                | Yes                   | No                                 |
+| `decodeEffectSchemaEffect()`          | No                    | Yes                                |
+| `createEffectAdapter().validators`    | Yes                   | No                                 |
+| `createEffectAdapter().run()`         | Yes                   | No                                 |
+| `createEffectAdapter().runEffect()`   | No                    | Yes                                |
+| `createEffectAdapter().runValidate()` | No                    | Yes                                |
+
+`deriveSchema` itself preserves the `R` parameter from your field schemas. If a field schema requires a service (e.g. a repository for uniqueness checks), the struct schema returned by `deriveSchema` will require it too. You can feed that schema directly to `decodeEffectSchemaEffect`, `runEffect`, or `runValidate` — all of which support the full `R` channel.
+
+The sync APIs (`decodeEffectSchema`, `validators`, `run`) are available only when `R = never`. When you use a service-requiring schema, those members are not present on the adapter. You get a TypeScript error at the call site rather than a runtime failure.
 
 ### `fromSubscriptionRef(ump, ref, options)`
 

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -213,6 +213,30 @@ const result = yield * validation.runEffect(availability, values)
 
 For manual composition, build the availability-aware schema with `deriveSchema()`. Decode it with `decodeEffectSchema()` inside an Effect workflow. If the schema has no service requirement and you need a plain result, use `decodeEffectSchemaSync()`.
 
+### `toAsyncWriteValidationAdapter(adapter, run)`
+
+Adapts an Effect validation adapter to `@umpire/write`'s async validation protocol. Use this when serviceful Effect schemas need to participate in async write or Drizzle checks:
+
+```ts
+import { Effect } from 'effect'
+import {
+  createEffectAdapter,
+  toAsyncWriteValidationAdapter,
+} from '@umpire/effect'
+
+const validation = createEffectAdapter()({ schemas })
+
+const writeValidation = toAsyncWriteValidationAdapter(validation, (effect) =>
+  Effect.runPromise(Effect.provide(effect, LiveLayer)),
+)
+
+await policy.checkCreateAsync(data, {
+  validation: writeValidation,
+})
+```
+
+The runner is supplied by your app so you control service provisioning. For context-free schemas, `Effect.runPromise` is enough.
+
 ### `UmpireValidationError`
 
 A tagged error class thrown by `runValidate` on validation failure. Use `Effect.catchTag` to handle it:

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -1,6 +1,6 @@
 # @umpire/effect
 
-Availability-aware Effect Schema validation, SubscriptionRef bridge, Stream utilities, and Layer wiring for [@umpire/core](https://www.npmjs.com/package/@umpire/core)-powered state. Disabled fields produce no validation errors. Required/optional follows Umpire's availability map.
+Availability-aware Effect Schema validation, SubscriptionRef bridge, Stream utilities, and Layer wiring for [@umpire/core](https://www.npmjs.com/package/@umpire/core)-powered state. `@umpire/effect` is Effect-first: use `runValidate(...)`, `runEffect(...)`, or manual `decodeEffectSchema(...)` inside `Effect.gen`. Disabled fields produce no validation errors. Required/optional follows Umpire's availability map.
 
 [Docs](https://umpire.tools/adapters/validation/effect/) · [Quick Start](https://umpire.tools/learn/)
 
@@ -21,7 +21,7 @@ import { Schema } from 'effect'
 import { enabledWhen, umpire } from '@umpire/core'
 import {
   createEffectAdapter,
-  decodeEffectSchema,
+  decodeEffectSchemaSync,
   deriveErrors,
   deriveSchema,
   effectErrors,
@@ -58,7 +58,7 @@ const fieldSchemas = {
 const availability = ump.check(values, { plan })
 
 const schema = deriveSchema(availability, fieldSchemas)
-const result = decodeEffectSchema(schema, values)
+const result = decodeEffectSchemaSync(schema, values)
 
 if (result._tag === 'Left') {
   const errors = deriveErrors(availability, effectErrors(result.error))
@@ -147,8 +147,9 @@ Builds a `Schema.Struct` from the availability map:
 - **Enabled + required** — field uses the base schema as-is
 - **Enabled + optional** — field is wrapped with `Schema.optional()`
 
-`deriveSchema` **preserves the `R` parameter** from your field schemas. If any field schema requires a service, the returned struct schema requires it too. This means you can pass the result to either `decodeEffectSchema` (sync, `R = never` required) or `decodeEffectSchemaEffect` (effectful, any `R`).
-Use `decodeEffectSchema()` for convenience, or call Effect v4's native `Schema.decodeUnknownResult()` directly.
+`deriveSchema` **preserves the `R` parameter** from your field schemas. If any field schema requires a service, the returned struct schema requires it too.
+
+For manual composition, build the availability-aware schema with `deriveSchema()`. Decode it with `decodeEffectSchema()` inside an Effect workflow. If the schema has no service requirement and you need a plain result, use `decodeEffectSchemaSync()`.
 
 #### `rejectFoul` option
 
@@ -210,7 +211,7 @@ const { errors } = validation.run(availability, values)
 const result = yield * validation.runEffect(availability, values)
 ```
 
-If you need every issue or deeper control, you can use `deriveSchema()` with either `decodeEffectSchema()` (sync) or `decodeEffectSchemaEffect()` (effectful).
+For manual composition, build the availability-aware schema with `deriveSchema()`. Decode it with `decodeEffectSchema()` inside an Effect workflow. If the schema has no service requirement and you need a plain result, use `decodeEffectSchemaSync()`.
 
 ### `UmpireValidationError`
 
@@ -231,18 +232,18 @@ validation.runValidate(availability, values).pipe(
 
 `error.errors` is a `Record<string, string | undefined>` — one entry per field, `undefined` when that field passed validation.
 
-### `decodeEffectSchemaEffect(schema, input, options?)`
+### `decodeEffectSchema(schema, input, options?)`
 
-The effectful variant of `decodeEffectSchema`. Use this when your schema has service dependencies (`R ≠ never`):
+Effect-first schema decoding. Use this in `Effect.gen` with the schema returned by `deriveSchema()`, including schemas with service dependencies (`R ≠ never`):
 
 ```ts
-import { decodeEffectSchemaEffect, deriveSchema } from '@umpire/effect'
+import { decodeEffectSchema, deriveSchema } from '@umpire/effect'
 
 const schema = deriveSchema(availability, fieldSchemas)
 // schema may carry R from field schemas with service dependencies
 
 const program = Effect.gen(function* () {
-  const result = yield* decodeEffectSchemaEffect(schema, values, {
+  const result = yield* decodeEffectSchema(schema, values, {
     errors: 'all',
   })
   if (result._tag === 'Left') {
@@ -252,7 +253,18 @@ const program = Effect.gen(function* () {
 })
 ```
 
-The sync `decodeEffectSchema` requires `R = never` — it cannot handle service-requiring schemas.
+### `decodeEffectSchemaSync(schema, input, options?)`
+
+Plain synchronous schema decoding for context-free schemas only. Use this only when you explicitly need a plain result and the schema has no Effect service requirement (`R = never`):
+
+```ts
+import { decodeEffectSchemaSync, deriveSchema } from '@umpire/effect'
+
+const schema = deriveSchema(availability, fieldSchemas)
+const result = decodeEffectSchemaSync(schema, values, { errors: 'all' })
+```
+
+`decodeEffectSchemaSync` cannot handle service-requiring schemas. Serviceful Effect schemas should use `decodeEffectSchema`, `runEffect`, or `runValidate`.
 
 ### `availabilityStream(ump, ref, options)`
 
@@ -335,16 +347,16 @@ Umpire's Effect package draws a clean line between sync and effectful APIs:
 | API                                   | Requires `R = never`? | Handles service-requiring schemas? |
 | ------------------------------------- | --------------------- | ---------------------------------- |
 | `deriveSchema()`                      | No — preserves `R`    | Yes                                |
-| `decodeEffectSchema()`                | Yes                   | No                                 |
-| `decodeEffectSchemaEffect()`          | No                    | Yes                                |
+| `decodeEffectSchema()`                | No                    | Yes                                |
+| `decodeEffectSchemaSync()`            | Yes                   | No                                 |
 | `createEffectAdapter().validators`    | Yes                   | No                                 |
 | `createEffectAdapter().run()`         | Yes                   | No                                 |
 | `createEffectAdapter().runEffect()`   | No                    | Yes                                |
 | `createEffectAdapter().runValidate()` | No                    | Yes                                |
 
-`deriveSchema` itself preserves the `R` parameter from your field schemas. If a field schema requires a service (e.g. a repository for uniqueness checks), the struct schema returned by `deriveSchema` will require it too. You can feed that schema directly to `decodeEffectSchemaEffect`, `runEffect`, or `runValidate` — all of which support the full `R` channel.
+`deriveSchema` itself preserves the `R` parameter from your field schemas. If a field schema requires a service (e.g. a repository for uniqueness checks), the struct schema returned by `deriveSchema` will require it too. You can feed that schema directly to `decodeEffectSchema`, `runEffect`, or `runValidate` — all of which support the full `R` channel.
 
-The sync APIs (`decodeEffectSchema`, `validators`, `run`) are available only when `R = never`. When you use a service-requiring schema, those members are not present on the adapter. You get a TypeScript error at the call site rather than a runtime failure.
+The sync APIs (`decodeEffectSchemaSync`, `validators`, `run`) are available only when `R = never`. When you use a service-requiring schema, those members are not present on the adapter. You get a TypeScript error at the call site rather than a runtime failure.
 
 ### `fromSubscriptionRef(ump, ref, options)`
 

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -65,7 +65,7 @@ if (result._tag === 'Left') {
 }
 
 // Or use the convenience adapter
-const validation = createEffectAdapter({
+const validation = createEffectAdapter()({
   schemas: fieldSchemas,
 })
 
@@ -114,7 +114,7 @@ Normalizes an Effect schema parse error or issue into `{ field, message }[]` pai
 
 Filters normalized field errors to only include enabled fields and keeps the first message per field. Returns `Partial<Record<field, message>>`. Root-level errors (from cross-field refinements) are keyed under `'_root'`.
 
-### `createEffectAdapter({ schemas, build?, rejectFoul? })`
+### `createEffectAdapter()({ schemas, build?, rejectFoul? })`
 
 Creates a convenience adapter with:
 
@@ -124,7 +124,7 @@ Creates a convenience adapter with:
 Use `build` to add cross-field refinements:
 
 ```ts
-const validation = createEffectAdapter({
+const validation = createEffectAdapter()({
   schemas: {
     password: Schema.String,
     confirmPassword: Schema.String,
@@ -183,7 +183,7 @@ For form-style inputs, define an explicit empty-state rule:
 ```ts
 import { isEmptyString, umpire } from '@umpire/core'
 
-const validation = createEffectAdapter({
+const validation = createEffectAdapter()({
   schemas: {
     email: Schema.String.check(
       Schema.makeFilter((s) =>

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -451,6 +451,18 @@ describe('createEffectAdapter', () => {
     expect(error.message).toBe('Validation failed: email')
   })
 
+  test('UmpireValidationError message ignores undefined error entries', () => {
+    const error = new UmpireValidationError({
+      errors: {
+        email: undefined,
+        name: 'Name is required',
+      },
+      normalizedErrors: [],
+    })
+
+    expect(error.message).toBe('Validation failed: name')
+  })
+
   test('runValidate rejects foul values when rejectFoul is enabled', async () => {
     const fields = { spotType: {}, vehicleType: {} }
     const validation = createEffectAdapter({
@@ -489,6 +501,12 @@ describe('createEffectAdapter', () => {
     expect(error.errors).toEqual({
       vehicleType: 'Vehicle type does not match the reserved spot',
     })
+    expect(error.normalizedErrors).toEqual([
+      {
+        field: 'vehicleType',
+        message: 'Vehicle type does not match the reserved spot',
+      },
+    ])
     expect(error.message).toBe('Validation failed: vehicleType')
   })
 

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -1,6 +1,7 @@
 import { enabledWhen, fairWhen, umpire } from '@umpire/core'
 import { Effect, Schema } from 'effect'
 import { createEffectAdapter } from '../src/adapter.js'
+import { UmpireValidationError } from '../src/errors.js'
 
 const emailSchema = stringMatching(
   (s) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s),
@@ -356,8 +357,36 @@ describe('createEffectAdapter', () => {
 
     expect(effectResult.errors).toEqual(syncResult.errors)
     expect(effectResult.normalizedErrors).toEqual(syncResult.normalizedErrors)
-    expect(effectResult.result).toMatchObject(syncResult.result)
+    expect(effectResult.result).toEqual(syncResult.result)
     expect(effectResult.schemaFields).toEqual(syncResult.schemaFields)
+  })
+
+  test('runEffect returns a successful decode result with schema fields', async () => {
+    const validation = createEffectAdapter({
+      schemas: {
+        email: emailSchema,
+        name: Schema.String,
+      },
+    })
+    const ump = umpire({
+      fields: { email: { required: true }, name: {} },
+      rules: [],
+      validators: validation.validators,
+    })
+    const availability = ump.check({
+      email: 'ok@example.com',
+      name: 'Alice',
+    })
+
+    const result = await Effect.runPromise(
+      validation.runEffect(availability, {
+        email: 'ok@example.com',
+        name: 'Alice',
+      }),
+    )
+
+    expect(result.result._tag).toBe('Right')
+    expect(result.schemaFields).toEqual(['email', 'name'])
   })
 
   test('runValidate returns the decoded value on success (not the decode wrapper)', async () => {
@@ -390,7 +419,7 @@ describe('createEffectAdapter', () => {
     const availability = ump.check({ age: '42' })
 
     const result = await Effect.runPromise(
-      validation.runValidate(availability, { age: '42' }),
+      validation.runValidate<{ age: number }>(availability, { age: '42' }),
     )
 
     // Schema.NumberFromString coerces string "42" to number 42
@@ -413,11 +442,54 @@ describe('createEffectAdapter', () => {
       Effect.flip(validation.runValidate(availability, { email: 'bad' })),
     )
 
+    expect(error).toBeInstanceOf(Error)
     expect(error._tag).toBe('UmpireValidationError')
     expect(error.errors).toEqual({ email: 'Enter a valid email' })
     expect(error.normalizedErrors).toEqual([
       { field: 'email', message: 'Enter a valid email' },
     ])
+    expect(error.message).toBe('Validation failed: email')
+  })
+
+  test('runValidate rejects foul values when rejectFoul is enabled', async () => {
+    const fields = { spotType: {}, vehicleType: {} }
+    const validation = createEffectAdapter({
+      schemas: {
+        spotType: Schema.Literals(['electric', 'standard']),
+        vehicleType: Schema.Literals(['electric', 'gas']),
+      },
+      rejectFoul: true,
+    })
+    const ump = umpire({
+      fields,
+      rules: [
+        fairWhen(
+          'vehicleType',
+          (value, values) =>
+            value === values.spotType || values.spotType === 'standard',
+          { reason: 'Vehicle type does not match the reserved spot' },
+        ),
+      ],
+    })
+    const availability = ump.check({
+      spotType: 'electric',
+      vehicleType: 'gas',
+    })
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        validation.runValidate(availability, {
+          spotType: 'electric',
+          vehicleType: 'gas',
+        }),
+      ),
+    )
+
+    expect(error).toBeInstanceOf(UmpireValidationError)
+    expect(error.errors).toEqual({
+      vehicleType: 'Vehicle type does not match the reserved spot',
+    })
+    expect(error.message).toBe('Validation failed: vehicleType')
   })
 
   test('can catch UmpireValidationError with Effect.catchTag', async () => {

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -1,5 +1,5 @@
 import { enabledWhen, fairWhen, umpire } from '@umpire/core'
-import { Schema } from 'effect'
+import { Effect, Schema } from 'effect'
 import { createEffectAdapter } from '../src/adapter.js'
 
 const emailSchema = stringMatching(
@@ -335,5 +335,113 @@ describe('createEffectAdapter', () => {
 
     expect(result.result).toMatchObject({ _tag: 'Left' })
     expect(result.errors).toEqual({ _root: 'Passwords do not match' })
+  })
+
+  test('runEffect returns the same result shape as run()', async () => {
+    const validation = createEffectAdapter({
+      schemas: { email: emailSchema },
+    })
+    const ump = umpire({
+      fields: { email: { required: true } },
+      rules: [],
+      validators: validation.validators,
+    })
+    const availability = ump.check({ email: 'bad' })
+    const values = { email: 'bad' }
+
+    const syncResult = validation.run(availability, values)
+    const effectResult = await Effect.runPromise(
+      validation.runEffect(availability, values),
+    )
+
+    expect(effectResult.errors).toEqual(syncResult.errors)
+    expect(effectResult.normalizedErrors).toEqual(syncResult.normalizedErrors)
+    expect(effectResult.result).toMatchObject(syncResult.result)
+    expect(effectResult.schemaFields).toEqual(syncResult.schemaFields)
+  })
+
+  test('runValidate returns the decoded value on success (not the decode wrapper)', async () => {
+    const validation = createEffectAdapter({
+      schemas: { name: Schema.String },
+    })
+    const ump = umpire({
+      fields: { name: { required: true } },
+      rules: [],
+      validators: validation.validators,
+    })
+    const availability = ump.check({ name: 'Alice' })
+
+    const result = await Effect.runPromise(
+      validation.runValidate(availability, { name: 'Alice' }),
+    )
+
+    expect(result).toEqual({ name: 'Alice' })
+  })
+
+  test('runValidate returns the transformed/decoded value for coercing schemas', async () => {
+    const validation = createEffectAdapter({
+      schemas: { age: Schema.NumberFromString },
+    })
+    const ump = umpire({
+      fields: { age: { required: true } },
+      rules: [],
+      validators: validation.validators,
+    })
+    const availability = ump.check({ age: '42' })
+
+    const result = await Effect.runPromise(
+      validation.runValidate(availability, { age: '42' }),
+    )
+
+    // Schema.NumberFromString coerces string "42" to number 42
+    expect(result).toEqual({ age: 42 })
+    expect(typeof result.age).toBe('number')
+  })
+
+  test('runValidate fails with UmpireValidationError on validation errors', async () => {
+    const validation = createEffectAdapter({
+      schemas: { email: emailSchema },
+    })
+    const ump = umpire({
+      fields: { email: { required: true } },
+      rules: [],
+      validators: validation.validators,
+    })
+    const availability = ump.check({ email: 'bad' })
+
+    const error = await Effect.runPromise(
+      Effect.flip(validation.runValidate(availability, { email: 'bad' })),
+    )
+
+    expect(error._tag).toBe('UmpireValidationError')
+    expect(error.errors).toEqual({ email: 'Enter a valid email' })
+    expect(error.normalizedErrors).toEqual([
+      { field: 'email', message: 'Enter a valid email' },
+    ])
+  })
+
+  test('can catch UmpireValidationError with Effect.catchTag', async () => {
+    const validation = createEffectAdapter({
+      schemas: { email: emailSchema },
+    })
+    const ump = umpire({
+      fields: { email: { required: true } },
+      rules: [],
+      validators: validation.validators,
+    })
+    const availability = ump.check({ email: 'bad' })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* validation.runValidate(availability, { email: 'bad' })
+        return 'success'
+      }).pipe(
+        Effect.catchTag('UmpireValidationError', (error) =>
+          Effect.succeed(`caught: ${error.errors.email}`),
+        ),
+      ),
+    )
+
+    expect(result).toBe('caught: Enter a valid email')
   })
 })

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -18,6 +18,15 @@ function stringMatching(
 }
 
 describe('createEffectAdapter', () => {
+  test('supports the public uncurried factory call', () => {
+    const validation = createEffectAdapter({
+      schemas: { email: emailSchema },
+    })
+
+    expect(typeof validation.run).toBe('function')
+    expect(typeof validation.validators.email).toBe('function')
+  })
+
   test('creates per-field validators that surface the first parse error', () => {
     const validation = createEffectAdapter()({
       schemas: { email: emailSchema },

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -19,7 +19,7 @@ function stringMatching(
 
 describe('createEffectAdapter', () => {
   test('creates per-field validators that surface the first parse error', () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: { email: emailSchema },
     })
 
@@ -39,7 +39,7 @@ describe('createEffectAdapter', () => {
   })
 
   test('per-field validator reports invalid for a type mismatch', () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: { count: Schema.Number },
     })
 
@@ -64,7 +64,7 @@ describe('createEffectAdapter', () => {
       companyName: { required: true },
     }
 
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: {
         email: emailSchema,
         password: stringMatching((s) => s.length >= 8, 'At least 8 characters'),
@@ -109,7 +109,7 @@ describe('createEffectAdapter', () => {
       (s) => s.length > 0,
       'Company name is required',
     )
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: {
         'account.accountType': Schema.Literals(['personal', 'business']),
         'account.companyName': companyNameSchema,
@@ -151,7 +151,7 @@ describe('createEffectAdapter', () => {
 
   test('throws when nested value shape is requested without a composed schema', () => {
     expect(() =>
-      createEffectAdapter({
+      createEffectAdapter()({
         schemas: {
           'account.companyName': Schema.String,
         },
@@ -165,7 +165,7 @@ describe('createEffectAdapter', () => {
   test('excludes disabled fields from schemaFields', () => {
     const fields = { name: {}, extra: {} }
 
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: { name: Schema.String, extra: Schema.String },
     })
 
@@ -187,7 +187,7 @@ describe('createEffectAdapter', () => {
   test('rejectFoul rejects enabled fields with a foul value', () => {
     const fields = { spotType: {}, vehicleType: {} }
 
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: {
         spotType: Schema.Literals(['electric', 'standard']),
         vehicleType: Schema.Literals(['electric', 'gas']),
@@ -235,7 +235,7 @@ describe('createEffectAdapter', () => {
   test('rejectFoul allows absent optional foul fields', () => {
     const fields = { spotType: {}, vehicleType: { required: false } }
 
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: {
         spotType: Schema.Literals(['electric', 'standard']),
         vehicleType: Schema.Literals(['electric', 'gas']),
@@ -269,7 +269,7 @@ describe('createEffectAdapter', () => {
   })
 
   test('rejectFoul uses the default message when no reason is provided', () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: {
         mode: Schema.Literals(['open', 'locked']),
         choice: Schema.String,
@@ -310,7 +310,7 @@ describe('createEffectAdapter', () => {
       confirmPassword: { required: true },
     }
 
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: {
         password: Schema.String,
         confirmPassword: Schema.String,
@@ -339,7 +339,7 @@ describe('createEffectAdapter', () => {
   })
 
   test('runEffect returns the same result shape as run()', async () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: { email: emailSchema },
     })
     const ump = umpire({
@@ -362,7 +362,7 @@ describe('createEffectAdapter', () => {
   })
 
   test('runEffect returns a successful decode result with schema fields', async () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: {
         email: emailSchema,
         name: Schema.String,
@@ -390,7 +390,7 @@ describe('createEffectAdapter', () => {
   })
 
   test('runValidate returns the decoded value on success (not the decode wrapper)', async () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: { name: Schema.String },
     })
     const ump = umpire({
@@ -408,7 +408,7 @@ describe('createEffectAdapter', () => {
   })
 
   test('runValidate returns the transformed/decoded value for coercing schemas', async () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: { age: Schema.NumberFromString },
     })
     const ump = umpire({
@@ -427,8 +427,76 @@ describe('createEffectAdapter', () => {
     expect(typeof result.age).toBe('number')
   })
 
+  test('runEffect supports nested valueShape pipelines', async () => {
+    const validation = createEffectAdapter()({
+      schemas: {
+        'account.companyName': Schema.String,
+      },
+      valueShape: 'nested',
+      build: () =>
+        Schema.Struct({
+          account: Schema.Struct({
+            companyName: stringMatching(
+              (value) => value.length > 0,
+              'Company name is required',
+            ),
+          }),
+        }),
+    })
+    const availability = {
+      'account.companyName': {
+        enabled: true,
+        fair: true,
+        required: true,
+        satisfied: false,
+        valid: true,
+      },
+    }
+
+    const result = await Effect.runPromise(
+      validation.runEffect(availability, {
+        'account.companyName': '',
+      }),
+    )
+
+    expect(result.result._tag).toBe('Left')
+    expect(result.errors).toEqual({
+      'account.companyName': 'Company name is required',
+    })
+  })
+
+  test('runValidate supports nested valueShape pipelines', async () => {
+    const validation = createEffectAdapter()({
+      schemas: {
+        'account.age': Schema.NumberFromString,
+      },
+      valueShape: 'nested',
+      build: () =>
+        Schema.Struct({
+          account: Schema.Struct({
+            age: Schema.NumberFromString,
+          }),
+        }),
+    })
+    const availability = {
+      'account.age': {
+        enabled: true,
+        fair: true,
+        required: true,
+        satisfied: true,
+        valid: true,
+      },
+    }
+
+    const decoded = await Effect.runPromise(
+      validation.runValidate(availability, { 'account.age': '42' }),
+    )
+
+    expect(decoded).toEqual({ account: { age: 42 } })
+  })
+
   test('runValidate fails with UmpireValidationError on validation errors', async () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: { email: emailSchema },
     })
     const ump = umpire({
@@ -463,9 +531,29 @@ describe('createEffectAdapter', () => {
     expect(error.message).toBe('Validation failed: name')
   })
 
+  test('UmpireValidationError falls back to generic message for empty errors', () => {
+    const error = new UmpireValidationError({
+      errors: {},
+      normalizedErrors: [],
+    })
+
+    expect(error.message).toBe('Validation failed')
+  })
+
+  test('UmpireValidationError falls back to generic message when all entries are undefined', () => {
+    const error = new UmpireValidationError({
+      errors: {
+        email: undefined,
+      },
+      normalizedErrors: [],
+    })
+
+    expect(error.message).toBe('Validation failed')
+  })
+
   test('runValidate rejects foul values when rejectFoul is enabled', async () => {
     const fields = { spotType: {}, vehicleType: {} }
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: {
         spotType: Schema.Literals(['electric', 'standard']),
         vehicleType: Schema.Literals(['electric', 'gas']),
@@ -511,7 +599,7 @@ describe('createEffectAdapter', () => {
   })
 
   test('can catch UmpireValidationError with Effect.catchTag', async () => {
-    const validation = createEffectAdapter({
+    const validation = createEffectAdapter()({
       schemas: { email: emailSchema },
     })
     const ump = umpire({

--- a/packages/effect/__tests__/adapter.test.ts
+++ b/packages/effect/__tests__/adapter.test.ts
@@ -1,5 +1,5 @@
 import { enabledWhen, fairWhen, umpire } from '@umpire/core'
-import { Effect, Schema } from 'effect'
+import { Context, Effect, Layer, Schema } from 'effect'
 import { createEffectAdapter } from '../src/adapter.js'
 import { UmpireValidationError } from '../src/errors.js'
 
@@ -621,5 +621,166 @@ describe('createEffectAdapter', () => {
     )
 
     expect(result).toBe('caught: Enter a valid email')
+  })
+
+  test('runValidate works with a serviceful Effect Schema when the service is provided', async () => {
+    const ParseService = Context.Service<{ parse: (s: string) => number }>(
+      'ParseService',
+    )
+
+    const servicefulSchema: Schema.Decoder<
+      number,
+      { parse: (s: string) => number }
+    > = Schema.declareConstructor()(
+      [],
+      () => (input: unknown, _ast: never) =>
+        Effect.gen(function* () {
+          const _svc = yield* Effect.service(ParseService)
+          if (typeof input === 'string') {
+            const n = Number(input)
+            if (isNaN(n)) {
+              return yield* Effect.fail(
+                new Schema.SchemaError('not a number' as never),
+              )
+            }
+            return n
+          }
+          return yield* Effect.fail(
+            new Schema.SchemaError('not a string' as never),
+          )
+        }),
+    )
+
+    const validation = createEffectAdapter()({
+      schemas: { value: servicefulSchema },
+    })
+
+    const availability = {
+      value: {
+        enabled: true,
+        fair: true,
+        required: true,
+        satisfied: true,
+        valid: true,
+      },
+    }
+
+    const result = await Effect.runPromise(
+      Effect.provide(
+        validation.runValidate(availability, { value: '42' }),
+        Layer.succeed(ParseService, { parse: (s: string) => Number(s) }),
+      ),
+    )
+
+    expect(result).toEqual({ value: 42 })
+  })
+
+  test('runEffect works with a serviceful Effect Schema when the service is provided', async () => {
+    const ParseService = Context.Service<{ parse: (s: string) => number }>(
+      'ParseService',
+    )
+
+    const servicefulSchema: Schema.Decoder<
+      number,
+      { parse: (s: string) => number }
+    > = Schema.declareConstructor()(
+      [],
+      () => (input: unknown, _ast: never) =>
+        Effect.gen(function* () {
+          const _svc = yield* Effect.service(ParseService)
+          if (typeof input === 'string') {
+            const n = Number(input)
+            if (isNaN(n)) {
+              return yield* Effect.fail(
+                new Schema.SchemaError('not a number' as never),
+              )
+            }
+            return n
+          }
+          return yield* Effect.fail(
+            new Schema.SchemaError('not a string' as never),
+          )
+        }),
+    )
+
+    const validation = createEffectAdapter()({
+      schemas: { value: servicefulSchema },
+    })
+
+    const availability = {
+      value: {
+        enabled: true,
+        fair: true,
+        required: true,
+        satisfied: true,
+        valid: true,
+      },
+    }
+
+    const result = await Effect.runPromise(
+      Effect.provide(
+        validation.runEffect(availability, { value: '42' }),
+        Layer.succeed(ParseService, { parse: (s: string) => Number(s) }),
+      ),
+    )
+
+    expect(result.result._tag).toBe('Right')
+    if (result.result._tag === 'Right') {
+      expect(result.result.value).toEqual({ value: 42 })
+    }
+  })
+
+  test('serviceful schema parse failure maps to UmpireValidationError', async () => {
+    const ParseService = Context.Service<{ parse: (s: string) => number }>(
+      'ParseService',
+    )
+
+    const servicefulSchema: Schema.Decoder<
+      number,
+      { parse: (s: string) => number }
+    > = Schema.declareConstructor()(
+      [],
+      () => (input: unknown, _ast: never) =>
+        Effect.gen(function* () {
+          const _svc = yield* Effect.service(ParseService)
+          if (typeof input === 'string') {
+            const n = Number(input)
+            if (isNaN(n)) {
+              return yield* Effect.fail(
+                new Schema.SchemaError('not a number' as never),
+              )
+            }
+            return n
+          }
+          return yield* Effect.fail(
+            new Schema.SchemaError('not a string' as never),
+          )
+        }),
+    )
+
+    const validation = createEffectAdapter()({
+      schemas: { value: servicefulSchema },
+    })
+
+    const availability = {
+      value: {
+        enabled: true,
+        fair: true,
+        required: true,
+        satisfied: true,
+        valid: true,
+      },
+    }
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        Effect.provide(
+          validation.runValidate(availability, { value: 'not-a-number' }),
+          Layer.succeed(ParseService, { parse: (s: string) => Number(s) }),
+        ),
+      ),
+    )
+
+    expect(error._tag).toBe('UmpireValidationError')
   })
 })

--- a/packages/effect/__tests__/async-layer.test.ts
+++ b/packages/effect/__tests__/async-layer.test.ts
@@ -1,0 +1,78 @@
+import { enabledWhen, umpire as asyncUmpire } from '@umpire/async'
+import type { AnyRule, Umpire as AsyncUmpire } from '@umpire/async'
+import { Context, Effect } from 'effect'
+import { umpireAsyncLayer } from '../src/async-layer.js'
+
+describe('umpireAsyncLayer', () => {
+  test('provides an async umpire instance through a layer', async () => {
+    const fields = { name: { required: true }, email: { required: false } }
+    const rules: AnyRule<typeof fields>[] = []
+
+    const UmpTag = Context.Service<AsyncUmpire<typeof fields>>('Umpire')
+
+    const live = umpireAsyncLayer(UmpTag, { fields, rules })
+
+    const program = Effect.gen(function* () {
+      const ump = yield* Effect.service(UmpTag)
+      return yield* Effect.promise(() =>
+        ump.check({ name: 'Alice', email: 'a@b.com' }),
+      )
+    })
+
+    const result = await Effect.runPromise(Effect.provide(program, live))
+
+    expect(result).toMatchObject({
+      name: { satisfied: true, enabled: true },
+      email: { satisfied: true, enabled: true },
+    })
+  })
+
+  test('layer produces the same availability as direct async umpire() call', async () => {
+    const fields = { name: { required: true } }
+    const rules: AnyRule<typeof fields>[] = []
+
+    const UmpTag = Context.Service<AsyncUmpire<typeof fields>>('Umpire')
+    const live = umpireAsyncLayer(UmpTag, { fields, rules })
+
+    const program = Effect.gen(function* () {
+      const ump = yield* Effect.service(UmpTag)
+      return yield* Effect.promise(() => ump.check({ name: 'Alice' }))
+    })
+
+    const layerResult = await Effect.runPromise(Effect.provide(program, live))
+    const direct = await asyncUmpire({ fields, rules }).check({ name: 'Alice' })
+
+    expect(layerResult).toEqual(direct)
+  })
+
+  test('supports async condition-aware rules through the layer', async () => {
+    const fields = { companyName: { required: true } }
+    const rules: AnyRule<typeof fields, { plan: 'personal' | 'business' }>[] = [
+      enabledWhen(
+        'companyName',
+        (_values, conditions) => conditions.plan === 'business',
+      ),
+    ]
+
+    const UmpTag =
+      Context.Service<
+        AsyncUmpire<typeof fields, { plan: 'personal' | 'business' }>
+      >('Umpire')
+    const live = umpireAsyncLayer(UmpTag, { fields, rules })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ump = yield* Effect.service(UmpTag)
+        return yield* Effect.promise(() =>
+          ump.check({ companyName: undefined }, { plan: 'business' }),
+        )
+      }).pipe(Effect.provide(live)),
+    )
+
+    expect(result.companyName).toMatchObject({
+      enabled: true,
+      required: true,
+      satisfied: false,
+    })
+  })
+})

--- a/packages/effect/__tests__/availability-stream-async.test.ts
+++ b/packages/effect/__tests__/availability-stream-async.test.ts
@@ -1,0 +1,294 @@
+import { umpire as asyncUmpire, defineRule, enabledWhen } from '@umpire/async'
+import { Deferred, Effect, Fiber, Stream, SubscriptionRef } from 'effect'
+import { availabilityStreamAsync } from '../src/availability-stream-async.js'
+
+function makeRef<S>(initial: S): SubscriptionRef.SubscriptionRef<S> {
+  return Effect.runSync(SubscriptionRef.make(initial))
+}
+
+describe('availabilityStreamAsync', () => {
+  test('emits the current availability on first emission', async () => {
+    const ump = asyncUmpire({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStreamAsync(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    const items = await Effect.runPromise(
+      Stream.take(stream, 1).pipe(Stream.runCollect),
+    )
+    const [first] = items
+
+    expect(first).toBeDefined()
+    expect(first?.name).toMatchObject({
+      enabled: true,
+      satisfied: true,
+    })
+  })
+
+  test('emits updated availability after ref changes', async () => {
+    const ump = asyncUmpire({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStreamAsync(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    const ready = Effect.runSync(Deferred.make<void>())
+    const fiber = Effect.runFork(
+      Stream.take(stream, 2).pipe(
+        Stream.tap(() => Deferred.succeed(ready, undefined)),
+        Stream.runCollect,
+      ),
+    )
+
+    await Effect.runPromise(Deferred.await(ready))
+    await Effect.runPromise(
+      SubscriptionRef.set(ref, { name: undefined as unknown as string }),
+    )
+
+    const items = await Effect.runPromise(Fiber.join(fiber))
+
+    expect(items.length).toBe(2)
+    const updated = items[1]
+    expect(updated.name.satisfied).toBe(false)
+  })
+
+  test('passes previous values to ump.check on subsequent emissions', async () => {
+    const ump = asyncUmpire({
+      fields: { email: { required: true }, name: {} },
+      rules: [
+        defineRule({
+          type: 'previous-email',
+          targets: ['name'],
+          sources: ['email'],
+          evaluate: (values, _conditions, prev) =>
+            Promise.resolve(
+              new Map([
+                [
+                  'name',
+                  {
+                    enabled: values.email === '' && prev?.email === 'a@b.com',
+                    reason: null,
+                  },
+                ],
+              ]),
+            ),
+        }),
+      ],
+    })
+    const ref = makeRef({ email: 'a@b.com', name: 'Bob' })
+    const stream = availabilityStreamAsync(ump, ref, {
+      select: (s) => ({ email: s.email, name: s.name }),
+    })
+
+    const [initial] = await Effect.runPromise(
+      Stream.take(stream, 1).pipe(Stream.runCollect),
+    )
+
+    const directInitial = await ump.check({ email: 'a@b.com', name: 'Bob' })
+    expect(initial).toEqual(directInitial)
+    expect(initial?.name.enabled).toBe(false)
+
+    const ready = Effect.runSync(Deferred.make<void>())
+    const fiber = Effect.runFork(
+      Stream.take(stream, 2).pipe(
+        Stream.tap(() => Deferred.succeed(ready, undefined)),
+        Stream.runCollect,
+      ),
+    )
+
+    await Effect.runPromise(Deferred.await(ready))
+    await Effect.runPromise(
+      SubscriptionRef.set(ref, { email: '', name: 'Bob' }),
+    )
+
+    const items = await Effect.runPromise(Fiber.join(fiber))
+
+    const directNext = await ump.check({ email: '', name: 'Bob' }, undefined, {
+      email: 'a@b.com',
+      name: 'Bob',
+    })
+    expect(items[1]).toEqual(directNext)
+    expect(items[1]?.name.enabled).toBe(true)
+  })
+
+  test('works with async rule evaluate functions', async () => {
+    const ump = asyncUmpire({
+      fields: { name: { required: true } },
+      rules: [
+        defineRule({
+          type: 'async-rule',
+          targets: ['name'],
+          sources: [],
+          evaluate: async (values) =>
+            new Map([
+              ['name', { enabled: values.name === 'Alice', reason: null }],
+            ]),
+        }),
+      ],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStreamAsync(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    const [first] = await Effect.runPromise(
+      Stream.take(stream, 1).pipe(Stream.runCollect),
+    )
+
+    expect(first?.name).toMatchObject({
+      enabled: true,
+      satisfied: true,
+    })
+  })
+
+  test('passes extracted conditions to ump.check when state changes', async () => {
+    const ump = asyncUmpire<
+      { companyName: { required: true } },
+      { plan: 'personal' | 'business' }
+    >({
+      fields: { companyName: { required: true } },
+      rules: [
+        enabledWhen(
+          'companyName',
+          (_values, conditions) => conditions.plan === 'business',
+        ),
+      ],
+    })
+    const ref = makeRef({
+      values: { companyName: undefined },
+      conditions: { plan: 'personal' as const },
+    })
+    const stream = availabilityStreamAsync(ump, ref, {
+      select: (s) => s.values,
+      conditions: (s) => s.conditions,
+    })
+
+    const ready = Effect.runSync(Deferred.make<void>())
+    const fiber = Effect.runFork(
+      Stream.take(stream, 2).pipe(
+        Stream.tap(() => Deferred.succeed(ready, undefined)),
+        Stream.runCollect,
+      ),
+    )
+
+    await Effect.runPromise(Deferred.await(ready))
+    await Effect.runPromise(
+      SubscriptionRef.set(ref, {
+        values: { companyName: undefined },
+        conditions: { plan: 'business' },
+      }),
+    )
+
+    const items = await Effect.runPromise(Fiber.join(fiber))
+
+    expect(items[0]?.companyName).toMatchObject({
+      enabled: false,
+      required: false,
+    })
+    expect(items[1]?.companyName).toMatchObject({
+      enabled: true,
+      required: true,
+      satisfied: false,
+    })
+  })
+
+  test('interruption aborts in-flight async check', async () => {
+    let wasAborted = false
+
+    const ump = asyncUmpire({
+      fields: { name: {} },
+      rules: [
+        defineRule({
+          type: 'hanging-rule',
+          targets: ['name'],
+          sources: [],
+          evaluate: async (
+            _values,
+            _conditions,
+            _prev,
+            _fields,
+            _availability,
+            signal,
+          ) => {
+            signal.addEventListener('abort', () => {
+              wasAborted = true
+            })
+            await new Promise<void>((_resolve, reject) => {
+              if (signal.aborted) {
+                wasAborted = true
+                reject(new Error('aborted'))
+                return
+              }
+              const onAbort = () => {
+                wasAborted = true
+                reject(new Error('aborted'))
+              }
+              signal.addEventListener('abort', onAbort, { once: true })
+            })
+            return new Map([['name', { enabled: true, reason: null }]])
+          },
+        }),
+      ],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStreamAsync(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    const fiber = Effect.runFork(Stream.take(stream, 1).pipe(Stream.runCollect))
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(wasAborted).toBe(true)
+  })
+
+  test('rejected async check fails the stream', async () => {
+    const ump = asyncUmpire({
+      fields: { name: { required: true } },
+      rules: [
+        defineRule({
+          type: 'failing-rule',
+          targets: ['name'],
+          sources: [],
+          evaluate: async () => {
+            throw new Error('async check failed')
+          },
+        }),
+      ],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStreamAsync(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    await expect(Effect.runPromise(Stream.runCollect(stream))).rejects.toThrow(
+      'async check failed',
+    )
+  })
+
+  test('availabilityStreamAsync is importable', () => {
+    expect(availabilityStreamAsync).toBeDefined()
+    expect(typeof availabilityStreamAsync).toBe('function')
+
+    const ump = asyncUmpire({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStreamAsync(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    expect(stream).toBeDefined()
+    expect(typeof stream.pipe).toBe('function')
+  })
+})

--- a/packages/effect/__tests__/availability-stream.test.ts
+++ b/packages/effect/__tests__/availability-stream.test.ts
@@ -1,0 +1,150 @@
+import { umpire } from '@umpire/core'
+import { Effect, Fiber, Stream, SubscriptionRef } from 'effect'
+import { availabilityStream } from '../src/availability-stream.js'
+
+function makeRef<S>(initial: S): SubscriptionRef.SubscriptionRef<S> {
+  return Effect.runSync(SubscriptionRef.make(initial))
+}
+
+describe('availabilityStream', () => {
+  test('emits the current availability on first emission', async () => {
+    const ump = umpire({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStream(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    const items = await Effect.runPromise(
+      Stream.take(stream, 1).pipe(Stream.runCollect),
+    )
+    const [first] = items
+
+    expect(first?.name).toMatchObject({ satisfied: true })
+  })
+
+  test('emits updated availability after ref changes', async () => {
+    const ump = umpire({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStream(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    // Fork a fiber that collects stream emissions into an array
+    const items: Array<unknown> = []
+    const fiber = Effect.runFork(
+      Stream.runForEach(stream, (a) =>
+        Effect.sync(() => {
+          items.push(a)
+        }),
+      ),
+    )
+
+    // Wait a tick for the initial emission to land
+    await new Promise((r) => setTimeout(r, 50))
+
+    // Update the ref — this triggers a new emission
+    await Effect.runPromise(
+      SubscriptionRef.set(ref, { name: undefined as unknown as string }),
+    )
+
+    // Wait for the update emission to be collected
+    await new Promise((r) => setTimeout(r, 50))
+
+    // Interrupt the fiber to stop collecting
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(items.length).toBeGreaterThanOrEqual(2)
+    // Verify the updated emission has unsatisfied name
+    const updated = items[1] as { name: { satisfied: boolean } }
+    expect(updated.name.satisfied).toBe(false)
+  })
+
+  test('passes previous values to ump.check on subsequent emissions', async () => {
+    const ump = umpire({
+      fields: { email: { required: true }, name: {} },
+      rules: [],
+    })
+    const ref = makeRef({ email: 'a@b.com', name: 'Bob' })
+    const stream = availabilityStream(ump, ref, {
+      select: (s) => ({ email: s.email, name: s.name }),
+    })
+
+    // Collect first emission
+    const [initial] = await Effect.runPromise(
+      Stream.take(stream, 1).pipe(Stream.runCollect),
+    )
+
+    // Verify it matches direct check (no previous values on first call)
+    const directInitial = ump.check({ email: 'a@b.com', name: 'Bob' })
+    expect(initial).toEqual(directInitial)
+
+    // Collect second emission after update
+    const items: Array<unknown> = []
+    const fiber = Effect.runFork(
+      Stream.drop(stream, 1).pipe(
+        Stream.runForEach((a) =>
+          Effect.sync(() => {
+            items.push(a)
+          }),
+        ),
+      ),
+    )
+
+    // Update ref to trigger next emission
+    await Effect.runPromise(
+      SubscriptionRef.set(ref, { email: '', name: 'Bob' }),
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    // The second emission should match a direct check with prev values
+    const directNext = ump.check({ email: '', name: 'Bob' }, undefined, {
+      email: 'a@b.com',
+      name: 'Bob',
+    })
+    expect(items[0]).toEqual(directNext)
+  })
+
+  test('stops emitting after fiber interruption', async () => {
+    const ump = umpire({
+      fields: { count: {} },
+      rules: [],
+    })
+    const ref = makeRef({ count: 0 })
+    const stream = availabilityStream(ump, ref, {
+      select: (s) => ({ count: s.count }),
+    })
+
+    const items: Array<unknown> = []
+    const fiber = Effect.runFork(
+      Stream.runForEach(stream, (a) =>
+        Effect.sync(() => {
+          items.push(a)
+        }),
+      ),
+    )
+
+    // Wait for initial emission
+    await new Promise((r) => setTimeout(r, 50))
+
+    // Capture count after initial, then interrupt
+    const countAfterInitial = items.length
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    // Update ref after interruption — should NOT produce new emissions
+    await Effect.runPromise(SubscriptionRef.set(ref, { count: 5 }))
+
+    // Wait in case of delayed emissions
+    await new Promise((r) => setTimeout(r, 100))
+
+    // No new emissions after interruption
+    expect(items.length).toBe(countAfterInitial)
+  })
+})

--- a/packages/effect/__tests__/availability-stream.test.ts
+++ b/packages/effect/__tests__/availability-stream.test.ts
@@ -1,4 +1,4 @@
-import { enabledWhen, umpire } from '@umpire/core'
+import { defineRule, enabledWhen, umpire } from '@umpire/core'
 import { Deferred, Effect, Fiber, Stream, SubscriptionRef } from 'effect'
 import { availabilityStream } from '../src/availability-stream.js'
 
@@ -62,7 +62,23 @@ describe('availabilityStream', () => {
   test('passes previous values to ump.check on subsequent emissions', async () => {
     const ump = umpire({
       fields: { email: { required: true }, name: {} },
-      rules: [],
+      rules: [
+        defineRule({
+          type: 'previous-email',
+          targets: ['name'],
+          sources: ['email'],
+          evaluate: (values, _conditions, prev) =>
+            new Map([
+              [
+                'name',
+                {
+                  enabled: values.email === '' && prev?.email === 'a@b.com',
+                  reason: null,
+                },
+              ],
+            ]),
+        }),
+      ],
     })
     const ref = makeRef({ email: 'a@b.com', name: 'Bob' })
     const stream = availabilityStream(ump, ref, {
@@ -77,6 +93,7 @@ describe('availabilityStream', () => {
     // Verify it matches direct check (no previous values on first call)
     const directInitial = ump.check({ email: 'a@b.com', name: 'Bob' })
     expect(initial).toEqual(directInitial)
+    expect(initial?.name.enabled).toBe(false)
 
     const ready = Effect.runSync(Deferred.make<void>())
     const fiber = Effect.runFork(
@@ -99,6 +116,7 @@ describe('availabilityStream', () => {
       name: 'Bob',
     })
     expect(items[1]).toEqual(directNext)
+    expect(items[1]?.name.enabled).toBe(true)
   })
 
   test('passes extracted conditions to ump.check when state changes', async () => {

--- a/packages/effect/__tests__/availability-stream.test.ts
+++ b/packages/effect/__tests__/availability-stream.test.ts
@@ -170,6 +170,26 @@ describe('availabilityStream', () => {
     })
   })
 
+  test('works when conditions selector is omitted', async () => {
+    const ump = umpire({
+      fields: { name: { required: true } },
+      rules: [],
+    })
+    const ref = makeRef({ name: 'Alice' })
+    const stream = availabilityStream(ump, ref, {
+      select: (s) => ({ name: s.name }),
+    })
+
+    const items = await Effect.runPromise(
+      Stream.take(stream, 1).pipe(Stream.runCollect),
+    )
+
+    expect(items[0]?.name).toMatchObject({
+      enabled: true,
+      satisfied: true,
+    })
+  })
+
   test('stops emitting after fiber interruption', async () => {
     const ump = umpire({
       fields: { count: {} },
@@ -181,15 +201,28 @@ describe('availabilityStream', () => {
     })
 
     const items: Array<unknown> = []
+    const firstEmission = Effect.runSync(Deferred.make<void>())
+    let sawFirstEmission = false
     const fiber = Effect.runFork(
-      Stream.runForEach(stream, (a) =>
-        Effect.sync(() => {
+      Stream.runForEach(stream, (a) => {
+        return Effect.sync(() => {
           items.push(a)
-        }),
-      ),
+          if (!sawFirstEmission) {
+            sawFirstEmission = true
+            return true
+          }
+          return false
+        }).pipe(
+          Effect.flatMap((isFirstEmission) =>
+            isFirstEmission
+              ? Deferred.succeed(firstEmission, undefined)
+              : Effect.void,
+          ),
+        )
+      }),
     )
 
-    await Effect.runPromise(Effect.yieldNow)
+    await Effect.runPromise(Deferred.await(firstEmission))
     const countAfterInitial = items.length
     expect(countAfterInitial).toBeGreaterThan(0)
 

--- a/packages/effect/__tests__/availability-stream.test.ts
+++ b/packages/effect/__tests__/availability-stream.test.ts
@@ -1,5 +1,5 @@
-import { umpire } from '@umpire/core'
-import { Effect, Fiber, Stream, SubscriptionRef } from 'effect'
+import { enabledWhen, umpire } from '@umpire/core'
+import { Deferred, Effect, Fiber, Stream, SubscriptionRef } from 'effect'
 import { availabilityStream } from '../src/availability-stream.js'
 
 function makeRef<S>(initial: S): SubscriptionRef.SubscriptionRef<S> {
@@ -22,7 +22,11 @@ describe('availabilityStream', () => {
     )
     const [first] = items
 
-    expect(first?.name).toMatchObject({ satisfied: true })
+    expect(first).toBeDefined()
+    expect(first?.name).toMatchObject({
+      enabled: true,
+      satisfied: true,
+    })
   })
 
   test('emits updated availability after ref changes', async () => {
@@ -35,33 +39,23 @@ describe('availabilityStream', () => {
       select: (s) => ({ name: s.name }),
     })
 
-    // Fork a fiber that collects stream emissions into an array
-    const items: Array<unknown> = []
+    const ready = Effect.runSync(Deferred.make<void>())
     const fiber = Effect.runFork(
-      Stream.runForEach(stream, (a) =>
-        Effect.sync(() => {
-          items.push(a)
-        }),
+      Stream.take(stream, 2).pipe(
+        Stream.tap(() => Deferred.succeed(ready, undefined)),
+        Stream.runCollect,
       ),
     )
 
-    // Wait a tick for the initial emission to land
-    await new Promise((r) => setTimeout(r, 50))
-
-    // Update the ref — this triggers a new emission
+    await Effect.runPromise(Deferred.await(ready))
     await Effect.runPromise(
       SubscriptionRef.set(ref, { name: undefined as unknown as string }),
     )
 
-    // Wait for the update emission to be collected
-    await new Promise((r) => setTimeout(r, 50))
+    const items = await Effect.runPromise(Fiber.join(fiber))
 
-    // Interrupt the fiber to stop collecting
-    await Effect.runPromise(Fiber.interrupt(fiber))
-
-    expect(items.length).toBeGreaterThanOrEqual(2)
-    // Verify the updated emission has unsatisfied name
-    const updated = items[1] as { name: { satisfied: boolean } }
+    expect(items.length).toBe(2)
+    const updated = items[1]
     expect(updated.name.satisfied).toBe(false)
   })
 
@@ -84,32 +78,78 @@ describe('availabilityStream', () => {
     const directInitial = ump.check({ email: 'a@b.com', name: 'Bob' })
     expect(initial).toEqual(directInitial)
 
-    // Collect second emission after update
-    const items: Array<unknown> = []
+    const ready = Effect.runSync(Deferred.make<void>())
     const fiber = Effect.runFork(
-      Stream.drop(stream, 1).pipe(
-        Stream.runForEach((a) =>
-          Effect.sync(() => {
-            items.push(a)
-          }),
-        ),
+      Stream.take(stream, 2).pipe(
+        Stream.tap(() => Deferred.succeed(ready, undefined)),
+        Stream.runCollect,
       ),
     )
 
-    // Update ref to trigger next emission
+    await Effect.runPromise(Deferred.await(ready))
     await Effect.runPromise(
       SubscriptionRef.set(ref, { email: '', name: 'Bob' }),
     )
 
-    await new Promise((r) => setTimeout(r, 50))
-    await Effect.runPromise(Fiber.interrupt(fiber))
+    const items = await Effect.runPromise(Fiber.join(fiber))
 
     // The second emission should match a direct check with prev values
     const directNext = ump.check({ email: '', name: 'Bob' }, undefined, {
       email: 'a@b.com',
       name: 'Bob',
     })
-    expect(items[0]).toEqual(directNext)
+    expect(items[1]).toEqual(directNext)
+  })
+
+  test('passes extracted conditions to ump.check when state changes', async () => {
+    const ump = umpire<
+      { companyName: { required: true } },
+      { plan: 'personal' | 'business' }
+    >({
+      fields: { companyName: { required: true } },
+      rules: [
+        enabledWhen(
+          'companyName',
+          (_values, conditions) => conditions.plan === 'business',
+        ),
+      ],
+    })
+    const ref = makeRef({
+      values: { companyName: undefined },
+      conditions: { plan: 'personal' as const },
+    })
+    const stream = availabilityStream(ump, ref, {
+      select: (s) => s.values,
+      conditions: (s) => s.conditions,
+    })
+
+    const ready = Effect.runSync(Deferred.make<void>())
+    const fiber = Effect.runFork(
+      Stream.take(stream, 2).pipe(
+        Stream.tap(() => Deferred.succeed(ready, undefined)),
+        Stream.runCollect,
+      ),
+    )
+
+    await Effect.runPromise(Deferred.await(ready))
+    await Effect.runPromise(
+      SubscriptionRef.set(ref, {
+        values: { companyName: undefined },
+        conditions: { plan: 'business' },
+      }),
+    )
+
+    const items = await Effect.runPromise(Fiber.join(fiber))
+
+    expect(items[0]?.companyName).toMatchObject({
+      enabled: false,
+      required: false,
+    })
+    expect(items[1]?.companyName).toMatchObject({
+      enabled: true,
+      required: true,
+      satisfied: false,
+    })
   })
 
   test('stops emitting after fiber interruption', async () => {
@@ -131,20 +171,14 @@ describe('availabilityStream', () => {
       ),
     )
 
-    // Wait for initial emission
-    await new Promise((r) => setTimeout(r, 50))
-
-    // Capture count after initial, then interrupt
+    await Effect.runPromise(Effect.yieldNow)
     const countAfterInitial = items.length
+    expect(countAfterInitial).toBeGreaterThan(0)
+
     await Effect.runPromise(Fiber.interrupt(fiber))
 
-    // Update ref after interruption — should NOT produce new emissions
     await Effect.runPromise(SubscriptionRef.set(ref, { count: 5 }))
 
-    // Wait in case of delayed emissions
-    await new Promise((r) => setTimeout(r, 100))
-
-    // No new emissions after interruption
     expect(items.length).toBe(countAfterInitial)
   })
 })

--- a/packages/effect/__tests__/effect-schema.test.ts
+++ b/packages/effect/__tests__/effect-schema.test.ts
@@ -1,5 +1,22 @@
-import { Schema } from 'effect'
+import { Effect, Schema } from 'effect'
+import { decodeEffectSchema, decodeEffectSchemaSync } from '../src/index.js'
 import { formatEffectErrors } from '../src/effect-schema.js'
+
+describe('decode helpers', () => {
+  test('decodeEffectSchema returns an Effect decode result', async () => {
+    const result = await Effect.runPromise(
+      decodeEffectSchema(Schema.NumberFromString, '42'),
+    )
+
+    expect(result).toEqual({ _tag: 'Right', value: 42 })
+  })
+
+  test('decodeEffectSchemaSync returns a plain decode result', () => {
+    const result = decodeEffectSchemaSync(Schema.NumberFromString, '42')
+
+    expect(result).toEqual({ _tag: 'Right', value: 42 })
+  })
+})
 
 describe('formatEffectErrors', () => {
   test('formats real Effect schema decode failures', () => {

--- a/packages/effect/__tests__/effect-schema.test.ts
+++ b/packages/effect/__tests__/effect-schema.test.ts
@@ -1,5 +1,10 @@
 import { Effect, Schema } from 'effect'
-import { decodeEffectSchema, decodeEffectSchemaSync } from '../src/index.js'
+import {
+  decodeEffectSchema,
+  decodeEffectSchemaSync,
+  isDecodeFailure,
+  isDecodeSuccess,
+} from '../src/index.js'
 import { formatEffectErrors } from '../src/effect-schema.js'
 
 describe('decode helpers', () => {
@@ -9,12 +14,32 @@ describe('decode helpers', () => {
     )
 
     expect(result).toEqual({ _tag: 'Right', value: 42 })
+    expect(isDecodeSuccess(result)).toBe(true)
+    expect(isDecodeFailure(result)).toBe(false)
+  })
+
+  test('decodeEffectSchema returns parse issues as a failed decode result', async () => {
+    const result = await Effect.runPromise(
+      decodeEffectSchema(Schema.Number, 'not-a-number'),
+    )
+
+    expect(result._tag).toBe('Left')
+    expect(isDecodeFailure(result)).toBe(true)
+    expect(isDecodeSuccess(result)).toBe(false)
+    expect(formatEffectErrors(result.error)[0]?.message).toContain('number')
   })
 
   test('decodeEffectSchemaSync returns a plain decode result', () => {
     const result = decodeEffectSchemaSync(Schema.NumberFromString, '42')
 
     expect(result).toEqual({ _tag: 'Right', value: 42 })
+  })
+
+  test('decodeEffectSchemaSync returns parse issues as a failed decode result', () => {
+    const result = decodeEffectSchemaSync(Schema.Number, 'not-a-number')
+
+    expect(result._tag).toBe('Left')
+    expect(formatEffectErrors(result.error)[0]?.message).toContain('number')
   })
 })
 

--- a/packages/effect/__tests__/from-subscription-ref.test.ts
+++ b/packages/effect/__tests__/from-subscription-ref.test.ts
@@ -96,8 +96,6 @@ describe('fromSubscriptionRef', () => {
     store.destroy()
 
     await Effect.runPromise(SubscriptionRef.set(ref, { showEmail: true }))
-    // Allow any pending microtasks to flush
-    await new Promise<void>((resolve) => setTimeout(resolve, 10))
 
     expect(callCount).toBe(0)
   })

--- a/packages/effect/__tests__/layer.test.ts
+++ b/packages/effect/__tests__/layer.test.ts
@@ -1,0 +1,48 @@
+import { umpire } from '@umpire/core'
+import type { Rule, Umpire } from '@umpire/core'
+import { Context, Effect } from 'effect'
+import { umpireLayer } from '../src/layer.js'
+
+describe('umpireLayer', () => {
+  test('provides an umpire instance through a layer that can be used in Effect.gen', async () => {
+    const fields = { name: { required: true }, email: { required: false } }
+    const rules: Rule<typeof fields>[] = []
+
+    const UmpTag = Context.Service<Umpire<typeof fields>>()
+
+    const live = umpireLayer(UmpTag, { fields, rules })
+
+    const program = Effect.gen(function* () {
+      const opt = yield* Effect.serviceOption(UmpTag)
+      if (opt._tag === 'None') return { missing: true } as const
+      return opt.value.check({ name: 'Alice', email: 'a@b.com' })
+    })
+
+    const result = await Effect.runPromise(Effect.provide(program, live))
+
+    expect(result).toMatchObject({
+      name: { satisfied: true, enabled: true },
+      email: { satisfied: true, enabled: true },
+    })
+  })
+
+  test('layer produces the same availability as direct umpire() call', async () => {
+    const fields = { name: { required: true } }
+    const rules: Rule<typeof fields>[] = []
+
+    const UmpTag = Context.Service<Umpire<typeof fields>>()
+
+    const live = umpireLayer(UmpTag, { fields, rules })
+
+    const program = Effect.gen(function* () {
+      const opt = yield* Effect.serviceOption(UmpTag)
+      if (opt._tag === 'None') throw new Error('missing')
+      return opt.value.check({ name: 'Alice' })
+    })
+
+    const layerResult = await Effect.runPromise(Effect.provide(program, live))
+    const direct = umpire({ fields, rules }).check({ name: 'Alice' })
+
+    expect(layerResult).toEqual(direct)
+  })
+})

--- a/packages/effect/__tests__/layer.test.ts
+++ b/packages/effect/__tests__/layer.test.ts
@@ -1,5 +1,5 @@
-import { umpire } from '@umpire/core'
-import type { Rule, Umpire } from '@umpire/core'
+import { enabledWhen, umpire } from '@umpire/core'
+import type { Rule, Umpire, ValidationMap } from '@umpire/core'
 import { Context, Effect } from 'effect'
 import { umpireLayer } from '../src/layer.js'
 
@@ -8,14 +8,13 @@ describe('umpireLayer', () => {
     const fields = { name: { required: true }, email: { required: false } }
     const rules: Rule<typeof fields>[] = []
 
-    const UmpTag = Context.Service<Umpire<typeof fields>>()
+    const UmpTag = Context.Service<Umpire<typeof fields>>('Umpire')
 
     const live = umpireLayer(UmpTag, { fields, rules })
 
     const program = Effect.gen(function* () {
-      const opt = yield* Effect.serviceOption(UmpTag)
-      if (opt._tag === 'None') return { missing: true } as const
-      return opt.value.check({ name: 'Alice', email: 'a@b.com' })
+      const ump = yield* Effect.service(UmpTag)
+      return ump.check({ name: 'Alice', email: 'a@b.com' })
     })
 
     const result = await Effect.runPromise(Effect.provide(program, live))
@@ -30,7 +29,7 @@ describe('umpireLayer', () => {
     const fields = { name: { required: true } }
     const rules: Rule<typeof fields>[] = []
 
-    const UmpTag = Context.Service<Umpire<typeof fields>>()
+    const UmpTag = Context.Service<Umpire<typeof fields>>('Umpire')
 
     const live = umpireLayer(UmpTag, { fields, rules })
 
@@ -44,5 +43,60 @@ describe('umpireLayer', () => {
     const direct = umpire({ fields, rules }).check({ name: 'Alice' })
 
     expect(layerResult).toEqual(direct)
+  })
+
+  test('wires validators through the provided umpire instance', async () => {
+    const fields = { email: { required: true } }
+    const rules: Rule<typeof fields>[] = []
+    const validators: ValidationMap<typeof fields> = {
+      email: (value) =>
+        value === 'ok@example.com'
+          ? { valid: true }
+          : { valid: false, error: 'Enter a valid email' },
+    }
+
+    const UmpTag = Context.Service<Umpire<typeof fields>>('Umpire')
+    const live = umpireLayer(UmpTag, { fields, rules, validators })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ump = yield* Effect.service(UmpTag)
+        return ump.check({ email: 'bad' })
+      }).pipe(Effect.provide(live)),
+    )
+
+    expect(result.email).toMatchObject({
+      valid: false,
+      error: 'Enter a valid email',
+    })
+  })
+
+  test('supports condition-aware rules through the layer', async () => {
+    const fields = { companyName: { required: true } }
+    const rules: Rule<typeof fields, { plan: 'personal' | 'business' }>[] = [
+      enabledWhen(
+        'companyName',
+        (_values, conditions) => conditions.plan === 'business',
+      ),
+    ]
+
+    const UmpTag =
+      Context.Service<Umpire<typeof fields, { plan: 'personal' | 'business' }>>(
+        'Umpire',
+      )
+    const live = umpireLayer(UmpTag, { fields, rules })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ump = yield* Effect.service(UmpTag)
+        return ump.check({ companyName: undefined }, { plan: 'business' })
+      }).pipe(Effect.provide(live)),
+    )
+
+    expect(result.companyName).toMatchObject({
+      enabled: true,
+      required: true,
+      satisfied: false,
+    })
   })
 })

--- a/packages/effect/__tests__/write-adapter.test.ts
+++ b/packages/effect/__tests__/write-adapter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test'
+import { Context, Effect, Layer, Schema } from 'effect'
+import { umpire } from '@umpire/core'
+import { runWriteValidationAdapterAsync } from '@umpire/write'
+import {
+  createEffectAdapter,
+  toAsyncWriteValidationAdapter,
+} from '../src/index.js'
+
+describe('toAsyncWriteValidationAdapter', () => {
+  test('adapts context-free Effect validation to the async write protocol', async () => {
+    const validation = createEffectAdapter()({
+      schemas: {
+        email: Schema.String.check(
+          Schema.makeFilter((value) =>
+            value.includes('@') ? undefined : 'Enter a valid email',
+          ),
+        ),
+      },
+    })
+    const writeValidation = toAsyncWriteValidationAdapter(
+      validation,
+      Effect.runPromise,
+    )
+    const ump = umpire({
+      fields: { email: { required: true } },
+      rules: [],
+    })
+    const availability = ump.check({ email: 'bad' })
+
+    const result = await runWriteValidationAdapterAsync(
+      writeValidation,
+      availability,
+      { email: 'bad' },
+    )
+
+    expect(result?.schemaIssues).toEqual([
+      { field: 'email', message: 'Enter a valid email' },
+    ])
+  })
+
+  test('lets callers provide services when adapting serviceful schemas', async () => {
+    const ParseService = Context.Service<{ parse: (s: string) => number }>(
+      'ParseService',
+    )
+    const servicefulSchema: Schema.Decoder<
+      number,
+      { parse: (s: string) => number }
+    > = Schema.declareConstructor()(
+      [],
+      () => (input: unknown, _ast: never) =>
+        Effect.gen(function* () {
+          const svc = yield* Effect.service(ParseService)
+          if (typeof input === 'string') return svc.parse(input)
+          return yield* Effect.fail(
+            new Schema.SchemaError('not a string' as never),
+          )
+        }),
+    )
+    const validation = createEffectAdapter()({
+      schemas: { value: servicefulSchema },
+    })
+    const writeValidation = toAsyncWriteValidationAdapter(
+      validation,
+      (effect) =>
+        Effect.runPromise(
+          Effect.provide(
+            effect,
+            Layer.succeed(ParseService, { parse: (value) => Number(value) }),
+          ),
+        ),
+    )
+    const ump = umpire({
+      fields: { value: { required: true } },
+      rules: [],
+    })
+    const availability = ump.check({ value: '42' })
+
+    const result = await runWriteValidationAdapterAsync(
+      writeValidation,
+      availability,
+      { value: '42' },
+    )
+
+    expect(result?.schemaIssues).toEqual([])
+    expect(result?.validationResult).toEqual({
+      _tag: 'Right',
+      value: { value: 42 },
+    })
+  })
+})

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -25,6 +25,7 @@
     ".claude"
   ],
   "dependencies": {
+    "@umpire/async": "workspace:*",
     "@umpire/core": "workspace:*",
     "@umpire/store": "workspace:*",
     "@umpire/write": "workspace:*"

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -17,6 +17,7 @@ import {
 } from './derive-errors.js'
 import {
   decodeEffectSchema,
+  decodeEffectSchemaEffect,
   isDecodeFailure,
   isDecodeSuccess,
   type EffectDecodeResult,
@@ -55,23 +56,37 @@ export type CreateEffectAdapterOptions<
   namespace?: NamespacedFieldOptions
 } & DeriveSchemaOptions
 
-export type EffectAdapterRunResult<F extends Record<string, FieldDef>> = {
+export type EffectAdapterRunResult<
+  F extends Record<string, FieldDef>,
+  Out = unknown,
+> = {
   errors: DerivedErrorMap<F>
   normalizedErrors: NormalizedFieldError[]
-  result: EffectDecodeResult<Record<string, unknown>>
+  result: EffectDecodeResult<Out>
   schemaFields: Array<keyof F & string>
 }
 
-export type EffectAdapter<F extends Record<string, FieldDef>, Out, R> = {
-  run(
-    availability: AvailabilityMap<F>,
-    values: InputValues,
-  ): EffectAdapterRunResult<F>
-  validators: ValidationMap<F>
+type SyncAdapterMembers<F extends Record<string, FieldDef>, Out, R> = [
+  R,
+] extends [never]
+  ? {
+      validators: ValidationMap<F>
+      run(
+        availability: AvailabilityMap<F>,
+        values: InputValues,
+      ): EffectAdapterRunResult<F, Out>
+    }
+  : {}
+
+export type EffectAdapter<
+  F extends Record<string, FieldDef>,
+  Out,
+  R,
+> = SyncAdapterMembers<F, Out, R> & {
   runEffect(
     availability: AvailabilityMap<F>,
     values: InputValues,
-  ): Effect.Effect<EffectAdapterRunResult<F>, never, R>
+  ): Effect.Effect<EffectAdapterRunResult<F, Out>, never, R>
   runValidate(
     availability: AvailabilityMap<F>,
     values: InputValues,
@@ -122,10 +137,10 @@ export function createEffectAdapter<
     const runImpl = (
       availability: AvailabilityMap<F>,
       values: InputValues,
-    ): EffectAdapterRunResult<F> => {
+    ): EffectAdapterRunResult<F, Out> => {
       const { schema, validationValues } = prepareRun(availability, values)
-      const result = decodeEffectSchema<Record<string, unknown>>(
-        schema as unknown as AnyEffectSchema<Record<string, unknown>, never>,
+      const result = decodeEffectSchema<Out>(
+        schema as unknown as AnyEffectSchema<Out, never>,
         validationValues,
         { errors: 'all' },
       )
@@ -147,8 +162,8 @@ export function createEffectAdapter<
 
     const finalizeRun = (
       availability: AvailabilityMap<F>,
-      result: EffectDecodeResult<Record<string, unknown>>,
-    ): EffectAdapterRunResult<F> => {
+      result: EffectDecodeResult<Out>,
+    ): EffectAdapterRunResult<F, Out> => {
       const rawErrors = isDecodeFailure(result)
         ? effectErrors(result.error)
         : []
@@ -168,17 +183,18 @@ export function createEffectAdapter<
       }
     }
 
-    const runEffectFn: (
-      availability: AvailabilityMap<F>,
-      values: InputValues,
-    ) => Effect.Effect<EffectAdapterRunResult<F>, never, R> = Effect.fn(
-      '@umpire/effect:runEffect',
-    )((availability: AvailabilityMap<F>, values: InputValues) =>
-      Effect.sync(() => runImpl(availability, values)),
-    ) as (
-      availability: AvailabilityMap<F>,
-      values: InputValues,
-    ) => Effect.Effect<EffectAdapterRunResult<F>, never, R>
+    const runEffectFn = Effect.fn('@umpire/effect:runEffect')(
+      (availability, values) =>
+        Effect.gen(function* () {
+          const { schema, validationValues } = prepareRun(availability, values)
+          const result = yield* decodeEffectSchemaEffect(
+            schema as AnyEffectSchema<Out, R>,
+            validationValues,
+            { errors: 'all' },
+          )
+          return finalizeRun(availability, result)
+        }),
+    )
 
     const runValidateFn: (
       availability: AvailabilityMap<F>,
@@ -208,6 +224,6 @@ export function createEffectAdapter<
       run: runImpl,
       runEffect: runEffectFn,
       runValidate: runValidateFn,
-    }
+    } as EffectAdapter<F, Out, R>
   }
 }

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -94,9 +94,40 @@ export type EffectAdapter<
 }
 
 export function createEffectAdapter<
+  F extends Record<string, FieldDef>,
+  Schemas extends FieldSchemas<F>,
+  BuiltSchema extends AnyEffectSchema<unknown, unknown> = AnyEffectSchema<
+    InferBaseOutput<F, Schemas>,
+    ExtractR<Schemas>
+  >,
+  Out = SchemaOutput<BuiltSchema>,
+  R = ValidationContext<F, Schemas, BuiltSchema>,
+>(
+  options: CreateEffectAdapterOptions<F, Schemas, BuiltSchema>,
+): EffectAdapter<F, Out, R>
+export function createEffectAdapter<
   F extends Record<string, FieldDef> = Record<string, FieldDef>,
->() {
-  return function <
+>(): <
+  Schemas extends FieldSchemas<F>,
+  BuiltSchema extends AnyEffectSchema<unknown, unknown> = AnyEffectSchema<
+    InferBaseOutput<F, Schemas>,
+    ExtractR<Schemas>
+  >,
+  Out = SchemaOutput<BuiltSchema>,
+  R = ValidationContext<F, Schemas, BuiltSchema>,
+>(
+  options: CreateEffectAdapterOptions<F, Schemas, BuiltSchema>,
+) => EffectAdapter<F, Out, R>
+export function createEffectAdapter<
+  F extends Record<string, FieldDef> = Record<string, FieldDef>,
+>(
+  options?: CreateEffectAdapterOptions<
+    F,
+    FieldSchemas<F>,
+    AnyEffectSchema<unknown, unknown>
+  >,
+) {
+  const createAdapter = <
     Schemas extends FieldSchemas<F>,
     BuiltSchema extends AnyEffectSchema<unknown, unknown> = AnyEffectSchema<
       InferBaseOutput<F, Schemas>,
@@ -106,7 +137,7 @@ export function createEffectAdapter<
     R = ValidationContext<F, Schemas, BuiltSchema>,
   >(
     options: CreateEffectAdapterOptions<F, Schemas, BuiltSchema>,
-  ): EffectAdapter<F, Out, R> {
+  ): EffectAdapter<F, Out, R> => {
     const { schemas, build, rejectFoul } = options
 
     if (options.valueShape === 'nested' && !build) {
@@ -226,4 +257,6 @@ export function createEffectAdapter<
       runValidate: runValidateFn,
     } as EffectAdapter<F, Out, R>
   }
+
+  return options === undefined ? createAdapter : createAdapter(options)
 }

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -129,14 +129,14 @@ export function createEffectAdapter<F extends Record<string, FieldDef>>(
   )
 
   const runValidateFn = Effect.fn('@umpire/effect:runValidate')(
-    (availability: AvailabilityMap<F>, values: InputValues) =>
+    <T = Record<string, unknown>>(
+      availability: AvailabilityMap<F>,
+      values: InputValues,
+    ) =>
       Effect.gen(function* () {
         const result = yield* runEffectFn(availability, values)
-        const hasErrors = Object.values(result.errors).some(
-          (message) => message !== undefined,
-        )
-        if (!hasErrors && isDecodeSuccess(result.result)) {
-          return result.result.value
+        if (isDecodeSuccess(result.result)) {
+          return result.result.value as T
         }
         return yield* Effect.fail(
           new UmpireValidationError({
@@ -151,6 +151,6 @@ export function createEffectAdapter<F extends Record<string, FieldDef>>(
     validators,
     run: runImpl,
     runEffect: runEffectFn,
-    runValidate: runValidateFn as EffectAdapter<F>['runValidate'],
+    runValidate: runValidateFn,
   }
 }

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -27,6 +27,8 @@ import {
   type DeriveSchemaOptions,
   type FieldSchemas,
 } from './derive-schema.js'
+import { Effect } from 'effect'
+import { UmpireValidationError } from './errors.js'
 
 export type CreateEffectAdapterOptions<F extends Record<string, FieldDef>> = {
   schemas: FieldSchemas<F>
@@ -48,6 +50,14 @@ export type EffectAdapter<F extends Record<string, FieldDef>> = {
     values: InputValues,
   ): EffectAdapterRunResult<F>
   validators: ValidationMap<F>
+  runEffect(
+    availability: AvailabilityMap<F>,
+    values: InputValues,
+  ): Effect.Effect<EffectAdapterRunResult<F>, never, never>
+  runValidate(
+    availability: AvailabilityMap<F>,
+    values: InputValues,
+  ): Effect.Effect<Record<string, unknown>, UmpireValidationError, never>
 }
 
 export function createEffectAdapter<F extends Record<string, FieldDef>>(
@@ -80,38 +90,67 @@ export function createEffectAdapter<F extends Record<string, FieldDef>>(
     }
   }
 
+  const runImpl = (
+    availability: AvailabilityMap<F>,
+    values: InputValues,
+  ): EffectAdapterRunResult<F> => {
+    const baseSchema = deriveSchema(availability, schemas, { rejectFoul })
+    const schema = build ? build(baseSchema) : baseSchema
+    const validationValues =
+      options.valueShape === 'nested'
+        ? nestNamespacedValues(values, options.namespace)
+        : values
+    const result = decodeEffectSchema<Record<string, unknown>>(
+      schema,
+      validationValues,
+      { errors: 'all' },
+    )
+    const rawErrors = isDecodeFailure(result) ? effectErrors(result.error) : []
+    const normalizedErrors =
+      options.valueShape === 'nested'
+        ? flattenFieldErrorPaths(rawErrors, options.namespace)
+        : rawErrors
+
+    const schemaFields = (
+      Object.keys(availability) as Array<keyof F & string>
+    ).filter((field) => availability[field]!.enabled && field in schemas)
+
+    return {
+      errors: deriveErrors(availability, normalizedErrors),
+      normalizedErrors,
+      result,
+      schemaFields,
+    }
+  }
+
+  const runEffectFn = Effect.fn('@umpire/effect:runEffect')(
+    (availability: AvailabilityMap<F>, values: InputValues) =>
+      Effect.sync(() => runImpl(availability, values)),
+  )
+
+  const runValidateFn = Effect.fn('@umpire/effect:runValidate')(
+    (availability: AvailabilityMap<F>, values: InputValues) =>
+      Effect.gen(function* () {
+        const result = yield* runEffectFn(availability, values)
+        const hasErrors = Object.values(result.errors).some(
+          (message) => message !== undefined,
+        )
+        if (!hasErrors && isDecodeSuccess(result.result)) {
+          return result.result.value
+        }
+        return yield* Effect.fail(
+          new UmpireValidationError({
+            errors: result.errors,
+            normalizedErrors: result.normalizedErrors,
+          }),
+        )
+      }),
+  )
+
   return {
     validators,
-    run(availability, values) {
-      const baseSchema = deriveSchema(availability, schemas, { rejectFoul })
-      const schema = build ? build(baseSchema) : baseSchema
-      const validationValues =
-        options.valueShape === 'nested'
-          ? nestNamespacedValues(values, options.namespace)
-          : values
-      const result = decodeEffectSchema<Record<string, unknown>>(
-        schema,
-        validationValues,
-        { errors: 'all' },
-      )
-      const rawErrors = isDecodeFailure(result)
-        ? effectErrors(result.error)
-        : []
-      const normalizedErrors =
-        options.valueShape === 'nested'
-          ? flattenFieldErrorPaths(rawErrors, options.namespace)
-          : rawErrors
-
-      const schemaFields = (
-        Object.keys(availability) as Array<keyof F & string>
-      ).filter((field) => availability[field]!.enabled && field in schemas)
-
-      return {
-        errors: deriveErrors(availability, normalizedErrors),
-        normalizedErrors,
-        result,
-        schemaFields,
-      }
-    },
+    run: runImpl,
+    runEffect: runEffectFn,
+    runValidate: runValidateFn,
   }
 }

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -25,14 +25,32 @@ import {
   deriveSchema,
   type AnyEffectSchema,
   type DeriveSchemaOptions,
+  type ExtractR,
   type FieldSchemas,
+  type InferBaseOutput,
 } from './derive-schema.js'
 import { Effect } from 'effect'
 import { UmpireValidationError } from './errors.js'
 
-export type CreateEffectAdapterOptions<F extends Record<string, FieldDef>> = {
-  schemas: FieldSchemas<F>
-  build?(schema: AnyEffectSchema): AnyEffectSchema
+type SchemaOutput<S> = S extends AnyEffectSchema<infer A, unknown> ? A : never
+
+type ValidationContext<
+  F extends Record<string, FieldDef>,
+  Schemas extends FieldSchemas<F>,
+  BuiltSchema extends AnyEffectSchema<unknown, unknown>,
+> =
+  | ExtractR<Schemas>
+  | (BuiltSchema extends AnyEffectSchema<unknown, infer R> ? R : never)
+
+export type CreateEffectAdapterOptions<
+  F extends Record<string, FieldDef>,
+  Schemas extends FieldSchemas<F>,
+  BuiltSchema extends AnyEffectSchema<unknown, unknown>,
+> = {
+  schemas: Schemas
+  build?(
+    schema: AnyEffectSchema<InferBaseOutput<F, Schemas>, ExtractR<Schemas>>,
+  ): BuiltSchema
   valueShape?: 'flat' | 'nested'
   namespace?: NamespacedFieldOptions
 } & DeriveSchemaOptions
@@ -44,7 +62,7 @@ export type EffectAdapterRunResult<F extends Record<string, FieldDef>> = {
   schemaFields: Array<keyof F & string>
 }
 
-export type EffectAdapter<F extends Record<string, FieldDef>> = {
+export type EffectAdapter<F extends Record<string, FieldDef>, Out, R> = {
   run(
     availability: AvailabilityMap<F>,
     values: InputValues,
@@ -53,90 +71,125 @@ export type EffectAdapter<F extends Record<string, FieldDef>> = {
   runEffect(
     availability: AvailabilityMap<F>,
     values: InputValues,
-  ): Effect.Effect<EffectAdapterRunResult<F>, never, never>
-  runValidate<T = Record<string, unknown>>(
+  ): Effect.Effect<EffectAdapterRunResult<F>, never, R>
+  runValidate(
     availability: AvailabilityMap<F>,
     values: InputValues,
-  ): Effect.Effect<T, UmpireValidationError, never>
+  ): Effect.Effect<Out, UmpireValidationError, R>
 }
 
-export function createEffectAdapter<F extends Record<string, FieldDef>>(
-  options: CreateEffectAdapterOptions<F>,
-): EffectAdapter<F> {
-  const { schemas, build, rejectFoul } = options
+export function createEffectAdapter<
+  F extends Record<string, FieldDef> = Record<string, FieldDef>,
+>() {
+  return function <
+    Schemas extends FieldSchemas<F>,
+    BuiltSchema extends AnyEffectSchema<unknown, unknown> = AnyEffectSchema<
+      InferBaseOutput<F, Schemas>,
+      ExtractR<Schemas>
+    >,
+    Out = SchemaOutput<BuiltSchema>,
+    R = ValidationContext<F, Schemas, BuiltSchema>,
+  >(
+    options: CreateEffectAdapterOptions<F, Schemas, BuiltSchema>,
+  ): EffectAdapter<F, Out, R> {
+    const { schemas, build, rejectFoul } = options
 
-  if (options.valueShape === 'nested' && !build) {
-    throw new Error(
-      '[@umpire/effect] valueShape: "nested" requires a build() callback because the derived per-field schema uses flat field keys.',
-    )
-  }
-
-  const validators = {} as ValidationMap<F>
-
-  for (const [field, schema] of Object.entries(schemas) as Array<
-    [keyof F & string, AnyEffectSchema | undefined]
-  >) {
-    if (!schema) continue
-
-    validators[field] = (value: unknown) => {
-      const result = decodeEffectSchema(schema, value)
-      if (isDecodeSuccess(result)) return { valid: true }
-
-      const errors = effectErrors(result.error)
-      const message = errors[0]?.message
-      return message !== undefined
-        ? { valid: false, error: message }
-        : { valid: false }
+    if (options.valueShape === 'nested' && !build) {
+      throw new Error(
+        '[@umpire/effect] valueShape: "nested" requires a build() callback because the derived per-field schema uses flat field keys.',
+      )
     }
-  }
 
-  const runImpl = (
-    availability: AvailabilityMap<F>,
-    values: InputValues,
-  ): EffectAdapterRunResult<F> => {
-    const baseSchema = deriveSchema(availability, schemas, { rejectFoul })
-    const schema = build ? build(baseSchema) : baseSchema
-    const validationValues =
-      options.valueShape === 'nested'
-        ? nestNamespacedValues(values, options.namespace)
-        : values
-    const result = decodeEffectSchema<Record<string, unknown>>(
-      schema,
-      validationValues,
-      { errors: 'all' },
-    )
-    const rawErrors = isDecodeFailure(result) ? effectErrors(result.error) : []
-    const normalizedErrors =
-      options.valueShape === 'nested'
-        ? flattenFieldErrorPaths(rawErrors, options.namespace)
-        : rawErrors
+    const validators = {} as ValidationMap<F>
 
-    const schemaFields = (
-      Object.keys(availability) as Array<keyof F & string>
-    ).filter((field) => availability[field]!.enabled && field in schemas)
+    for (const [field, schema] of Object.entries(schemas) as Array<
+      [keyof F & string, AnyEffectSchema | undefined]
+    >) {
+      if (!schema) continue
 
-    return {
-      errors: deriveErrors(availability, normalizedErrors),
-      normalizedErrors,
-      result,
-      schemaFields,
+      validators[field] = (value: unknown) => {
+        const result = decodeEffectSchema(schema, value)
+        if (isDecodeSuccess(result)) return { valid: true }
+
+        const errors = effectErrors(result.error)
+        const message = errors[0]?.message
+        return message !== undefined
+          ? { valid: false, error: message }
+          : { valid: false }
+      }
     }
-  }
 
-  const runEffectFn = Effect.fn('@umpire/effect:runEffect')(
-    (availability: AvailabilityMap<F>, values: InputValues) =>
-      Effect.sync(() => runImpl(availability, values)),
-  )
-
-  const runValidateFn = Effect.fn('@umpire/effect:runValidate')(
-    <T = Record<string, unknown>>(
+    const runImpl = (
       availability: AvailabilityMap<F>,
       values: InputValues,
-    ) =>
+    ): EffectAdapterRunResult<F> => {
+      const { schema, validationValues } = prepareRun(availability, values)
+      const result = decodeEffectSchema<Record<string, unknown>>(
+        schema as unknown as AnyEffectSchema<Record<string, unknown>, never>,
+        validationValues,
+        { errors: 'all' },
+      )
+      return finalizeRun(availability, result)
+    }
+
+    const prepareRun = (
+      availability: AvailabilityMap<F>,
+      values: InputValues,
+    ) => {
+      const baseSchema = deriveSchema(availability, schemas, { rejectFoul })
+      const schema = build ? build(baseSchema) : baseSchema
+      const validationValues =
+        options.valueShape === 'nested'
+          ? nestNamespacedValues(values, options.namespace)
+          : values
+      return { schema, validationValues }
+    }
+
+    const finalizeRun = (
+      availability: AvailabilityMap<F>,
+      result: EffectDecodeResult<Record<string, unknown>>,
+    ): EffectAdapterRunResult<F> => {
+      const rawErrors = isDecodeFailure(result)
+        ? effectErrors(result.error)
+        : []
+      const normalizedErrors =
+        options.valueShape === 'nested'
+          ? flattenFieldErrorPaths(rawErrors, options.namespace)
+          : rawErrors
+      const schemaFields = (
+        Object.keys(availability) as Array<keyof F & string>
+      ).filter((field) => availability[field]!.enabled && field in schemas)
+
+      return {
+        errors: deriveErrors(availability, normalizedErrors),
+        normalizedErrors,
+        result,
+        schemaFields,
+      }
+    }
+
+    const runEffectFn: (
+      availability: AvailabilityMap<F>,
+      values: InputValues,
+    ) => Effect.Effect<EffectAdapterRunResult<F>, never, R> = Effect.fn(
+      '@umpire/effect:runEffect',
+    )((availability: AvailabilityMap<F>, values: InputValues) =>
+      Effect.sync(() => runImpl(availability, values)),
+    ) as (
+      availability: AvailabilityMap<F>,
+      values: InputValues,
+    ) => Effect.Effect<EffectAdapterRunResult<F>, never, R>
+
+    const runValidateFn: (
+      availability: AvailabilityMap<F>,
+      values: InputValues,
+    ) => Effect.Effect<Out, UmpireValidationError, R> = Effect.fn(
+      '@umpire/effect:runValidate',
+    )((availability: AvailabilityMap<F>, values: InputValues) =>
       Effect.gen(function* () {
         const result = yield* runEffectFn(availability, values)
         if (isDecodeSuccess(result.result)) {
-          return result.result.value as T
+          return result.result.value as Out
         }
         return yield* Effect.fail(
           new UmpireValidationError({
@@ -145,12 +198,16 @@ export function createEffectAdapter<F extends Record<string, FieldDef>>(
           }),
         )
       }),
-  )
+    ) as (
+      availability: AvailabilityMap<F>,
+      values: InputValues,
+    ) => Effect.Effect<Out, UmpireValidationError, R>
 
-  return {
-    validators,
-    run: runImpl,
-    runEffect: runEffectFn,
-    runValidate: runValidateFn,
+    return {
+      validators,
+      run: runImpl,
+      runEffect: runEffectFn,
+      runValidate: runValidateFn,
+    }
   }
 }

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -54,10 +54,10 @@ export type EffectAdapter<F extends Record<string, FieldDef>> = {
     availability: AvailabilityMap<F>,
     values: InputValues,
   ): Effect.Effect<EffectAdapterRunResult<F>, never, never>
-  runValidate(
+  runValidate<T = Record<string, unknown>>(
     availability: AvailabilityMap<F>,
     values: InputValues,
-  ): Effect.Effect<Record<string, unknown>, UmpireValidationError, never>
+  ): Effect.Effect<T, UmpireValidationError, never>
 }
 
 export function createEffectAdapter<F extends Record<string, FieldDef>>(
@@ -151,6 +151,6 @@ export function createEffectAdapter<F extends Record<string, FieldDef>>(
     validators,
     run: runImpl,
     runEffect: runEffectFn,
-    runValidate: runValidateFn,
+    runValidate: runValidateFn as EffectAdapter<F>['runValidate'],
   }
 }

--- a/packages/effect/src/adapter.ts
+++ b/packages/effect/src/adapter.ts
@@ -17,7 +17,7 @@ import {
 } from './derive-errors.js'
 import {
   decodeEffectSchema,
-  decodeEffectSchemaEffect,
+  decodeEffectSchemaSync,
   isDecodeFailure,
   isDecodeSuccess,
   type EffectDecodeResult,
@@ -123,7 +123,7 @@ export function createEffectAdapter<
       if (!schema) continue
 
       validators[field] = (value: unknown) => {
-        const result = decodeEffectSchema(schema, value)
+        const result = decodeEffectSchemaSync(schema, value)
         if (isDecodeSuccess(result)) return { valid: true }
 
         const errors = effectErrors(result.error)
@@ -139,7 +139,7 @@ export function createEffectAdapter<
       values: InputValues,
     ): EffectAdapterRunResult<F, Out> => {
       const { schema, validationValues } = prepareRun(availability, values)
-      const result = decodeEffectSchema<Out>(
+      const result = decodeEffectSchemaSync<Out>(
         schema as unknown as AnyEffectSchema<Out, never>,
         validationValues,
         { errors: 'all' },
@@ -187,7 +187,7 @@ export function createEffectAdapter<
       (availability, values) =>
         Effect.gen(function* () {
           const { schema, validationValues } = prepareRun(availability, values)
-          const result = yield* decodeEffectSchemaEffect(
+          const result = yield* decodeEffectSchema(
             schema as AnyEffectSchema<Out, R>,
             validationValues,
             { errors: 'all' },

--- a/packages/effect/src/adapter.typecheck.ts
+++ b/packages/effect/src/adapter.typecheck.ts
@@ -1,0 +1,75 @@
+import { Schema } from 'effect'
+import { createEffectAdapter } from './adapter.js'
+import type { AnyEffectSchema } from './derive-schema.js'
+
+type Expect<T extends true> = T
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false
+
+const _inferred = createEffectAdapter()({
+  schemas: {
+    age: Schema.NumberFromString,
+  },
+})
+
+type InferredOutput = Awaited<
+  ReturnType<
+    typeof _inferred.runValidate
+  > extends import('effect').Effect.Effect<infer A, unknown, unknown>
+    ? Promise<A>
+    : never
+>
+
+type _inferredOutputCheck = Expect<
+  InferredOutput extends { age?: number } ? true : false
+>
+
+type ServiceEnv = { readonly service: unique symbol }
+
+const serviceSchema = Schema.NumberFromString as AnyEffectSchema<
+  number,
+  ServiceEnv
+>
+
+const effectOnly = createEffectAdapter()({
+  schemas: {
+    age: serviceSchema,
+  },
+})
+
+effectOnly.run({} as never, {})
+
+type EffectOnlyContext =
+  ReturnType<
+    typeof effectOnly.runValidate
+  > extends import('effect').Effect.Effect<unknown, unknown, infer R>
+    ? R
+    : never
+
+type _serviceContextCheck = Expect<Equal<EffectOnlyContext, ServiceEnv>>
+
+const _builtOverride = createEffectAdapter()({
+  schemas: {
+    age: Schema.NumberFromString,
+  },
+  build: () =>
+    Schema.Struct({
+      user: Schema.Struct({
+        age: Schema.Number,
+      }),
+    }),
+})
+
+type BuiltOutput = Awaited<
+  ReturnType<
+    typeof _builtOverride.runValidate
+  > extends import('effect').Effect.Effect<infer A, unknown, unknown>
+    ? Promise<A>
+    : never
+>
+
+type _buildOutputCheck = Expect<
+  BuiltOutput extends { user: { age: number } } ? true : false
+>

--- a/packages/effect/src/adapter.typecheck.ts
+++ b/packages/effect/src/adapter.typecheck.ts
@@ -39,7 +39,11 @@ const effectOnly = createEffectAdapter()({
   },
 })
 
+// @ts-expect-error serviceful schemas cannot expose sync run()
 effectOnly.run({} as never, {})
+
+// @ts-expect-error serviceful schemas cannot expose sync validators
+void effectOnly.validators
 
 type EffectOnlyContext =
   ReturnType<

--- a/packages/effect/src/adapter.typecheck.ts
+++ b/packages/effect/src/adapter.typecheck.ts
@@ -14,6 +14,14 @@ const _inferred = createEffectAdapter()({
   },
 })
 
+const _uncurried = createEffectAdapter({
+  schemas: {
+    age: Schema.NumberFromString,
+  },
+})
+
+void _uncurried.validators.age
+
 type InferredOutput = Awaited<
   ReturnType<
     typeof _inferred.runValidate

--- a/packages/effect/src/async-layer.ts
+++ b/packages/effect/src/async-layer.ts
@@ -1,0 +1,29 @@
+import { Context, Layer } from 'effect'
+import { umpire as asyncUmpire } from '@umpire/async'
+import type {
+  AnyRule,
+  AnyValidationMap,
+  Umpire as AsyncUmpire,
+} from '@umpire/async'
+import type { FieldInput, NormalizeFields } from '@umpire/core'
+
+type AsyncUmpireDefinition<
+  FInput extends Record<string, FieldInput>,
+  C extends Record<string, unknown>,
+> = {
+  fields: FInput
+  rules: AnyRule<NormalizeFields<FInput>, C>[]
+  validators?: AnyValidationMap<NormalizeFields<FInput>>
+  onAbort?: (reason?: unknown) => void
+}
+
+export function umpireAsyncLayer<
+  FInput extends Record<string, FieldInput>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+  I = AsyncUmpire<NormalizeFields<FInput>, C>,
+>(
+  tag: Context.Key<I, AsyncUmpire<NormalizeFields<FInput>, C>>,
+  definition: AsyncUmpireDefinition<FInput, C>,
+): Layer.Layer<I, never, never> {
+  return Layer.sync(tag, () => asyncUmpire(definition))
+}

--- a/packages/effect/src/availability-stream-async.ts
+++ b/packages/effect/src/availability-stream-async.ts
@@ -1,0 +1,41 @@
+import { Effect, Stream, SubscriptionRef } from 'effect'
+import type { AvailabilityMap, FieldDef, InputValues } from '@umpire/core'
+import type { Umpire as AsyncUmpire } from '@umpire/async'
+import type { FromStoreOptions } from '@umpire/store'
+
+type AsyncAvailabilityStreamState = {
+  readonly prevValues: InputValues | undefined
+}
+
+export function availabilityStreamAsync<
+  S,
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  ump: AsyncUmpire<F, C>,
+  ref: SubscriptionRef.SubscriptionRef<S>,
+  options: FromStoreOptions<S, C>,
+): Stream.Stream<AvailabilityMap<F>, unknown, never> {
+  return SubscriptionRef.changes(ref).pipe(
+    Stream.mapAccumEffect(
+      () => undefined as AsyncAvailabilityStreamState | undefined,
+      (prev, state) =>
+        Effect.gen(function* () {
+          const values = options.select(state)
+          const conditions = options.conditions?.(state)
+
+          const availability = yield* Effect.tryPromise({
+            try: (signal) =>
+              prev
+                ? ump.check(values, conditions, prev.prevValues, signal)
+                : ump.check(values, conditions, undefined, signal),
+            catch: (error) => error,
+          })
+
+          // Effect v4 Stream.mapAccumEffect emits from an iterable, so wrap
+          // the single availability snapshot in a one-item array.
+          return [{ prevValues: values }, [availability]] as const
+        }),
+    ),
+  )
+}

--- a/packages/effect/src/availability-stream.ts
+++ b/packages/effect/src/availability-stream.ts
@@ -1,0 +1,38 @@
+import { Stream, SubscriptionRef } from 'effect'
+import type {
+  AvailabilityMap,
+  FieldDef,
+  InputValues,
+  Umpire,
+} from '@umpire/core'
+import type { FromStoreOptions } from '@umpire/store'
+
+type AvailabilityStreamState<S> = {
+  readonly state: S
+  readonly prevValues: InputValues | undefined
+}
+
+export function availabilityStream<
+  S,
+  F extends Record<string, FieldDef>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  ump: Umpire<F, C>,
+  ref: SubscriptionRef.SubscriptionRef<S>,
+  options: FromStoreOptions<S, C>,
+): Stream.Stream<AvailabilityMap<F>, never, never> {
+  return SubscriptionRef.changes(ref).pipe(
+    Stream.mapAccum(
+      () => undefined as AvailabilityStreamState<S> | undefined,
+      (prev, state) => {
+        const values = options.select(state)
+        const conditions = options.conditions?.(state)
+        const availability = prev
+          ? ump.check(values, conditions, prev.prevValues)
+          : ump.check(values, conditions)
+
+        return [{ state, prevValues: values }, [availability]]
+      },
+    ),
+  )
+}

--- a/packages/effect/src/availability-stream.ts
+++ b/packages/effect/src/availability-stream.ts
@@ -20,6 +20,8 @@ export function availabilityStream<
   ref: SubscriptionRef.SubscriptionRef<S>,
   options: FromStoreOptions<S, C>,
 ): Stream.Stream<AvailabilityMap<F>, never, never> {
+  // SubscriptionRef.changes emits the current state first. Treat that initial
+  // snapshot as a fresh check, then pass previous values on later emissions.
   return SubscriptionRef.changes(ref).pipe(
     Stream.mapAccum(
       () => undefined as AvailabilityStreamState | undefined,

--- a/packages/effect/src/availability-stream.ts
+++ b/packages/effect/src/availability-stream.ts
@@ -7,8 +7,7 @@ import type {
 } from '@umpire/core'
 import type { FromStoreOptions } from '@umpire/store'
 
-type AvailabilityStreamState<S> = {
-  readonly state: S
+type AvailabilityStreamState = {
   readonly prevValues: InputValues | undefined
 }
 
@@ -23,7 +22,7 @@ export function availabilityStream<
 ): Stream.Stream<AvailabilityMap<F>, never, never> {
   return SubscriptionRef.changes(ref).pipe(
     Stream.mapAccum(
-      () => undefined as AvailabilityStreamState<S> | undefined,
+      () => undefined as AvailabilityStreamState | undefined,
       (prev, state) => {
         const values = options.select(state)
         const conditions = options.conditions?.(state)
@@ -31,7 +30,9 @@ export function availabilityStream<
           ? ump.check(values, conditions, prev.prevValues)
           : ump.check(values, conditions)
 
-        return [{ state, prevValues: values }, [availability]]
+        // Effect v4 Stream.mapAccum emits from an iterable, so wrap the single
+        // availability snapshot in a one-item array.
+        return [{ prevValues: values }, [availability]]
       },
     ),
   )

--- a/packages/effect/src/derive-schema.ts
+++ b/packages/effect/src/derive-schema.ts
@@ -1,10 +1,27 @@
 import { Schema } from 'effect'
 import type { AvailabilityMap, FieldDef } from '@umpire/core'
 
-export type AnyEffectSchema = Schema.Decoder<unknown, never>
+export type AnyEffectSchema<A = unknown, R = never> = Schema.Decoder<A, R>
+
+type SchemaOutput<S> = S extends AnyEffectSchema<infer A, unknown> ? A : never
+
+export type ExtractR<Schemas extends Record<string, unknown>> = {
+  [K in keyof Schemas]: Schemas[K] extends AnyEffectSchema<unknown, infer R>
+    ? R
+    : never
+}[keyof Schemas]
+
+export type InferBaseOutput<
+  F extends Record<string, FieldDef>,
+  Schemas extends FieldSchemas<F>,
+> = Partial<{
+  [K in keyof F & string as Schemas[K] extends AnyEffectSchema
+    ? K
+    : never]: SchemaOutput<Schemas[K]>
+}>
 
 export type FieldSchemas<F extends Record<string, FieldDef>> = Partial<
-  Record<keyof F & string, AnyEffectSchema>
+  Record<keyof F & string, AnyEffectSchema<unknown, unknown>>
 >
 
 export type DeriveSchemaOptions = {
@@ -24,11 +41,14 @@ export type DeriveSchemaOptions = {
 // both required fields and Schema.optional(...) entries in a struct shape.
 type ShapeEntry = Schema.Top
 
-export function deriveSchema<F extends Record<string, FieldDef>>(
+export function deriveSchema<
+  F extends Record<string, FieldDef>,
+  Schemas extends FieldSchemas<F>,
+>(
   availability: AvailabilityMap<F>,
-  schemas: FieldSchemas<F>,
+  schemas: Schemas,
   options?: DeriveSchemaOptions,
-): AnyEffectSchema {
+): AnyEffectSchema<InferBaseOutput<F, Schemas>, ExtractR<Schemas>> {
   const rejectFoul = options?.rejectFoul ?? false
   const shape: Record<string, ShapeEntry> = {}
 
@@ -53,5 +73,8 @@ export function deriveSchema<F extends Record<string, FieldDef>>(
 
   return Schema.Struct(
     shape as Schema.Struct.Fields,
-  ) as unknown as AnyEffectSchema
+  ) as unknown as AnyEffectSchema<
+    InferBaseOutput<F, Schemas>,
+    ExtractR<Schemas>
+  >
 }

--- a/packages/effect/src/effect-schema.ts
+++ b/packages/effect/src/effect-schema.ts
@@ -20,17 +20,7 @@ export type EffectDecodeResult<A> =
       readonly error: unknown
     }
 
-export function decodeEffectSchema<A = unknown>(
-  schema: Schema.Decoder<unknown, never>,
-  input: unknown,
-  options?: EffectParseOptions,
-): EffectDecodeResult<A> {
-  return normalizeDecodeResult<A>(
-    Schema.decodeUnknownResult(schema)(input, options),
-  )
-}
-
-export function decodeEffectSchemaEffect<A = unknown, R = never>(
+export function decodeEffectSchema<A = unknown, R = never>(
   schema: Schema.Decoder<A, R>,
   input: unknown,
   options?: EffectParseOptions,
@@ -46,6 +36,16 @@ export function decodeEffectSchemaEffect<A = unknown, R = never>(
         return { _tag: 'Left', error: issue }
       },
     }),
+  )
+}
+
+export function decodeEffectSchemaSync<A = unknown>(
+  schema: Schema.Decoder<unknown, never>,
+  input: unknown,
+  options?: EffectParseOptions,
+): EffectDecodeResult<A> {
+  return normalizeDecodeResult<A>(
+    Schema.decodeUnknownResult(schema)(input, options),
   )
 }
 

--- a/packages/effect/src/effect-schema.ts
+++ b/packages/effect/src/effect-schema.ts
@@ -62,7 +62,9 @@ export function formatEffectErrors(
   parseError: unknown,
 ): NormalizedEffectError[] {
   const issue =
-    isRecord(parseError) && 'issue' in parseError && !('_tag' in parseError)
+    isRecord(parseError) &&
+    'issue' in parseError &&
+    (!('_tag' in parseError) || parseError._tag === 'SchemaError')
       ? parseError.issue
       : parseError
 

--- a/packages/effect/src/effect-schema.ts
+++ b/packages/effect/src/effect-schema.ts
@@ -1,4 +1,4 @@
-import { Result, Schema } from 'effect'
+import { Effect, Result, Schema } from 'effect'
 import type { SchemaAST, SchemaIssue } from 'effect'
 import type { FieldPathSegment } from '@umpire/write'
 
@@ -27,6 +27,25 @@ export function decodeEffectSchema<A = unknown>(
 ): EffectDecodeResult<A> {
   return normalizeDecodeResult<A>(
     Schema.decodeUnknownResult(schema)(input, options),
+  )
+}
+
+export function decodeEffectSchemaEffect<A = unknown, R = never>(
+  schema: Schema.Decoder<A, R>,
+  input: unknown,
+  options?: EffectParseOptions,
+): Effect.Effect<EffectDecodeResult<A>, never, R> {
+  return Schema.decodeUnknownEffect(schema)(input, options).pipe(
+    Effect.match({
+      onSuccess: (value): EffectDecodeResult<A> => ({ _tag: 'Right', value }),
+      onFailure: (error): EffectDecodeResult<A> => {
+        const issue =
+          isRecord(error) && error._tag === 'SchemaError' && 'issue' in error
+            ? (error as { issue: unknown }).issue
+            : error
+        return { _tag: 'Left', error: issue }
+      },
+    }),
   )
 }
 

--- a/packages/effect/src/errors.ts
+++ b/packages/effect/src/errors.ts
@@ -5,5 +5,20 @@ export class UmpireValidationError extends Data.TaggedError(
   'UmpireValidationError',
 )<{
   readonly errors: Record<string, string | undefined>
+  readonly message: string
   readonly normalizedErrors: NormalizedFieldError[]
-}> {}
+}> {
+  constructor(args: {
+    readonly errors: Record<string, string | undefined>
+    readonly normalizedErrors: NormalizedFieldError[]
+  }) {
+    const fields = Object.keys(args.errors)
+    super({
+      ...args,
+      message:
+        fields.length > 0
+          ? `Validation failed: ${fields.join(', ')}`
+          : 'Validation failed',
+    })
+  }
+}

--- a/packages/effect/src/errors.ts
+++ b/packages/effect/src/errors.ts
@@ -1,0 +1,9 @@
+import { Data } from 'effect'
+import type { NormalizedFieldError } from './derive-errors.js'
+
+export class UmpireValidationError extends Data.TaggedError(
+  'UmpireValidationError',
+)<{
+  readonly errors: Record<string, string | undefined>
+  readonly normalizedErrors: NormalizedFieldError[]
+}> {}

--- a/packages/effect/src/errors.ts
+++ b/packages/effect/src/errors.ts
@@ -12,7 +12,16 @@ export class UmpireValidationError extends Data.TaggedError(
     readonly errors: Record<string, string | undefined>
     readonly normalizedErrors: NormalizedFieldError[]
   }) {
-    const fields = Object.keys(args.errors)
+    const fields = Object.entries(args.errors).reduce<string[]>(
+      (acc, [field, message]) => {
+        if (message !== undefined) {
+          acc.push(field)
+        }
+
+        return acc
+      },
+      [],
+    )
     super({
       ...args,
       message:

--- a/packages/effect/src/from-subscription-ref.ts
+++ b/packages/effect/src/from-subscription-ref.ts
@@ -16,6 +16,7 @@ export function fromSubscriptionRef<
 
   const subscribe = (listener: (next: S, prev: S) => void): (() => void) => {
     const tracker = trackPreviousState(getState())
+    let active = true
 
     // Effect's changes stream emits the current value immediately, then all
     // subsequent changes. Drop the first emission so the listener only fires on
@@ -24,12 +25,15 @@ export function fromSubscriptionRef<
       Stream.runForEach(Stream.drop(SubscriptionRef.changes(ref), 1), (next) =>
         Effect.sync(() => {
           const prev = tracker.next(next)
-          listener(next, prev)
+          if (active) {
+            listener(next, prev)
+          }
         }),
       ),
     )
 
     return () => {
+      active = false
       Effect.runFork(Fiber.interrupt(fiber))
     }
   }

--- a/packages/effect/src/from-subscription-ref.ts
+++ b/packages/effect/src/from-subscription-ref.ts
@@ -16,7 +16,6 @@ export function fromSubscriptionRef<
 
   const subscribe = (listener: (next: S, prev: S) => void): (() => void) => {
     const tracker = trackPreviousState(getState())
-    let active = true
 
     // Effect's changes stream emits the current value immediately, then all
     // subsequent changes. Drop the first emission so the listener only fires on
@@ -25,17 +24,12 @@ export function fromSubscriptionRef<
       Stream.runForEach(Stream.drop(SubscriptionRef.changes(ref), 1), (next) =>
         Effect.sync(() => {
           const prev = tracker.next(next)
-          if (active) {
-            listener(next, prev)
-          }
+          listener(next, prev)
         }),
       ),
     )
 
-    return () => {
-      active = false
-      Effect.runFork(Fiber.interrupt(fiber))
-    }
+    return () => Effect.runFork(Fiber.interrupt(fiber))
   }
 
   return fromStore(ump, { getState, subscribe }, options)

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -8,7 +8,7 @@ export { deriveErrors, effectErrors } from './derive-errors.js'
 export type { DerivedErrorMap, NormalizedFieldError } from './derive-errors.js'
 export {
   decodeEffectSchema,
-  decodeEffectSchemaEffect,
+  decodeEffectSchemaSync,
   isDecodeFailure,
   isDecodeSuccess,
 } from './effect-schema.js'

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -19,6 +19,8 @@ export type {
   EffectAdapter,
   EffectAdapterRunResult,
 } from './adapter.js'
+export { toAsyncWriteValidationAdapter } from './write-adapter.js'
+export type { EffectAdapterRunner } from './write-adapter.js'
 export { UmpireValidationError } from './errors.js'
 export { fromSubscriptionRef } from './from-subscription-ref.js'
 export { availabilityStream } from './availability-stream.js'

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -18,4 +18,5 @@ export type {
   EffectAdapter,
   EffectAdapterRunResult,
 } from './adapter.js'
+export { UmpireValidationError } from './errors.js'
 export { fromSubscriptionRef } from './from-subscription-ref.js'

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -8,6 +8,7 @@ export { deriveErrors, effectErrors } from './derive-errors.js'
 export type { DerivedErrorMap, NormalizedFieldError } from './derive-errors.js'
 export {
   decodeEffectSchema,
+  decodeEffectSchemaEffect,
   isDecodeFailure,
   isDecodeSuccess,
 } from './effect-schema.js'
@@ -21,4 +22,6 @@ export type {
 export { UmpireValidationError } from './errors.js'
 export { fromSubscriptionRef } from './from-subscription-ref.js'
 export { availabilityStream } from './availability-stream.js'
+export { availabilityStreamAsync } from './availability-stream-async.js'
 export { umpireLayer } from './layer.js'
+export { umpireAsyncLayer } from './async-layer.js'

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -20,3 +20,5 @@ export type {
 } from './adapter.js'
 export { UmpireValidationError } from './errors.js'
 export { fromSubscriptionRef } from './from-subscription-ref.js'
+export { availabilityStream } from './availability-stream.js'
+export { umpireLayer } from './layer.js'

--- a/packages/effect/src/layer.ts
+++ b/packages/effect/src/layer.ts
@@ -1,0 +1,28 @@
+import { Context, Layer } from 'effect'
+import { umpire } from '@umpire/core'
+import type {
+  FieldInput,
+  NormalizeFields,
+  Rule,
+  Umpire,
+  ValidationMap,
+} from '@umpire/core'
+
+type UmpireDefinition<
+  FInput extends Record<string, FieldInput>,
+  C extends Record<string, unknown>,
+> = {
+  fields: FInput
+  rules: Rule<NormalizeFields<FInput>, C>[]
+  validators?: ValidationMap<NormalizeFields<FInput>>
+}
+
+export function umpireLayer<
+  FInput extends Record<string, FieldInput>,
+  C extends Record<string, unknown> = Record<string, unknown>,
+>(
+  tag: ReturnType<typeof Context.Service<Umpire<NormalizeFields<FInput>, C>>>,
+  definition: UmpireDefinition<FInput, C>,
+): Layer.Layer<Umpire<NormalizeFields<FInput>, C>, never, never> {
+  return Layer.sync(tag, () => umpire(definition))
+}

--- a/packages/effect/src/layer.ts
+++ b/packages/effect/src/layer.ts
@@ -1,4 +1,4 @@
-import { Context, Layer } from 'effect'
+import { Layer } from 'effect'
 import { umpire } from '@umpire/core'
 import type {
   FieldInput,
@@ -21,7 +21,10 @@ export function umpireLayer<
   FInput extends Record<string, FieldInput>,
   C extends Record<string, unknown> = Record<string, unknown>,
 >(
-  tag: ReturnType<typeof Context.Service<Umpire<NormalizeFields<FInput>, C>>>,
+  // Effect v4 beta 59: Context.Service returns ServiceClass but Layer.sync
+  // expects Key — they are compatible at runtime but the types don't align.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tag: any,
   definition: UmpireDefinition<FInput, C>,
 ): Layer.Layer<Umpire<NormalizeFields<FInput>, C>, never, never> {
   return Layer.sync(tag, () => umpire(definition))

--- a/packages/effect/src/layer.ts
+++ b/packages/effect/src/layer.ts
@@ -1,4 +1,4 @@
-import { Layer } from 'effect'
+import { Context, Layer } from 'effect'
 import { umpire } from '@umpire/core'
 import type {
   FieldInput,
@@ -20,12 +20,10 @@ type UmpireDefinition<
 export function umpireLayer<
   FInput extends Record<string, FieldInput>,
   C extends Record<string, unknown> = Record<string, unknown>,
+  I = Umpire<NormalizeFields<FInput>, C>,
 >(
-  // Effect v4 beta 59: Context.Service returns ServiceClass but Layer.sync
-  // expects Key — they are compatible at runtime but the types don't align.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tag: any,
+  tag: Context.Key<I, Umpire<NormalizeFields<FInput>, C>>,
   definition: UmpireDefinition<FInput, C>,
-): Layer.Layer<Umpire<NormalizeFields<FInput>, C>, never, never> {
+): Layer.Layer<I, never, never> {
   return Layer.sync(tag, () => umpire(definition))
 }

--- a/packages/effect/src/write-adapter.ts
+++ b/packages/effect/src/write-adapter.ts
@@ -1,0 +1,25 @@
+import type { FieldDef } from '@umpire/core'
+import type { AsyncWriteValidationAdapter } from '@umpire/write'
+import type { Effect } from 'effect'
+import type { EffectAdapter, EffectAdapterRunResult } from './adapter.js'
+
+export type EffectAdapterRunner<R> = <A>(
+  effect: Effect.Effect<A, never, R>,
+) => Promise<A>
+
+export function toAsyncWriteValidationAdapter<
+  F extends Record<string, FieldDef>,
+  Out,
+  R,
+>(
+  adapter: Pick<EffectAdapter<F, Out, R>, 'runEffect'>,
+  run: EffectAdapterRunner<R>,
+): AsyncWriteValidationAdapter<F> {
+  return {
+    run(availability, values) {
+      return run(adapter.runEffect(availability, values)) as Promise<
+        EffectAdapterRunResult<F, Out>
+      >
+    },
+  }
+}

--- a/packages/effect/tsconfig.json
+++ b/packages/effect/tsconfig.json
@@ -7,6 +7,8 @@
     "paths": {
       "@umpire/core": ["../core/src/index.ts"],
       "@umpire/core/*": ["../core/src/*"],
+      "@umpire/async": ["../async/src/index.ts"],
+      "@umpire/async/*": ["../async/src/*"],
       "@umpire/store": ["../store/src/index.ts"],
       "@umpire/write": ["../write/src/index.ts"],
       "@umpire/write/*": ["../write/src/*"]
@@ -15,6 +17,7 @@
   "include": ["src"],
   "references": [
     { "path": "../core" },
+    { "path": "../async" },
     { "path": "../store" },
     { "path": "../write" }
   ]

--- a/packages/integration-tests/__tests__/drizzle-async-write.integration.test.ts
+++ b/packages/integration-tests/__tests__/drizzle-async-write.integration.test.ts
@@ -5,7 +5,12 @@ import {
   requires as requiresAsync,
 } from '@umpire/async'
 import { createAsyncDrizzlePolicy, createDrizzlePolicy } from '@umpire/drizzle'
+import {
+  createEffectAdapter,
+  toAsyncWriteValidationAdapter,
+} from '@umpire/effect'
 import type { AsyncWriteValidationAdapter } from '@umpire/write'
+import { Context, Effect, Layer, Schema, SchemaGetter } from 'effect'
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 const accounts = sqliteTable('async_write_accounts', {
@@ -117,5 +122,72 @@ describe('drizzle async write integration', () => {
     expect(result.issues.schema).toEqual([
       { field: 'companyName', message: 'Company name is not allowed' },
     ])
+  })
+
+  it('async policy composes serviceful Effect validation through the write adapter bridge', async () => {
+    const DiscountService = Context.Service<{
+      isAllowed(code: string): boolean
+    }>('DiscountService')
+    const discountCodeSchema = Schema.String.pipe(
+      Schema.decode({
+        decode: SchemaGetter.checkEffect<
+          string,
+          { isAllowed(code: string): boolean }
+        >((input) =>
+          Effect.gen(function* () {
+            const service = yield* Effect.service(DiscountService)
+            return service.isAllowed(input)
+              ? undefined
+              : 'Discount code is not allowed'
+          }),
+        ),
+        encode: SchemaGetter.passthrough(),
+      }),
+    )
+    const validation = createEffectAdapter()({
+      schemas: { discountCode: discountCodeSchema },
+    })
+    const writeValidation = toAsyncWriteValidationAdapter(
+      validation,
+      (effect) =>
+        Effect.runPromise(
+          Effect.provide(
+            effect,
+            Layer.succeed(DiscountService, {
+              isAllowed: (code) => code === 'SAVE10',
+            }),
+          ),
+        ),
+    )
+
+    const badResult = await buildAsyncPolicy().checkCreate(
+      {
+        accountType: 'personal',
+        discountCode: 'BLOCKED',
+      },
+      {
+        context: { allowDiscounts: true },
+        validation: writeValidation,
+      },
+    )
+
+    expect(badResult.ok).toBe(false)
+    expect(badResult.issues.schema).toEqual([
+      { field: 'discountCode', message: 'Discount code is not allowed' },
+    ])
+
+    const goodResult = await buildAsyncPolicy().checkCreate(
+      {
+        accountType: 'personal',
+        discountCode: 'SAVE10',
+      },
+      {
+        context: { allowDiscounts: true },
+        validation: writeValidation,
+      },
+    )
+
+    expect(goodResult.ok).toBe(true)
+    expect(goodResult.data.discountCode).toBe('SAVE10')
   })
 })

--- a/packages/integration-tests/__tests__/drizzle-sqlite-write.integration.test.ts
+++ b/packages/integration-tests/__tests__/drizzle-sqlite-write.integration.test.ts
@@ -681,7 +681,7 @@ describe('drizzle sqlite freight quote single-table write', () => {
 
       const policy = createDrizzlePolicy(freightQuotes, {
         table: { exclude: ['createdAt'] },
-        validation: createEffectAdapter({
+        validation: createEffectAdapter()({
           schemas: effectSchemas,
           rejectFoul: true,
         }),

--- a/packages/store/src/fromStore.ts
+++ b/packages/store/src/fromStore.ts
@@ -92,8 +92,8 @@ export function fromStore<
 
     destroy(): void {
       active = false
-      unsubscribe()
       listeners.clear()
+      unsubscribe()
     },
   }
 }

--- a/packages/store/src/fromStore.ts
+++ b/packages/store/src/fromStore.ts
@@ -45,10 +45,13 @@ export function fromStore<
 
   let currentAvailability = ump.check(initialValues, initialConditions)
   let currentFouls: Foul<F>[] = []
+  let active = true
 
   const listeners = new Set<(availability: AvailabilityMap<F>) => void>()
 
   const unsubscribe = store.subscribe((state, prevState) => {
+    if (!active) return
+
     const nextValues = select(state)
     const nextConditions = readConditions(state)
     const prevValues = select(prevState)
@@ -88,6 +91,7 @@ export function fromStore<
     },
 
     destroy(): void {
+      active = false
       unsubscribe()
       listeners.clear()
     },

--- a/packages/write/README.md
+++ b/packages/write/README.md
@@ -124,9 +124,9 @@ where `createEffectAdapter()` exposes sync `run` / `validators`.
 
 Serviceful Effect schemas cannot satisfy `WriteValidationAdapter` because they
 do not expose sync `run`. Use the async/effectful write path for those schemas.
-Until an explicit Effect-to-Promise write adapter bridge exists, compose
-`runValidate(...)`, `runEffect(...)`, or `decodeEffectSchema(...)` in your own
-Effect workflow instead of treating the bridge as automatic.
+`@umpire/effect` provides `toAsyncWriteValidationAdapter(...)` to bridge an
+Effect adapter into `AsyncWriteValidationAdapter` while letting your app decide
+how to provide Effect services.
 
 `runWriteValidationAdapter` calls the adapter (if provided) and returns
 normalized schema issues. `composeWriteResult` then merges write-policy issues,

--- a/packages/write/README.md
+++ b/packages/write/README.md
@@ -118,8 +118,15 @@ import type { WriteValidationAdapter } from '@umpire/write'
 
 `WriteValidationAdapter<F>` is a structural protocol — any object with a
 `run(availability, values)` method that returns normalized field-level errors
-satisfies it. The adapters exported by `@umpire/zod` and `@umpire/effect`
-satisfy this protocol out of the box.
+satisfies it. The adapter exported by `@umpire/zod` satisfies this protocol out
+of the box. `@umpire/effect` satisfies it only for context-free Effect schemas
+where `createEffectAdapter()` exposes sync `run` / `validators`.
+
+Serviceful Effect schemas cannot satisfy `WriteValidationAdapter` because they
+do not expose sync `run`. Use the async/effectful write path for those schemas.
+Until an explicit Effect-to-Promise write adapter bridge exists, compose
+`runValidate(...)`, `runEffect(...)`, or `decodeEffectSchema(...)` in your own
+Effect workflow instead of treating the bridge as automatic.
 
 `runWriteValidationAdapter` calls the adapter (if provided) and returns
 normalized schema issues. `composeWriteResult` then merges write-policy issues,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,7 +1920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@umpire/async@workspace:^, @umpire/async@workspace:packages/async":
+"@umpire/async@workspace:*, @umpire/async@workspace:^, @umpire/async@workspace:packages/async":
   version: 0.0.0-use.local
   resolution: "@umpire/async@workspace:packages/async"
   dependencies:
@@ -1986,6 +1986,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@umpire/effect@workspace:packages/effect"
   dependencies:
+    "@umpire/async": "workspace:*"
     "@umpire/core": "workspace:*"
     "@umpire/store": "workspace:*"
     "@umpire/write": "workspace:*"


### PR DESCRIPTION
## Problem

`@umpire/effect` currently uses Effect as a schema library and as a reactive primitive (`SubscriptionRef`), but drops out of the Effect type system at the boundary. Every operation resolves with `Effect.runSync` internally and returns plain objects. This means:

- Umpire validation cannot be composed into `Effect.gen` generator flows via `yield*`
- Validation failures live in plain data, not in the Effect error channel: no `catchAll`, `mapError`, or typed error handling
- There is no `Context.Tag` / `Layer` for umpire instances, so umpire cannot be injected as an Effect service
- `fromSubscriptionRef` exposes an imperative `destroy()` pattern instead of a composable `Stream`
- Key operations produce no named Effect frames, so they are harder to inspect in Effect telemetry and stack traces

The goal is to add a fully Effect-typed surface on top of the existing synchronous one, without breaking existing callers.

## Current Branch State

I think this works, but remains sync-only. Exploring an `async` umpire package that could unlock more.

