### PR TITLE
🔌 Add @umpire/jsx to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
       solid_changed: ${{ steps.versions.outputs.solid_changed }}
       tanstack_form_changed: ${{ steps.versions.outputs.tanstack_form_changed }}
       async_changed: ${{ steps.versions.outputs.async_changed }}
+      jsx_changed: ${{ steps.versions.outputs.jsx_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,7 +63,7 @@ jobs:
           const fs = require('node:fs');
           const path = require('node:path');
 
-          const packages = ['async', 'core', 'dsl', 'effect', 'json', 'reads', 'write', 'drizzle', 'devtools', 'store', 'signals', 'react', 'redux', 'pinia', 'tanstack-form', 'tanstack-store', 'vuex', 'zustand', 'zod', 'testing', 'eslint-plugin', 'solid'];
+          const packages = ['async', 'core', 'dsl', 'effect', 'json', 'reads', 'write', 'drizzle', 'devtools', 'store', 'signals', 'react', 'redux', 'pinia', 'tanstack-form', 'tanstack-store', 'vuex', 'zustand', 'zod', 'testing', 'eslint-plugin', 'solid', 'jsx'];
 
           // Manual dispatch: mark everything changed so all packages are published.
           if (process.env.MANUAL_DISPATCH === 'true') {
@@ -476,6 +477,21 @@ jobs:
       - name: Publish @umpire/async
         if: needs.detect-version-changes.outputs.async_changed == 'true'
         working-directory: packages/async
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="latest"
+          if echo "$VERSION" | grep -q "-"; then TAG="alpha"; fi
+          PKG=$(node -p "require('./package.json').name")
+          if npm show "$PKG@$VERSION" version > /dev/null 2>&1; then
+            echo "$PKG@$VERSION already published, skipping"
+          else
+            yarn pack -o package.tgz
+            npm publish package.tgz --provenance --access public --tag "$TAG"
+          fi
+
+      - name: Publish @umpire/jsx
+        if: needs.detect-version-changes.outputs.jsx_changed == 'true'
+        working-directory: packages/jsx
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG="latest"


### PR DESCRIPTION
## Summary
- Adds `@umpire/jsx` to the version-detection and publish steps in `publish.yml`
- Appends `jsx` to `ALL_PACKAGES` in `scripts/set-latest.sh`
- Future version bumps (via changesets) will trigger automatic CI publish

Requires #130 to merge first lol did this out of order

## Notes
- First publish must be done manually (requires local npm auth — no `--provenance` flag, OIDC only works in CI)
- This PR wires all subsequent publishes through the existing CI pipeline