### PR TITLE
✍️ simplify initial documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,63 +13,24 @@ Forms are the most common use case, but Umpire works anywhere state fits a plain
 ## Quick Example
 
 ```ts
-import { enabledWhen, requires, umpire } from '@umpire/core'
+import { requires, umpire } from '@umpire/core'
 
-const signupUmp = umpire({
+const ump = umpire({
   fields: {
-    email: { required: true, isEmpty: (v) => !v },
-    password: { required: true, isEmpty: (v) => !v },
-    confirmPassword: { required: true, isEmpty: (v) => !v },
-    referralCode: {},
-    companyName: {},
-    companySize: {},
+    password: {},
+    confirmPassword: {},
   },
-  rules: [
-    requires('confirmPassword', 'password'),
-    enabledWhen('companyName', (_values, cond) => cond.plan === 'business', {
-      reason: 'business plan required',
-    }),
-    enabledWhen('companySize', (_values, cond) => cond.plan === 'business', {
-      reason: 'business plan required',
-    }),
-    requires('companySize', 'companyName'),
-  ],
+  rules: [requires('confirmPassword', 'password')],
 })
 
-const availability = signupUmp.check(
-  { email: 'alex@example.com', password: 'hunter2' },
-  { plan: 'personal' },
-)
+ump.check({ password: '', confirmPassword: '' }).confirmPassword
+// { enabled: false, satisfied: false, fair: true, required: false, reason: 'requires password', reasons: ['requires password'] }
 
-availability.companyName
-// { enabled: false, required: false, reason: 'business plan required', reasons: ['business plan required'] }
-
-const fouls = signupUmp.play(
-  {
-    values: {
-      email: 'alex@example.com',
-      password: 'hunter2',
-      companyName: 'Acme',
-      companySize: '50',
-    },
-    conditions: { plan: 'business' },
-  },
-  {
-    values: {
-      email: 'alex@example.com',
-      password: 'hunter2',
-      companyName: 'Acme',
-      companySize: '50',
-    },
-    conditions: { plan: 'personal' },
-  },
-)
-
-// [
-//   { field: 'companyName', reason: 'business plan required', suggestedValue: undefined },
-//   { field: 'companySize', reason: 'business plan required', suggestedValue: undefined },
-// ]
+ump.check({ password: 'hunter2', confirmPassword: '' }).confirmPassword
+// { enabled: true, satisfied: false, fair: true, required: false, reason: null, reasons: [] }
 ```
+
+For a larger example with conditions, plan-gated fields, and `play()` transitions, see the [Signup example](https://sdougbrown.github.io/umpire/examples/signup/) in the docs.
 
 ## Packages
 

--- a/docs/src/content/docs/learn.mdx
+++ b/docs/src/content/docs/learn.mdx
@@ -57,6 +57,8 @@ ump.check({ password: '', confirmPassword: '' }).confirmPassword
   <RequiresDemo client:load />
 </div>
 
+Every Umpire rule takes two inputs: **values** and **conditions**. Values are what the user has entered — the current form state you pass to `check()`. Conditions are external facts that come from outside the form: the user's plan tier, a feature flag, a permission level, or anything else your app controls that isn't itself a field. Keeping them separate means your rules can react to context changes without treating app state as if it were user input.
+
 ## `enabledWhen()`
 
 Use `enabledWhen()` when a field depends on an external fact instead of another field value. Plan tiers, feature flags, permissions, and environment checks usually belong here.
@@ -78,6 +80,8 @@ ump.check({ companyName: '' }, { plan: 'personal' }).companyName
 </div>
 
 ## `fairWhen()`
+
+Unlike `requires()` and `enabledWhen()`, `fairWhen()` does not disable a field. The field stays available — the user can still interact with it. What changes is the field's current value: it passes the emptiness check but no longer fits the current state, so it is marked **foul**. `play()` uses foul status to suggest a reset for that field, leaving the decision of when to act on that suggestion with you.
 
 Use `fairWhen()` when a field's current value might stop being an appropriate selection after something else changes. The field stays enabled — it just carries a value that no longer fits, and `play()` will recommend clearing it.
 


### PR DESCRIPTION
Replace the multi-concept README quick example with the smallest valid umpire program (one field pair + requires + check), showing actual return values. Add a values-vs-conditions bridge paragraph to learn.mdx before the enabledWhen section, and prepend a fairWhen anchor that distinguishes the enabled/fair axes before the existing code example.