### PR TITLE
🏠 Migrate repo references to umpire-tools org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Umpire is a declarative field-availability engine. Define fields, declare rules 
 
 Forms are the most common use case, but Umpire works anywhere state fits a plain object with interdependent options — game boards, config panels, pricing calculators, permission matrices. If it has fields and rules, Umpire can call the game.
 
-[Docs](https://sdougbrown.github.io/umpire/) • [GitHub](https://github.com/sdougbrown/umpire)
+[Docs](https://umpire.tools/) • [GitHub](https://github.com/umpire-tools/umpire)
 
 [![Coverage Status](https://coveralls.io/repos/github/sdougbrown/umpire/badge.svg?branch=main)](https://coveralls.io/github/sdougbrown/umpire?branch=main)
 
@@ -121,7 +121,7 @@ Local repo work expects:
 
 ## Docs
 
-Full docs, concepts, and examples live at https://sdougbrown.github.io/umpire/
+Full docs, concepts, and examples live at https://umpire.tools/
 
 ## Droid-Friendly
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -56,7 +56,7 @@ export default defineConfig({
         {
           icon: 'github',
           label: 'GitHub',
-          href: 'https://github.com/sdougbrown/umpire',
+          href: 'https://github.com/umpire-tools/umpire',
         },
       ],
       sidebar: [

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/async"
   },
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/core"
   },
   "publishConfig": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/devtools"
   },
   "publishConfig": {

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -2,7 +2,7 @@
 
 When your server-side state is modeled in Drizzle, `@umpire/drizzle` gives you the fastest way to start an Umpire policy from real schema metadata. It derives a `fields` object from your table columns so you can focus on the cross-field business rules that Drizzle doesn't know about — "companyName is required for business accounts" — and run consistent policy checks before persistence via `checkCreate` and `checkPatch`.
 
-[Docs](https://sdougbrown.github.io/umpire/adapters/database/drizzle/) · [Quick Start](https://sdougbrown.github.io/umpire/learn/)
+[Docs](https://umpire.tools/adapters/database/drizzle/) · [Quick Start](https://umpire.tools/learn/)
 
 ## Install
 
@@ -163,6 +163,6 @@ result composition lives in `@umpire/write`.
 
 ## Docs
 
-- [Drizzle adapter](https://sdougbrown.github.io/umpire/adapters/database/drizzle/) — column mapping table, write checks, and boundary guide
-- [@umpire/write](https://sdougbrown.github.io/umpire/extensions/write/) — full result shape for `checkCreate`/`checkPatch`
-- [Quick Start](https://sdougbrown.github.io/umpire/learn/) — learn each rule primitive
+- [Drizzle adapter](https://umpire.tools/adapters/database/drizzle/) — column mapping table, write checks, and boundary guide
+- [@umpire/write](https://umpire.tools/extensions/write/) — full result shape for `checkCreate`/`checkPatch`
+- [Quick Start](https://umpire.tools/learn/) — learn each rule primitive

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -38,7 +38,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/drizzle"
   },
   "publishConfig": {

--- a/packages/dsl/package.json
+++ b/packages/dsl/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/dsl"
   },
   "publishConfig": {

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -34,7 +34,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/effect"
   },
   "publishConfig": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/eslint-plugin"
   },
   "publishConfig": {

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/json"
   },
   "publishConfig": {

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -305,7 +305,7 @@ Either way, no React import needed — `@umpire/jsx` ships its own JSX runtime.
 
 ## See Also
 
-- [`@umpire/core`](https://github.com/sdougbrown/umpire/tree/main/packages/core) — the plain-function API that `@umpire/jsx` compiles down to. Start here if JSX isn't your thing.
-- [`@umpire/dsl`](https://github.com/sdougbrown/umpire/tree/main/packages/dsl) — expression helpers like `expr.and()`, `expr.eq()`, etc., used with the `when` prop on `<Requires>`.
+- [`@umpire/core`](https://github.com/umpire-tools/umpire/tree/main/packages/core) — the plain-function API that `@umpire/jsx` compiles down to. Start here if JSX isn't your thing.
+- [`@umpire/dsl`](https://github.com/umpire-tools/umpire/tree/main/packages/dsl) — expression helpers like `expr.and()`, `expr.eq()`, etc., used with the `when` prop on `<Requires>`.
 
 For Sully ❤️

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -38,7 +38,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/jsx"
   },
   "publishConfig": {

--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/pinia"
   },
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/react"
   },
   "publishConfig": {

--- a/packages/reads/package.json
+++ b/packages/reads/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/reads"
   },
   "publishConfig": {

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/redux"
   },
   "publishConfig": {

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -75,7 +75,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/signals"
   },
   "publishConfig": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/solid"
   },
   "publishConfig": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/store"
   },
   "publishConfig": {

--- a/packages/tanstack-form/package.json
+++ b/packages/tanstack-form/package.json
@@ -77,7 +77,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/tanstack-form"
   },
   "publishConfig": {

--- a/packages/tanstack-store/package.json
+++ b/packages/tanstack-store/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/tanstack-store"
   },
   "publishConfig": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/testing"
   },
   "publishConfig": {

--- a/packages/vuex/package.json
+++ b/packages/vuex/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/vuex"
   },
   "publishConfig": {

--- a/packages/write/package.json
+++ b/packages/write/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/write"
   },
   "publishConfig": {

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -46,7 +46,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/zod"
   },
   "publishConfig": {

--- a/packages/zustand/package.json
+++ b/packages/zustand/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sdougbrown/umpire.git",
+    "url": "git+https://github.com/umpire-tools/umpire.git",
     "directory": "packages/zustand"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Updates `repository.url` in all 23 `packages/*/package.json` files to `github.com/umpire-tools/umpire`
- Updates GitHub links in `README.md`, `docs/astro.config.mjs`, `packages/drizzle/README.md`, and `packages/jsx/README.md`
- Replaces `sdougbrown.github.io/umpire` links with `umpire.tools` (the canonical docs URL)

## Not included

- Coveralls badge in `README.md:11` — needs the org repo added to Coveralls first
- GitHub Actions secrets/environments — manual step in repo settings after transfer
- GitHub Pages environment — manual step after transfer

## Test plan

- [ ] All package `repository` fields resolve to `github.com/umpire-tools/umpire`
- [ ] README links point to correct org and docs URL
- [ ] No remaining `sdougbrown` references (Coveralls badge excepted)