### PR TITLE
✍️ docs: ladder onboarding improvements across core packages

### DIFF
--- a/docs/src/content/docs/extensions/json/index.md
+++ b/docs/src/content/docs/extensions/json/index.md
@@ -13,6 +13,12 @@ It defines what can be expressed in a language-neutral schema, serializes TypeSc
 yarn add @umpire/core @umpire/json
 ```
 
+## At a glance
+
+- Loading a schema from a server or database — `fromJsonSafe(raw)` validates and hydrates in one call, never throws
+- Extending a parsed schema with app-specific TypeScript rules — `fromJson(schema)` + hand-written rules spread into the same `umpire()` call
+- Building rules that must round-trip through JSON — `namedValidators.*()`, `*Expr` builders, and `toJson()`
+
 ## Parsing from untrusted input
 
 When a schema arrives from user input, `localStorage`, an API response, or any other source you don't control, you need to validate it before hydrating it. Two APIs cover this — choose based on how much you want to separate those two steps.
@@ -170,33 +176,37 @@ Top-level `validators` are the portable field-local validation surface. They att
 
 At runtime, `fromJson()` turns these into `umpire({ validators })` entries. The field stays structurally enabled or disabled according to rules; the validator only answers whether the current satisfied value is well-formed.
 
-## Two check shapes
+## createJsonRules()
 
-In `@umpire/core`, `check()` is already doing two things depending on context: it's a predicate factory when used inside `enabledWhen()` or `requires()`, and older configs may still use it as a standalone structural constraint. `@umpire/json` now keeps field-local validation separate with `validators`, but preserves the older `check` rule shape for compatibility.
+When you author portable rules from TypeScript, field names are plain strings — a typo compiles fine and only surfaces at runtime. `createJsonRules<F, C>()` fixes that. It returns the full set of portable builders scoped to your field and conditions types, so TypeScript catches bad field names at the call site.
 
-**Top-level `"check"`** is the legacy standalone structural form. It still parses for compatibility, but it remains a fairness rule rather than validator metadata:
+```ts
+import { umpire } from '@umpire/core'
+import { createJsonRules, namedValidators, fromJson } from '@umpire/json'
 
-```json
-{ "type": "check", "field": "email", "op": "email" }
+type Fields = { email: {}; plan: {}; submit: {} }
+type Conditions = { isAdmin: boolean }
+
+const { enabledWhenExpr, requiresJson, disablesExpr, fairWhenExpr,
+        requiresExpr, anyOfJson, eitherOfJson, expr } = createJsonRules<Fields, Conditions>()
+
+const { fields, rules, validators } = fromJson(schema)
+
+const ump = umpire({
+  fields,
+  rules: [
+    ...rules,
+    // passing 'submet' instead of 'submit' would be a TypeScript error
+    enabledWhenExpr('submit', expr.check('email', namedValidators.email())),
+    requiresJson('plan', 'email'),
+  ],
+  validators,
+})
 ```
 
-**`expr.check()`** is the portable predicate-source form. It appears inside a predicate expression, letting one field's availability depend on whether another field passes a portable validator:
+The returned object includes: `enabledWhenExpr`, `requiresJson`, `requiresExpr`, `disablesExpr`, `fairWhenExpr`, `anyOfJson`, `eitherOfJson`, and `expr` (the JSON-aware expression builder that adds `expr.check()` on top of `@umpire/dsl`'s `expr.*`).
 
-```json
-{
-  "type": "enabledWhen",
-  "field": "submit",
-  "when": { "op": "check", "field": "email", "check": { "op": "email" } }
-}
-```
-
-The modern split is:
-
-- `validators` for field-local validation metadata
-- `expr.check()` for structural predicates that depend on another field passing a portable validator
-- top-level `"check"` only when you need to preserve older JSON schemas
-
-See [@umpire/dsl](/extensions/dsl/) for the full non-`check` expression vocabulary.
+Use `createJsonRules()` when you control the field type and want compile-time feedback. Use the module-level exports when the field type is unknown at the time you write the rule — for example, in a generic utility that accepts any schema.
 
 ## Conditions
 
@@ -235,6 +245,34 @@ Some rules are too app-specific to serialize safely. When `toJson()` encounters 
 `excluded.key` gives each entry a stable identity. Later serializations can replace or remove entries by key when a runtime learns to handle a previously excluded slot natively.
 
 `excluded` is informational. No runtime evaluates it automatically. Its job is to tell the next implementation: there was logic here, and you'll need to recreate it natively.
+
+## Two check shapes
+
+In `@umpire/core`, `check()` is already doing two things depending on context: it's a predicate factory when used inside `enabledWhen()` or `requires()`, and older configs may still use it as a standalone structural constraint. `@umpire/json` now keeps field-local validation separate with `validators`, but preserves the older `check` rule shape for compatibility.
+
+**Top-level `"check"`** is the legacy standalone structural form. It still parses for compatibility, but it remains a fairness rule rather than validator metadata:
+
+```json
+{ "type": "check", "field": "email", "op": "email" }
+```
+
+**`expr.check()`** is the portable predicate-source form. It appears inside a predicate expression, letting one field's availability depend on whether another field passes a portable validator:
+
+```json
+{
+  "type": "enabledWhen",
+  "field": "submit",
+  "when": { "op": "check", "field": "email", "check": { "op": "email" } }
+}
+```
+
+The modern split is:
+
+- `validators` for field-local validation metadata
+- `expr.check()` for structural predicates that depend on another field passing a portable validator
+- top-level `"check"` only when you need to preserve older JSON schemas
+
+See [@umpire/dsl](/extensions/dsl/) for the full non-`check` expression vocabulary.
 
 ## Portable field semantics
 

--- a/packages/dsl/README.md
+++ b/packages/dsl/README.md
@@ -11,8 +11,13 @@ Reach for `@umpire/dsl` when your rules live entirely in TypeScript — no seria
 A scheduler form where `endDate` is only available once the user has set a `startDate` and chosen a recurrence mode other than `'none'`:
 
 ```ts
-import { expr } from '@umpire/dsl'
+import { expr, compileExpr } from '@umpire/dsl'
 import { umpire, enabledWhen } from '@umpire/core'
+
+const endDateEnabled = compileExpr(
+  expr.and(expr.present('startDate'), expr.neq('recurrence', 'none')),
+  { fieldNames: new Set(['startDate', 'recurrence']) },
+)
 
 const ump = umpire({
   fields: {
@@ -21,12 +26,7 @@ const ump = umpire({
     endDate: {},
     timezone: {},
   },
-  rules: [
-    enabledWhen(
-      'endDate',
-      expr.and(expr.present('startDate'), expr.neq('recurrence', 'none')),
-    ),
-  ],
+  rules: [enabledWhen('endDate', endDateEnabled)],
 })
 
 ump.check({

--- a/packages/dsl/README.md
+++ b/packages/dsl/README.md
@@ -2,11 +2,58 @@
 
 Pure expression DSL and compiler helpers for Umpire.
 
-This package contains:
+## When to use this vs `@umpire/json`
 
-- `Expr` (non-`check` expression union)
-- `ExprBuilder` and `expr.*` builder helpers
-- `compileExpr()`
-- `getExprFieldRefs()`
+Reach for `@umpire/dsl` when your rules live entirely in TypeScript — no serialization, no JSON schemas, no round-tripping across runtimes. If you need `expr.check()` or rules that survive a JSON boundary, use `@umpire/json` instead. Its `expr` is a superset and covers everything here.
 
-`expr.check()`, portable validator helpers, and JSON-aware rule builders live in `@umpire/json`.
+## Example
+
+A scheduler form where `endDate` is only available once the user has set a `startDate` and chosen a recurrence mode other than `'none'`:
+
+```ts
+import { expr } from '@umpire/dsl'
+import { umpire, enabledWhen } from '@umpire/core'
+
+const ump = umpire({
+  fields: {
+    startDate: {},
+    recurrence: {},
+    endDate: {},
+    timezone: {},
+  },
+  rules: [
+    enabledWhen(
+      'endDate',
+      expr.and(expr.present('startDate'), expr.neq('recurrence', 'none')),
+    ),
+  ],
+})
+
+ump.check({
+  startDate: '2026-06-01',
+  recurrence: 'weekly',
+  endDate: null,
+  timezone: 'UTC',
+})
+// endDate: { enabled: true, required: false, satisfied: false }
+
+ump.check({
+  startDate: null,
+  recurrence: 'none',
+  endDate: null,
+  timezone: 'UTC',
+})
+// endDate: { enabled: false, required: false, satisfied: false }
+```
+
+## API
+
+| Export                             | What it is                                                                                                                   |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `expr`                             | Expression builder — `expr.present()`, `expr.neq()`, `expr.and()`, and the rest                                              |
+| `compileExpr(expression, options)` | Turns an `Expr` into a `(values, conditions) => boolean` predicate; validates field and condition references at compile time |
+| `getExprFieldRefs(expression)`     | Returns the unique field names referenced by an expression                                                                   |
+| `Expr`                             | Union type of all expression AST nodes                                                                                       |
+| `ExprBuilder<F, C>`                | Typed shape of `expr`, parameterized over field names and condition keys                                                     |
+
+For the full `expr.*` method table, see the [docs page](https://umpire.tools/extensions/dsl/).

--- a/packages/json/README.md
+++ b/packages/json/README.md
@@ -13,11 +13,82 @@ Portable schema parsing and serialization for [@umpire/core](https://www.npmjs.c
 npm install @umpire/core @umpire/dsl @umpire/json
 ```
 
+## Which API?
+
+- Loading a schema from a server or database — `fromJsonSafe(raw)`
+- Extending a parsed schema with app-specific TypeScript rules — `fromJson(schema)` + hand-written rules
+- Building rules that must round-trip through JSON — `namedValidators.*()` + `*Expr` builders + `toJson()`
+
 ## Usage
+
+The minimum path: validate and hydrate with `fromJsonSafe()`, guard the result, then pass the pieces into `umpire()`.
+
+```ts
+import { umpire } from '@umpire/core'
+import { fromJsonSafe } from '@umpire/json'
+
+const schema = {
+  version: 1,
+  fields: {
+    email: { isEmpty: 'string' },
+    submit: {},
+  },
+  rules: [],
+  validators: {
+    email: { op: 'email', error: 'Enter a valid email address' },
+  },
+}
+
+const result = fromJsonSafe(schema)
+
+if (!result.ok) {
+  console.error(result.errors)
+  return
+}
+
+const ump = umpire({
+  fields: result.fields,
+  rules: result.rules,
+  validators: result.validators,
+})
+console.log(ump.check({ email: 'user@example.com', submit: null }))
+```
+
+### Composing with hand-written rules
+
+When most of your schema lives in JSON but a few rules require app-specific TypeScript logic, hydrate the JSON portion first, then spread the parsed rules alongside your hand-written ones in the same `umpire()` call. Hydrated rules and hand-written rules coexist without conflict — `umpire()` sees a single flat array and evaluates them together.
 
 ```ts
 import { check, enabledWhen, umpire } from '@umpire/core'
-import { namedValidators, fromJson, toJson } from '@umpire/json'
+import { namedValidators, fromJson } from '@umpire/json'
+
+const { fields, rules, validators } = fromJson(schema)
+
+const ump = umpire({
+  fields,
+  rules: [
+    ...rules,
+    enabledWhen('submit', check('email', namedValidators.email()), {
+      reason: 'Enter a valid email address',
+    }),
+  ],
+  validators,
+})
+```
+
+### Authoring for portability
+
+When rules need to cross a runtime boundary — stored in a database, sent from a server, loaded in a different language — build them through the portable builders.
+
+```ts
+import { umpire } from '@umpire/core'
+import {
+  namedValidators,
+  enabledWhenExpr,
+  expr,
+  toJson,
+  fromJson,
+} from '@umpire/json'
 
 const schema = {
   version: 1,
@@ -35,22 +106,15 @@ const { fields, rules, validators } = fromJson(schema)
 
 const mergedRules = [
   ...rules,
-  enabledWhen('submit', check('email', namedValidators.email()), {
+  enabledWhenExpr('submit', expr.check('email', namedValidators.email()), {
     reason: 'Enter a valid email address',
   }),
 ]
 
-const ump = umpire({
-  fields,
-  rules: mergedRules,
-  validators,
-})
+const ump = umpire({ fields, rules: mergedRules, validators })
 
-const json = toJson({
-  fields,
-  rules: mergedRules,
-  validators,
-})
+// Round-trips cleanly — enabledWhenExpr carries its own JSON definition
+const json = toJson({ fields, rules: mergedRules, validators })
 ```
 
 ## API

--- a/packages/reads/README.md
+++ b/packages/reads/README.md
@@ -30,14 +30,15 @@ const reads = createReads<
     motherboardFair: boolean
   }
 >({
-  selectedCpu: ({ input }) => cpuById[input.cpu ?? ''],
+  selectedCpu: ({ input }) =>
+    input.cpu === 'am5' ? { socket: 'am5' } : undefined,
   motherboardFair: ({ input, read }) => {
     const cpu = read('selectedCpu')
     if (!input.motherboard || !cpu) {
       return true
     }
 
-    return input.motherboard.startsWith(cpu.socket)
+    return input.motherboard === cpu.socket
   },
 })
 
@@ -64,7 +65,7 @@ reads.inspect({ cpu: 'am5', motherboard: 'am5' })
 
 ## API
 
-- `createReads(resolvers)` builds a read table from named resolver functions. Returns the table with per-key shorthand methods, plus `resolve()`, `inspect()`, and `trace()`. Use this as the foundation for all read-backed rules.
+- `createReads(resolvers)` builds a read table from named resolver functions. Returns the table with per-key shorthand methods, plus `resolve()`, `inspect()`, `from()`, and `trace()`. Use this as the foundation for all read-backed rules.
 - `fairWhenRead(field, key, table, options?)` generates a `fairWhen` rule backed by a boolean read and registers the connection on the table so it appears in `inspect()` and `challenge()` traces. Reach for this when a fairness check depends on a derived value you want named and shared.
 - `enabledWhenRead(field, key, table, options?)` does the same for availability: generates an `enabledWhen` rule backed by a boolean read. Use it when the condition for enabling a field involves derived or catalog-driven data.
 - `fromRead(table, key, selectInput?)` extracts a read as a plain predicate function rather than generating a rule automatically. Useful when you need the read-backed value inside a hand-written rule or a conditional you're composing yourself.

--- a/packages/reads/README.md
+++ b/packages/reads/README.md
@@ -10,6 +10,10 @@ Derived read tables and read-backed rule bridges for [@umpire/core](https://www.
 npm install @umpire/core @umpire/reads
 ```
 
+## The problem it solves
+
+A plain `fairWhen` predicate works, but it's anonymous — `challenge()` sees that a rule fired, not what domain concept drove it. It's also local: render logic that needs the same derived value has to reimplement the same lookup independently. `@umpire/reads` solves both by naming the derivation once and making it available to rules, inspection, and any other consumer without recomputation.
+
 ## Usage
 
 ```ts
@@ -22,15 +26,18 @@ const reads = createReads<
     motherboard?: string
   },
   {
+    selectedCpu: { socket: string } | undefined
     motherboardFair: boolean
   }
 >({
-  motherboardFair: ({ input }) => {
-    if (!input.motherboard) {
+  selectedCpu: ({ input }) => cpuById[input.cpu ?? ''],
+  motherboardFair: ({ input, read }) => {
+    const cpu = read('selectedCpu')
+    if (!input.motherboard || !cpu) {
       return true
     }
 
-    return input.motherboard === input.cpu
+    return input.motherboard.startsWith(cpu.socket)
   },
 })
 
@@ -53,13 +60,15 @@ reads.motherboardFair({ cpu: 'am5', motherboard: 'am5' })
 reads.inspect({ cpu: 'am5', motherboard: 'am5' })
 ```
 
+`motherboardFair` calls `read('selectedCpu')` rather than repeating the lookup. Both reads are evaluated at most once per `resolve()` or `inspect()` call, regardless of how many rules or other reads depend on them.
+
 ## API
 
-- `createReads(resolvers)` builds a read table with per-key shorthand methods plus `resolve()`, `inspect()`, `from()`, and `trace()`.
-- `fairWhenRead(field, key, table, options?)` bridges a boolean read into a `fairWhen` rule.
-- `enabledWhenRead(field, key, table, options?)` bridges a boolean read into an `enabledWhen` rule.
-- `fromRead(table, key, selectInput?)` returns a predicate helper from a boolean read.
-- `ReadInputType.CONDITIONS` evaluates a read against rule conditions instead of field values.
+- `createReads(resolvers)` builds a read table from named resolver functions. Returns the table with per-key shorthand methods, plus `resolve()`, `inspect()`, and `trace()`. Use this as the foundation for all read-backed rules.
+- `fairWhenRead(field, key, table, options?)` generates a `fairWhen` rule backed by a boolean read and registers the connection on the table so it appears in `inspect()` and `challenge()` traces. Reach for this when a fairness check depends on a derived value you want named and shared.
+- `enabledWhenRead(field, key, table, options?)` does the same for availability: generates an `enabledWhen` rule backed by a boolean read. Use it when the condition for enabling a field involves derived or catalog-driven data.
+- `fromRead(table, key, selectInput?)` extracts a read as a plain predicate function rather than generating a rule automatically. Useful when you need the read-backed value inside a hand-written rule or a conditional you're composing yourself.
+- `ReadInputType.CONDITIONS` is passed as `inputType` in options to `fairWhenRead` or `enabledWhenRead` when the read should receive rule conditions as its input instead of field values. Use it for reads that evaluate metadata about the form context rather than the user's current values.
 
 ## Behavior Notes
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -238,3 +238,46 @@ expect(uncoveredRules).toEqual([])
 `report().fieldStates` records `seenEnabled`, `seenDisabled`, `seenFair`, `seenFoul`, `seenSatisfied`, and `seenUnsatisfied` for every field. `report().uncoveredRules` lists rules that never produced a failure in any instrumented call, using `challenge()` `ruleId` metadata to distinguish multiple same-type rules on the same target. Call `tracker.reset()` to clear observations between scenarios without rebuilding the wrapped umpire.
 
 For full documentation see the [Testing reference](https://umpire.dev/extensions/testing/#trackcoverageump).
+
+## Complementing trackCoverage
+
+`trackCoverage` and `monkeyTest` answer different questions and are worth running together.
+
+`trackCoverage` tells you which states your named scenarios exercised — coverage in the sense of deliberate test design. If `uncoveredRules` is non-empty, a rule went untested by any scenario you wrote.
+
+`monkeyTest` doesn't know about your scenarios. It probes the rule graph directly across inputs no human would enumerate, looking for structural failures. A rule could be fully covered by `trackCoverage` and still fail `monkeyTest` — if the predicate is impure or produces foul cycles on certain value combinations.
+
+```typescript
+import { fairWhen, requires, umpire } from '@umpire/core'
+import { monkeyTest, trackCoverage } from '@umpire/testing'
+
+const ump = umpire({
+  fields: {
+    email: { required: true },
+    password: { required: true },
+    referralCode: {},
+  },
+  rules: [
+    requires('referralCode', 'email'),
+    fairWhen('password', (val) => String(val).length >= 8, {
+      reason: 'Password must be at least 8 characters',
+    }),
+  ],
+})
+
+const tracker = trackCoverage(ump)
+
+// Scenario tests run through the tracker
+tracker.ump.check({
+  email: 'user@example.com',
+  password: 'hunter2!',
+  referralCode: 'PROMO',
+})
+tracker.ump.check({ email: null, password: 'abc' })
+
+// Every rule failure was exercised by at least one scenario
+expect(tracker.report().uncoveredRules).toEqual([])
+
+// Structural invariants hold across all sampled inputs
+expect(monkeyTest(ump).passed).toBe(true)
+```


### PR DESCRIPTION
## Summary

Applies the "APIs as Ladders" analysis to docs and READMEs across five packages, making the first-step lower and the progression more gradual for new users.

- **`@umpire/core` learn page + root README** — values/conditions explainer before `enabledWhen`, `fairWhen` anchored to the enabled/disabled axis, README quick example simplified to one rule
- **`@umpire/json`** — README restructured into three rungs (load-and-run → compose → author for portability), `## Which API?` picker added, docs page gets an `## At a glance` orientation, `createJsonRules()` documented for the first time, `## Two check shapes` moved to end of page as advanced/compat context
- **`@umpire/dsl`** — README was nearly empty; now has a when-to-use-this-vs-json paragraph, a scheduler-domain example, and an API summary table
- **`@umpire/reads`** — README gets a problem statement and updates the example to show read-to-read composition via `read()`, making memoization concrete; API bullets say when-to-reach-for-each
- **`@umpire/testing`** — README gets a "Complementing trackCoverage" section explaining why both `trackCoverage` and `monkeyTest` are worth running together

No source code changes. Docs pages that were already solid (reads, dsl, testing) are untouched.

## Test plan

- [ ] Verify docs site builds (`cd docs && yarn build`)
- [ ] Spot-check that all code examples in changed READMEs reference real exported APIs