### PR TITLE
fix(json-schema): align Profile v1 RC3 parity

### DIFF
--- a/.changeset/json-schema-proto.md
+++ b/.changeset/json-schema-proto.md
@@ -2,4 +2,4 @@
 "@umpire/json-schema": minor
 ---
 
-Release `@umpire/json-schema` 0.1.0, the JSON Schema composition profile. Adds `compileProfile()`, `compileSchemas()`, `CompiledProfile` with separate `check()`/`validateStructure()`/`evaluate()` APIs, and `filterStructuralIssues()` UI helper. Structural validation uses AJV 2020-12, conforms to `umpire-spec` v1.1.0-rc.2, and remains independent of Umpire availability evaluation.
+Release `@umpire/json-schema` 0.1.0, the JSON Schema composition profile. Adds `compileProfile()`, `compileSchemas()`, `CompiledProfile` with separate `check()`/`validateStructure()`/`evaluate()` APIs, and `filterStructuralIssues()` UI helper. Structural validation uses AJV 2020-12, conforms to `umpire-spec` v1.1.0-rc.3, and remains independent of Umpire availability evaluation.

--- a/packages/json-schema/__tests__/definition-regressions.test.ts
+++ b/packages/json-schema/__tests__/definition-regressions.test.ts
@@ -346,11 +346,9 @@ describe('deterministic Go generated names', () => {
       'invalidName',
       '/valueSchema/properties/123value',
     )
-    expectDefinitionIssue(
-      profileFor({ type: 'string' }, { name: 'type' }),
-      'invalidName',
-      '/valueSchema/properties/type',
-    )
+    expect(
+      compileProfile(profileFor({ type: 'string' }, { name: 'type' })).ok,
+    ).toBe(true)
 
     const collision = profileFor({ type: 'string' })
     ;(collision.valueSchema as JsonObject).properties = {
@@ -363,14 +361,14 @@ describe('deterministic Go generated names', () => {
     }
     expectDefinitionIssue(collision, 'nameCollision', '/valueSchema/properties')
 
-    expectDefinitionIssue(
-      profileFor(
-        { $ref: '#/$defs/type' },
-        { defs: { type: { type: 'string' } } },
-      ),
-      'invalidName',
-      '/valueSchema/$defs/type',
-    )
+    expect(
+      compileProfile(
+        profileFor(
+          { $ref: '#/$defs/type' },
+          { defs: { type: { type: 'string' } } },
+        ),
+      ).ok,
+    ).toBe(true)
   })
 
   test('audits nested fields, enum constants, variants, conditions, and branch groups', () => {

--- a/packages/json-schema/__tests__/definition-regressions.test.ts
+++ b/packages/json-schema/__tests__/definition-regressions.test.ts
@@ -1,0 +1,491 @@
+import { describe, expect, test } from 'bun:test'
+
+import { compileProfile } from '../src/index.js'
+
+type JsonObject = Record<string, unknown>
+
+type ProfileOptions = {
+  name?: string
+  defaultValue?: unknown
+  conditions?: JsonObject
+  rules?: unknown[]
+  defs?: JsonObject
+}
+
+function profileFor(schema: unknown, options: ProfileOptions = {}): JsonObject {
+  const name = options.name ?? 'value'
+  const field: JsonObject = { isEmpty: 'present' }
+  if ('defaultValue' in options) field.default = options.defaultValue
+  return {
+    $schema:
+      'https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json',
+    profileVersion: 1,
+    valueSchema: {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: { [name]: schema },
+      required: [],
+      additionalProperties: false,
+      ...(options.defs ? { $defs: options.defs } : {}),
+    },
+    umpire: {
+      version: 1,
+      fields: { [name]: field },
+      rules: options.rules ?? [],
+      ...(options.conditions ? { conditions: options.conditions } : {}),
+    },
+  }
+}
+
+function expectDefinitionIssue(raw: unknown, code: string, path: string): void {
+  const result = compileProfile(raw)
+  expect(result.ok).toBe(false)
+  if (result.ok) return
+  expect(result.issues).toContainEqual(expect.objectContaining({ code, path }))
+}
+
+const strictStringObject = {
+  type: 'object',
+  properties: { value: { type: 'string' } },
+  required: [],
+  additionalProperties: false,
+}
+
+const taggedUnion = {
+  oneOf: [
+    {
+      type: 'object',
+      properties: {
+        kind: { const: 'manual' },
+        instructions: { type: 'string' },
+      },
+      required: ['kind', 'instructions'],
+      additionalProperties: false,
+    },
+    {
+      type: 'object',
+      properties: { kind: { const: 'run' }, command: { type: 'string' } },
+      required: ['kind', 'command'],
+      additionalProperties: false,
+    },
+  ],
+}
+
+describe('RC3 definition issue paths', () => {
+  test('meta-schema still rejects unknown canonical wrapper members', () => {
+    expectDefinitionIssue(
+      { ...profileFor({ type: 'string' }), extra: true },
+      'invalidProfile',
+      '/',
+    )
+  })
+
+  test('rejects root oneOf while preserving property tagged unions', () => {
+    const rootUnion = profileFor({ type: 'string' })
+    ;(rootUnion.valueSchema as JsonObject).oneOf = taggedUnion.oneOf
+    expectDefinitionIssue(rootUnion, 'unsupportedKeyword', '/valueSchema/oneOf')
+
+    expect(compileProfile(profileFor(taggedUnion)).ok).toBe(true)
+
+    const withNonDiscriminatorConst = {
+      oneOf: taggedUnion.oneOf.map((branch) => ({
+        ...branch,
+        properties: {
+          version: { type: 'string', const: 'v1' },
+          ...branch.properties,
+        },
+        required: [...branch.required, 'version'],
+      })),
+    }
+    expect(compileProfile(profileFor(withNonDiscriminatorConst)).ok).toBe(true)
+  })
+
+  test.each([
+    ['allOf'],
+    ['anyOf'],
+    ['not'],
+    ['uniqueItems'],
+    ['pattern'],
+    ['format'],
+    ['$dynamicRef'],
+    ['$recursiveRef'],
+    ['if'],
+    ['then'],
+    ['else'],
+    ['prefixItems'],
+    ['contains'],
+    ['multipleOf'],
+    ['patternProperties'],
+    ['propertyNames'],
+    ['dependentRequired'],
+    ['dependentSchemas'],
+    ['contentEncoding'],
+    ['contentMediaType'],
+    ['contentSchema'],
+    ['default'],
+    ['x-transform'],
+  ])('rejects excluded keyword %s at its exact path', (keyword) => {
+    expectDefinitionIssue(
+      profileFor({ type: 'string', [keyword]: true }),
+      'unsupportedKeyword',
+      `/valueSchema/properties/value/${keyword}`,
+    )
+  })
+
+  test.each([[['string', 'null']], [['string', 'number']], ['null']])(
+    'rejects unsupported type shape %j as invalidProfile',
+    (type) => {
+      expectDefinitionIssue(
+        profileFor({ type }),
+        'invalidProfile',
+        '/valueSchema/properties/value/type',
+      )
+    },
+  )
+
+  test('uses documented array-shape codes and paths', () => {
+    expectDefinitionIssue(
+      profileFor({ type: 'array', items: [{ type: 'string' }] }),
+      'invalidProfile',
+      '/valueSchema/properties/value/items',
+    )
+    expectDefinitionIssue(
+      profileFor({ type: 'array' }),
+      'invalidProfile',
+      '/valueSchema/properties/value',
+    )
+  })
+
+  test('uses one aggregate discriminator path for malformed unions', () => {
+    const path = '/valueSchema/properties/value/oneOf'
+    expectDefinitionIssue(
+      profileFor({ oneOf: [{ type: 'string' }, { type: 'number' }] }),
+      'invalidDiscriminator',
+      path,
+    )
+    expectDefinitionIssue(
+      profileFor({
+        oneOf: [
+          {
+            type: 'object',
+            properties: { kind: { const: 'same' } },
+            required: ['kind'],
+            additionalProperties: false,
+          },
+          {
+            type: 'object',
+            properties: { kind: { const: 'same' } },
+            required: ['kind'],
+            additionalProperties: false,
+          },
+        ],
+      }),
+      'invalidDiscriminator',
+      path,
+    )
+    expectDefinitionIssue(
+      profileFor({
+        oneOf: taggedUnion.oneOf.map((branch) => ({
+          ...branch,
+          required: branch.required.filter((name) => name !== 'kind'),
+        })),
+      }),
+      'invalidDiscriminator',
+      path,
+    )
+  })
+})
+
+describe('strict schema invariants', () => {
+  test('distinguishes missing and non-false additionalProperties paths', () => {
+    const rootMissing = profileFor({ type: 'string' })
+    delete (rootMissing.valueSchema as JsonObject).additionalProperties
+    expectDefinitionIssue(rootMissing, 'invalidProfile', '/valueSchema')
+
+    const rootTrue = profileFor({ type: 'string' })
+    ;(rootTrue.valueSchema as JsonObject).additionalProperties = true
+    expectDefinitionIssue(
+      rootTrue,
+      'invalidProfile',
+      '/valueSchema/additionalProperties',
+    )
+
+    expectDefinitionIssue(
+      profileFor({ type: 'object', properties: {} }),
+      'invalidProfile',
+      '/valueSchema/properties/value',
+    )
+    expectDefinitionIssue(
+      profileFor({
+        type: 'object',
+        properties: {},
+        additionalProperties: true,
+      }),
+      'invalidProfile',
+      '/valueSchema/properties/value/additionalProperties',
+    )
+  })
+
+  test('requires explicit object type, properties, and declared required names', () => {
+    expectDefinitionIssue(
+      profileFor({ properties: {}, additionalProperties: false }),
+      'invalidProfile',
+      '/valueSchema/properties/value',
+    )
+    expectDefinitionIssue(
+      profileFor({ type: 'object', additionalProperties: false }),
+      'invalidProfile',
+      '/valueSchema/properties/value',
+    )
+    expectDefinitionIssue(
+      profileFor({
+        type: 'object',
+        properties: {},
+        required: ['missing'],
+        additionalProperties: false,
+      }),
+      'invalidProfile',
+      '/valueSchema/properties/value/required',
+    )
+  })
+
+  test('rejects root required names absent from root properties', () => {
+    const raw = profileFor({ type: 'string' })
+    ;(raw.valueSchema as JsonObject).required = ['missing']
+    expectDefinitionIssue(raw, 'invalidProfile', '/valueSchema/required')
+  })
+
+  test('validates schema shapes reached through $defs and escaped local refs', () => {
+    const valid = profileFor(
+      { $ref: '#/$defs/A~1B' },
+      { defs: { 'A/B': strictStringObject } },
+    )
+    expect(compileProfile(valid).ok).toBe(true)
+
+    expectDefinitionIssue(
+      profileFor(
+        { $ref: '#/$defs/Bad' },
+        {
+          defs: {
+            Bad: { type: 'object', properties: {}, additionalProperties: true },
+          },
+        },
+      ),
+      'invalidProfile',
+      '/valueSchema/$defs/Bad/additionalProperties',
+    )
+  })
+
+  test('rejects nested root-only schema keywords', () => {
+    expectDefinitionIssue(
+      profileFor({
+        type: 'string',
+        $defs: { Nested: { type: 'string' } },
+      }),
+      'unsupportedKeyword',
+      '/valueSchema/properties/value/$defs',
+    )
+  })
+})
+
+describe('deterministic Go generated names', () => {
+  test('rejects invalid and colliding property and definition names', () => {
+    expectDefinitionIssue(
+      profileFor({ type: 'string' }, { name: '123value' }),
+      'invalidName',
+      '/valueSchema/properties/123value',
+    )
+    expectDefinitionIssue(
+      profileFor({ type: 'string' }, { name: 'type' }),
+      'invalidName',
+      '/valueSchema/properties/type',
+    )
+
+    const collision = profileFor({ type: 'string' })
+    ;(collision.valueSchema as JsonObject).properties = {
+      'user-id': { type: 'string' },
+      user_id: { type: 'string' },
+    }
+    ;(collision.umpire as JsonObject).fields = {
+      'user-id': { isEmpty: 'string' },
+      user_id: { isEmpty: 'string' },
+    }
+    expectDefinitionIssue(collision, 'nameCollision', '/valueSchema/properties')
+
+    expectDefinitionIssue(
+      profileFor(
+        { $ref: '#/$defs/type' },
+        { defs: { type: { type: 'string' } } },
+      ),
+      'invalidName',
+      '/valueSchema/$defs/type',
+    )
+  })
+
+  test('audits nested fields, enum constants, variants, conditions, and branch groups', () => {
+    expectDefinitionIssue(
+      profileFor({
+        type: 'object',
+        properties: {
+          'user-id': { type: 'string' },
+          user_id: { type: 'string' },
+        },
+        additionalProperties: false,
+      }),
+      'nameCollision',
+      '/valueSchema/properties/value/properties',
+    )
+    expectDefinitionIssue(
+      profileFor({ type: 'string', enum: ['ready-now', 'ready_now'] }),
+      'nameCollision',
+      '/valueSchema/properties/value/enum',
+    )
+    expectDefinitionIssue(
+      profileFor({
+        oneOf: taggedUnion.oneOf.map((branch, index) => ({
+          ...branch,
+          properties: {
+            ...branch.properties,
+            kind: { const: index === 0 ? 'ready-now' : 'ready_now' },
+          },
+        })),
+      }),
+      'nameCollision',
+      '/valueSchema/properties/value/oneOf',
+    )
+    expectDefinitionIssue(
+      profileFor(
+        { type: 'string' },
+        {
+          conditions: {
+            'allow-edit': { type: 'boolean' },
+            allow_edit: { type: 'boolean' },
+          },
+        },
+      ),
+      'nameCollision',
+      '/umpire/conditions',
+    )
+    expectDefinitionIssue(
+      profileFor(
+        { type: 'string' },
+        {
+          rules: [
+            {
+              type: 'oneOf',
+              group: 'choice',
+              branches: { 'ready-now': ['value'], ready_now: ['value'] },
+            },
+          ],
+        },
+      ),
+      'nameCollision',
+      '/umpire/rules/0/branches',
+    )
+  })
+
+  test('detects collisions with nested types and default helper names', () => {
+    expectDefinitionIssue(
+      profileFor(
+        { type: 'object', properties: {}, additionalProperties: false },
+        { defs: { 'fields-value': strictStringObject } },
+      ),
+      'nameCollision',
+      '/valueSchema/$defs/fields-value',
+    )
+    expectDefinitionIssue(
+      profileFor({ type: 'string' }, { defs: { fields: strictStringObject } }),
+      'nameCollision',
+      '/valueSchema/$defs/fields',
+    )
+  })
+})
+
+describe('numeric safety and defaults', () => {
+  test.each([
+    [
+      { type: 'integer', const: Number.MAX_SAFE_INTEGER + 1 },
+      '/valueSchema/properties/value/const',
+    ],
+    [
+      { type: 'integer', enum: [1, Number.MAX_SAFE_INTEGER + 1] },
+      '/valueSchema/properties/value/enum',
+    ],
+    [
+      { type: 'integer', maximum: Number.MAX_SAFE_INTEGER + 1 },
+      '/valueSchema/properties/value/maximum',
+    ],
+    [
+      {
+        type: 'array',
+        items: { type: 'string' },
+        maxItems: Number.MAX_SAFE_INTEGER + 1,
+      },
+      '/valueSchema/properties/value/maxItems',
+    ],
+    [
+      { type: 'number', const: Number.POSITIVE_INFINITY },
+      '/valueSchema/properties/value/const',
+    ],
+  ])('rejects unsafe schema literal at %s', (schema, path) => {
+    expectDefinitionIssue(profileFor(schema), 'unsafeNumber', path)
+  })
+
+  test('rejects unsafe defaults, including through local references', () => {
+    expectDefinitionIssue(
+      profileFor(
+        { $ref: '#/$defs/Count' },
+        {
+          defs: { Count: { type: 'integer' } },
+          defaultValue: Number.MAX_SAFE_INTEGER + 1,
+        },
+      ),
+      'invalidDefault',
+      '/umpire/fields/value/default',
+    )
+    expectDefinitionIssue(
+      profileFor(
+        { type: 'number' },
+        { defaultValue: Number.POSITIVE_INFINITY },
+      ),
+      'invalidDefault',
+      '/umpire/fields/value/default',
+    )
+  })
+
+  test('reports runtime unsafe integers and non-finite numbers', () => {
+    const integer = compileProfile(profileFor({ type: 'integer' }))
+    expect(integer.ok).toBe(true)
+    if (integer.ok) {
+      expect(
+        integer.profile.validateStructure({
+          value: Number.MAX_SAFE_INTEGER + 1,
+        }).issues,
+      ).toContainEqual(
+        expect.objectContaining({ code: 'safeInteger', path: '/value' }),
+      )
+    }
+
+    const number = compileProfile(profileFor({ type: 'number' }))
+    expect(number.ok).toBe(true)
+    if (number.ok) {
+      expect(
+        number.profile.validateStructure({ value: Number.POSITIVE_INFINITY })
+          .issues,
+      ).toContainEqual(
+        expect.objectContaining({ code: 'type', path: '/value' }),
+      )
+    }
+  })
+
+  test('resolves refs for isEmpty compatibility', () => {
+    const raw = profileFor(
+      { $ref: '#/$defs/Count' },
+      { defs: { Count: { type: 'integer' } } },
+    )
+    ;((raw.umpire as JsonObject).fields as JsonObject).value = {
+      isEmpty: 'string',
+    }
+    expectDefinitionIssue(raw, 'incompatibleIsEmpty', '/umpire/fields/value')
+  })
+})

--- a/packages/json-schema/__tests__/definition-regressions.test.ts
+++ b/packages/json-schema/__tests__/definition-regressions.test.ts
@@ -37,11 +37,20 @@ function profileFor(schema: unknown, options: ProfileOptions = {}): JsonObject {
   }
 }
 
-function expectDefinitionIssue(raw: unknown, code: string, path: string): void {
+function expectDefinitionIssues(
+  raw: unknown,
+  expected: Array<[code: string, path: string]>,
+): void {
   const result = compileProfile(raw)
   expect(result.ok).toBe(false)
   if (result.ok) return
-  expect(result.issues).toContainEqual(expect.objectContaining({ code, path }))
+  expect(result.issues.map(({ code, path }) => [code, path]).sort()).toEqual(
+    expected.sort(),
+  )
+}
+
+function expectDefinitionIssue(raw: unknown, code: string, path: string): void {
+  expectDefinitionIssues(raw, [[code, path]])
 }
 
 const strictStringObject = {
@@ -78,6 +87,25 @@ describe('RC3 definition issue paths', () => {
       'invalidProfile',
       '/',
     )
+  })
+
+  test.each([
+    ['non-array rules', null],
+    ['non-object rule', [null]],
+    [
+      'non-object oneOf branches',
+      [{ type: 'oneOf', group: 'choice', branches: null }],
+    ],
+    [
+      'non-array eitherOf branch rules',
+      [{ type: 'eitherOf', group: 'choice', branches: { first: null } }],
+    ],
+    ['non-array anyOf rules', [{ type: 'anyOf', rules: null }]],
+  ])('returns invalidProfile without throwing for malformed %s', (_, rules) => {
+    const raw = profileFor({ type: 'string' })
+    ;(raw.umpire as JsonObject).rules = rules
+    expect(() => compileProfile(raw)).not.toThrow()
+    expectDefinitionIssue(raw, 'invalidProfile', '/umpire')
   })
 
   test('rejects root oneOf while preserving property tagged unions', () => {
@@ -255,6 +283,29 @@ describe('strict schema invariants', () => {
     expectDefinitionIssue(raw, 'invalidProfile', '/valueSchema/required')
   })
 
+  test('does not resolve inherited definition or required-property names', () => {
+    expectDefinitionIssue(
+      profileFor({ $ref: '#/$defs/toString' }),
+      'invalidReference',
+      '/valueSchema/properties/value/$ref',
+    )
+
+    expectDefinitionIssue(
+      profileFor({
+        type: 'object',
+        properties: {},
+        required: ['toString'],
+        additionalProperties: false,
+      }),
+      'invalidProfile',
+      '/valueSchema/properties/value/required',
+    )
+
+    const root = profileFor({ type: 'string' })
+    ;(root.valueSchema as JsonObject).required = ['toString']
+    expectDefinitionIssue(root, 'invalidProfile', '/valueSchema/required')
+  })
+
   test('validates schema shapes reached through $defs and escaped local refs', () => {
     const valid = profileFor(
       { $ref: '#/$defs/A~1B' },
@@ -399,6 +450,41 @@ describe('deterministic Go generated names', () => {
       '/valueSchema/$defs/fields',
     )
   })
+
+  test('detects collisions across generated symbol categories', () => {
+    const enumAndObject = profileFor({ type: 'string' })
+    ;(enumAndObject.valueSchema as JsonObject).properties = {
+      status: { type: 'string', enum: ['ready'] },
+      'status-value-ready': strictStringObject,
+    }
+    ;(enumAndObject.umpire as JsonObject).fields = {
+      status: { isEmpty: 'string' },
+      'status-value-ready': { isEmpty: 'object' },
+    }
+    expectDefinitionIssue(
+      enumAndObject,
+      'nameCollision',
+      '/valueSchema/properties/status-value-ready',
+    )
+
+    expectDefinitionIssue(
+      profileFor(
+        { type: 'string' },
+        {
+          defs: { 'choice-branch': strictStringObject },
+          rules: [
+            {
+              type: 'oneOf',
+              group: 'choice',
+              branches: { first: ['value'], second: ['value'] },
+            },
+          ],
+        },
+      ),
+      'nameCollision',
+      '/umpire/rules/0/group',
+    )
+  })
 })
 
 describe('numeric safety and defaults', () => {
@@ -453,29 +539,78 @@ describe('numeric safety and defaults', () => {
     )
   })
 
-  test('reports runtime unsafe integers and non-finite numbers', () => {
+  test.each([Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER])(
+    'accepts safe integer boundary %d in schemas, defaults, and values',
+    (boundary) => {
+      const result = compileProfile(
+        profileFor(
+          { type: 'integer', const: boundary },
+          { defaultValue: boundary },
+        ),
+      )
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.profile.validateStructure({ value: boundary })).toEqual({
+        valid: true,
+        issues: [],
+      })
+    },
+  )
+
+  test('reports only the applicable runtime numeric issue', () => {
     const integer = compileProfile(profileFor({ type: 'integer' }))
     expect(integer.ok).toBe(true)
     if (integer.ok) {
       expect(
-        integer.profile.validateStructure({
-          value: Number.MAX_SAFE_INTEGER + 1,
-        }).issues,
-      ).toContainEqual(
-        expect.objectContaining({ code: 'safeInteger', path: '/value' }),
-      )
+        integer.profile
+          .validateStructure({ value: 1.5 })
+          .issues.map(({ code, path }) => [code, path]),
+      ).toEqual([['type', '/value']])
+      expect(
+        integer.profile
+          .validateStructure({ value: Number.MAX_SAFE_INTEGER + 1 })
+          .issues.map(({ code, path }) => [code, path]),
+      ).toEqual([['safeInteger', '/value']])
     }
 
     const number = compileProfile(profileFor({ type: 'number' }))
     expect(number.ok).toBe(true)
     if (number.ok) {
       expect(
-        number.profile.validateStructure({ value: Number.POSITIVE_INFINITY })
-          .issues,
-      ).toContainEqual(
-        expect.objectContaining({ code: 'type', path: '/value' }),
-      )
+        number.profile
+          .validateStructure({ value: Number.POSITIVE_INFINITY })
+          .issues.map(({ code, path }) => [code, path]),
+      ).toEqual([['type', '/value']])
     }
+  })
+
+  test.each(['a/b', 'a~b'])(
+    'escapes field %s while matching and reporting an invalid default',
+    (name) => {
+      expectDefinitionIssue(
+        profileFor({ type: 'integer' }, { name, defaultValue: 1.5 }),
+        'invalidDefault',
+        `/umpire/fields/${name.replace(/~/g, '~0').replace(/\//g, '~1')}/default`,
+      )
+    },
+  )
+
+  test('treats tagged unions as objects for isEmpty compatibility', () => {
+    const incompatible = profileFor(taggedUnion)
+    ;((incompatible.umpire as JsonObject).fields as JsonObject).value = {
+      isEmpty: 'string',
+    }
+    expectDefinitionIssue(
+      incompatible,
+      'incompatibleIsEmpty',
+      '/umpire/fields/value',
+    )
+
+    const compatible = profileFor(taggedUnion)
+    ;((compatible.umpire as JsonObject).fields as JsonObject).value = {
+      isEmpty: 'object',
+    }
+    expect(compileProfile(compatible).ok).toBe(true)
   })
 
   test('resolves refs for isEmpty compatibility', () => {

--- a/packages/json-schema/__tests__/fixtures.ts
+++ b/packages/json-schema/__tests__/fixtures.ts
@@ -52,30 +52,30 @@ export const workflowProfile: ProfileDocument = {
           {
             type: 'object',
             properties: {
-              type: { type: 'string', const: 'manual' },
+              kind: { type: 'string', const: 'manual' },
               instructions: { type: 'string', minLength: 1 },
             },
-            required: ['type', 'instructions'],
+            required: ['kind', 'instructions'],
             additionalProperties: false,
           },
           {
             type: 'object',
             properties: {
-              type: { type: 'string', const: 'run' },
+              kind: { type: 'string', const: 'run' },
               script: { type: 'string', minLength: 1 },
               timeout: { type: 'integer', minimum: 1, maximum: 3600 },
             },
-            required: ['type', 'script'],
+            required: ['kind', 'script'],
             additionalProperties: false,
           },
           {
             type: 'object',
             properties: {
-              type: { type: 'string', const: 'loop' },
+              kind: { type: 'string', const: 'loop' },
               iterator: { type: 'string', minLength: 1 },
               maxIterations: { type: 'integer', minimum: 1, maximum: 1000 },
             },
-            required: ['type', 'iterator', 'maxIterations'],
+            required: ['kind', 'iterator', 'maxIterations'],
             additionalProperties: false,
           },
         ],
@@ -134,18 +134,18 @@ export const validWorkflowInstance = {
     {
       id: 'build',
       label: 'Build application',
-      action: { type: 'run', script: 'yarn build', timeout: 300 },
+      action: { kind: 'run', script: 'yarn build', timeout: 300 },
     },
     {
       id: 'approve',
       label: 'Manual approval',
-      action: { type: 'manual', instructions: 'Review and approve' },
+      action: { kind: 'manual', instructions: 'Review and approve' },
     },
     {
       id: 'retry-check',
       label: 'Retry check',
       action: {
-        type: 'loop',
+        kind: 'loop',
         iterator: 'attempt',
         maxIterations: 5,
       },
@@ -175,7 +175,7 @@ export const missingRequiredNodePropInstance = {
   nodes: [
     {
       label: 'Missing id',
-      action: { type: 'manual', instructions: 'Fix this' },
+      action: { kind: 'manual', instructions: 'Fix this' },
     },
   ],
 }
@@ -188,7 +188,7 @@ export const unknownNodePropertyInstance = {
     {
       id: 'step1',
       label: 'Step 1',
-      action: { type: 'manual', instructions: 'Do something' },
+      action: { kind: 'manual', instructions: 'Do something' },
       extraProp: 'not-allowed',
     },
   ],
@@ -202,7 +202,7 @@ export const invalidDiscriminatorInstance = {
     {
       id: 'step1',
       label: 'Step 1',
-      action: { type: 'unknown_action' },
+      action: { kind: 'unknown_action' },
     },
   ],
 }
@@ -229,7 +229,7 @@ export const omittedTagsInstance = {
       id: 'step1',
       label: 'Step 1',
       action: {
-        type: 'loop',
+        kind: 'loop',
         iterator: 'i',
         maxIterations: 10,
       },
@@ -245,7 +245,7 @@ export const nullTagsInstance = {
     {
       id: 'step1',
       label: 'Step 1',
-      action: { type: 'manual', instructions: 'Do it' },
+      action: { kind: 'manual', instructions: 'Do it' },
     },
   ],
   tags: null,

--- a/packages/json-schema/__tests__/profile.test.ts
+++ b/packages/json-schema/__tests__/profile.test.ts
@@ -276,7 +276,7 @@ describe('CompiledProfile.validateStructure()', () => {
     ).toBe(true)
   })
 
-  test('missing discriminator emits required at /nodes/0/action/type', () => {
+  test('missing discriminator emits required at /nodes/0/action/kind', () => {
     const result = compileProfile(workflowProfile)
     expect(result.ok).toBe(true)
     if (!result.ok) return
@@ -287,7 +287,7 @@ describe('CompiledProfile.validateStructure()', () => {
     expect(structure.valid).toBe(false)
     expect(
       structure.issues.some(
-        (i) => i.code === 'required' && i.path === '/nodes/0/action/type',
+        (i) => i.code === 'required' && i.path === '/nodes/0/action/kind',
       ),
     ).toBe(true)
   })
@@ -875,7 +875,8 @@ describe('Coverage gaps', () => {
       expect(
         result.issues.some(
           (i) =>
-            i.code === 'invalidProfile' && i.message.includes('incompatible'),
+            i.code === 'invalidProfile' &&
+            i.path === '/valueSchema/properties/status/enum',
         ),
       ).toBe(true)
     }

--- a/packages/json-schema/conformance/.synced-at-version
+++ b/packages/json-schema/conformance/.synced-at-version
@@ -1,5 +1,5 @@
 {
-  "version": "v1.1.0-rc.2",
-  "tarballSha256": "560184f267e4224f00dd5bed8a6a66bcafdb906153c80699c0f074ec30144240",
-  "fixtureDigest": "74c7bcbebc33ff21cf7df964cf05bc0f602d925f1d6e98a76de80119052eac6a"
+  "version": "v1.1.0-rc.3",
+  "tarballSha256": "392aabcd711ab26df3a1e90b0789a23faf875a922c955445e05f3ccadff75d1c",
+  "fixtureDigest": "32eed92fd3937519cc76918cad0ca1f5f656b47170e016812e3f6f4f0b1cb4f7"
 }

--- a/packages/json-schema/conformance/failures/profile-definition-failures.json
+++ b/packages/json-schema/conformance/failures/profile-definition-failures.json
@@ -1,7 +1,7 @@
 {
   "fixtureVersion": 1,
   "id": "profile-definition-failures",
-  "description": "Profile definition rejection cases: unsupported keywords, field mismatches, incompatible isEmpty, invalid defaults, bad references, invalid discriminators, and unsafe numbers.",
+  "description": "Profile definition rejection cases: closed vocabulary, schema consistency, references, tagged unions, field correspondence, defaults, names, and numeric safety.",
   "failures": [
     {
       "id": "excluded-keyword-allOf",
@@ -14,6 +14,7 @@
           "type": "object",
           "properties": {
             "x": {
+              "type": "string",
               "allOf": [
                 {
                   "type": "string"
@@ -55,6 +56,7 @@
           "type": "object",
           "properties": {
             "x": {
+              "type": "string",
               "anyOf": [
                 {
                   "type": "string"
@@ -254,6 +256,43 @@
               "isEmpty": "string"
             },
             "extraField": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "fieldMismatch",
+          "path": "/valueSchema"
+        }
+      ]
+    },
+    {
+      "id": "field-mismatch-missing-umpire-field",
+      "description": "valueSchema has a property not present in umpire fields.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "orphan": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "title": {
               "isEmpty": "string"
             }
           },
@@ -468,6 +507,39 @@
       ]
     },
     {
+      "id": "value-schema-missing-root-type-object",
+      "description": "valueSchema root must declare type: 'object'.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "invalidProfile",
+          "path": "/valueSchema"
+        }
+      ]
+    },
+    {
       "id": "untagged-oneof-discriminator-not-string-const",
       "description": "oneOf branches must use a string const discriminator, not a boolean or number.",
       "profile": {
@@ -646,6 +718,1013 @@
         {
           "code": "invalidDiscriminator",
           "path": "/valueSchema/properties/cmd/oneOf"
+        }
+      ]
+    },
+    {
+      "id": "root-union",
+      "description": "A root oneOf is outside the closed Profile v1 vocabulary.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "additionalProperties": false,
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "const": "a"
+                }
+              },
+              "required": [
+                "value"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "const": "b"
+                }
+              },
+              "required": [
+                "value"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "unsupportedKeyword",
+          "path": "/valueSchema/oneOf"
+        }
+      ]
+    },
+    {
+      "id": "untagged-oneof",
+      "description": "oneOf branches without a common required string-const discriminator are rejected.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "choice": { "oneOf": [{ "type": "string" }, { "type": "number" }] } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "choice": { "isEmpty": "present" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidDiscriminator", "path": "/valueSchema/properties/choice/oneOf" }
+      ]
+    },
+    {
+      "id": "malformed-tagged-union-duplicate-discriminator",
+      "description": "Tagged union branches must use distinct discriminator const values.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "choice": {
+              "oneOf": [
+                { "type": "object", "properties": { "kind": { "const": "same" } }, "required": ["kind"], "additionalProperties": false },
+                { "type": "object", "properties": { "kind": { "const": "same" } }, "required": ["kind"], "additionalProperties": false }
+              ]
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "choice": { "isEmpty": "present" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidDiscriminator", "path": "/valueSchema/properties/choice/oneOf" }
+      ]
+    },
+    {
+      "id": "nullable-type-array",
+      "description": "Type arrays, including nullable arrays, are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": ["string", "null"] } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "string" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema/properties/value/type" }
+      ]
+    },
+    {
+      "id": "explicit-null-type",
+      "description": "The explicit null type is not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": "null" } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "present" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema/properties/value/type" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-dynamicRef",
+      "description": "Dynamic references are unsupported keywords in Profile v1.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "item": { "type": "string", "$dynamicRef": "#/$defs/Item" } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "item": { "isEmpty": "present" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/item/$dynamicRef" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-recursiveRef",
+      "description": "Recursive references are unsupported keywords in Profile v1.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "item": { "type": "string", "$recursiveRef": "#/$defs/Item" } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "item": { "isEmpty": "present" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/item/$recursiveRef" }
+      ]
+    },
+    {
+      "id": "invalid-reference-sibling",
+      "description": "A local reference cannot have schema siblings.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "item": { "$ref": "#/$defs/Item", "title": "item" } },
+          "required": [],
+          "additionalProperties": false,
+          "$defs": { "Item": { "type": "string" } }
+        },
+        "umpire": { "version": 1, "fields": { "item": { "isEmpty": "present" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidReference", "path": "/valueSchema/properties/item" }
+      ]
+    },
+    {
+      "id": "invalid-reference-missing-local-target",
+      "description": "A local reference must resolve to a root $defs entry.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "item": { "$ref": "#/$defs/Missing" } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "item": { "isEmpty": "present" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidReference", "path": "/valueSchema/properties/item/$ref" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-if",
+      "description": "Conditional schemas are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": "string", "if": { "type": "string" } } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "present" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/value/if" }
+      ]
+    },
+    {
+      "id": "tuple-items-array",
+      "description": "Array items must be one homogeneous schema, not a tuple array.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "values": { "type": "array", "items": [{ "type": "string" }] } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "values": { "isEmpty": "array" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema/properties/values/items" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-prefixItems",
+      "description": "Prefix arrays are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "values": { "type": "array", "prefixItems": [{ "type": "string" }], "items": { "type": "string" } } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "values": { "isEmpty": "array" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/values/prefixItems" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-contains",
+      "description": "Array contains is not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "values": { "type": "array", "items": { "type": "string" }, "contains": { "const": "x" } } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "values": { "isEmpty": "array" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/values/contains" }
+      ]
+    },
+    {
+      "id": "array-missing-items",
+      "description": "Array schemas must declare items.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "values": { "type": "array" } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "values": { "isEmpty": "array" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema/properties/values" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-multipleOf",
+      "description": "multipleOf is not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": "number", "multipleOf": 0.5 } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "number" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/value/multipleOf" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-patternProperties",
+      "description": "Pattern properties are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "config": { "type": "object", "properties": {}, "additionalProperties": false, "patternProperties": { "^x-": { "type": "string" } } }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "config": { "isEmpty": "object" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/config/patternProperties" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-propertyNames",
+      "description": "Property-name schemas are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "config": { "type": "object", "properties": {}, "additionalProperties": false, "propertyNames": { "pattern": "^[a-z]+$" } }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "config": { "isEmpty": "object" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/config/propertyNames" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-dependentRequired",
+      "description": "Dependent properties are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "config": { "type": "object", "properties": { "a": { "type": "string" }, "b": { "type": "string" } }, "additionalProperties": false, "dependentRequired": { "a": ["b"] } }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "config": { "isEmpty": "object" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/config/dependentRequired" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-dependentSchemas",
+      "description": "Dependent schemas are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "config": {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "type": "string"
+                },
+                "b": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "dependentSchemas": {
+                "a": {
+                  "type": "object",
+                  "properties": {
+                    "a": {
+                      "type": "string"
+                    },
+                    "b": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "b"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "config": {
+              "isEmpty": "object"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "unsupportedKeyword",
+          "path": "/valueSchema/properties/config/dependentSchemas"
+        }
+      ]
+    },
+    {
+      "id": "excluded-keyword-contentEncoding",
+      "description": "Content vocabulary is not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": "string", "contentEncoding": "base64" } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "string" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/value/contentEncoding" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-contentMediaType",
+      "description": "Content media types are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string",
+              "contentMediaType": "application/json"
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "unsupportedKeyword",
+          "path": "/valueSchema/properties/value/contentMediaType"
+        }
+      ]
+    },
+    {
+      "id": "excluded-keyword-contentSchema",
+      "description": "Embedded content schemas are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string",
+              "contentSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "unsupportedKeyword",
+          "path": "/valueSchema/properties/value/contentSchema"
+        }
+      ]
+    },
+    {
+      "id": "excluded-keyword-default",
+      "description": "JSON Schema default is not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": "string", "default": "fallback" } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "string" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/value/default" }
+      ]
+    },
+    {
+      "id": "excluded-keyword-x-transform",
+      "description": "Unknown transformation keywords are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": "string", "x-transform": "trim" } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "string" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "unsupportedKeyword", "path": "/valueSchema/properties/value/x-transform" }
+      ]
+    },
+    {
+      "id": "root-missing-additionalProperties",
+      "description": "The root object must explicitly declare additionalProperties: false.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": "string" } },
+          "required": []
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "string" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema" }
+      ]
+    },
+    {
+      "id": "root-additionalProperties-true",
+      "description": "The root object must reject unknown properties.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "value": { "type": "string" } },
+          "required": [],
+          "additionalProperties": true
+        },
+        "umpire": { "version": 1, "fields": { "value": { "isEmpty": "string" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema/additionalProperties" }
+      ]
+    },
+    {
+      "id": "nested-object-missing-additionalProperties",
+      "description": "Nested objects must explicitly declare additionalProperties: false.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "config": { "type": "object", "properties": {} } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "config": { "isEmpty": "object" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema/properties/config" }
+      ]
+    },
+    {
+      "id": "nested-object-additionalProperties-true",
+      "description": "Nested objects must reject unknown properties.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "config": { "type": "object", "properties": {}, "additionalProperties": true } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "config": { "isEmpty": "object" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema/properties/config/additionalProperties" }
+      ]
+    },
+    {
+      "id": "required-name-missing-from-properties",
+      "description": "Every required name must be declared in the same object properties.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": { "config": { "type": "object", "properties": {}, "required": ["missing"], "additionalProperties": false } },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": { "version": 1, "fields": { "config": { "isEmpty": "object" } }, "rules": [] }
+      },
+      "expectedDefinitionIssues": [
+        { "code": "invalidProfile", "path": "/valueSchema/properties/config/required" }
+      ]
+    },
+    {
+      "id": "root-required-name-missing-from-properties",
+      "description": "Every root required name must be declared in root properties.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "missing"
+          ],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "invalidProfile",
+          "path": "/valueSchema/required"
+        }
+      ]
+    },
+    {
+      "id": "multiple-type-array",
+      "description": "Type arrays are unsupported even when they do not include null.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": [
+                "string",
+                "number"
+              ]
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "present"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "invalidProfile",
+          "path": "/valueSchema/properties/value/type"
+        }
+      ]
+    },
+    {
+      "id": "excluded-keyword-then",
+      "description": "Conditional then schemas are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string",
+              "then": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "unsupportedKeyword",
+          "path": "/valueSchema/properties/value/then"
+        }
+      ]
+    },
+    {
+      "id": "excluded-keyword-else",
+      "description": "Conditional else schemas are not supported.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string",
+              "else": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "unsupportedKeyword",
+          "path": "/valueSchema/properties/value/else"
+        }
+      ]
+    },
+    {
+      "id": "invalid-name-leading-digit",
+      "description": "A property name that converts to a Go identifier beginning with a digit is invalid.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "123value": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "123value": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "invalidName",
+          "path": "/valueSchema/properties/123value"
+        }
+      ]
+    },
+    {
+      "id": "name-collision-after-go-conversion",
+      "description": "Distinct property names that both convert to UserId must be rejected rather than suffixed.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "user-id": {
+              "type": "string"
+            },
+            "user_id": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "user-id": {
+              "isEmpty": "string"
+            },
+            "user_id": {
+              "isEmpty": "string"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "nameCollision",
+          "path": "/valueSchema/properties"
+        }
+      ]
+    },
+    {
+      "id": "unsafe-integer-schema-const",
+      "description": "Integer schema literals outside the JavaScript safe-integer range are rejected.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "integer",
+              "const": 9007199254740992
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "value": {
+              "isEmpty": "number"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "unsafeNumber",
+          "path": "/valueSchema/properties/value/const"
+        }
+      ]
+    },
+    {
+      "id": "malformed-tagged-union-discriminator-not-required",
+      "description": "A tagged-union discriminator must be required in every branch.",
+      "profile": {
+        "$schema": "https://spec.umpire.tools/profiles/json-schema/v1/profile.schema.json",
+        "profileVersion": 1,
+        "valueSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "choice": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "const": "run"
+                    },
+                    "command": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "command"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "const": "manual"
+                    },
+                    "instructions": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "instructions"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "umpire": {
+          "version": 1,
+          "fields": {
+            "choice": {
+              "isEmpty": "present"
+            }
+          },
+          "rules": []
+        }
+      },
+      "expectedDefinitionIssues": [
+        {
+          "code": "invalidDiscriminator",
+          "path": "/valueSchema/properties/choice/oneOf"
         }
       ]
     }

--- a/packages/json-schema/conformance/fixtures/avenor-workflow.json
+++ b/packages/json-schema/conformance/fixtures/avenor-workflow.json
@@ -434,7 +434,7 @@
     },
     {
       "id": "wrong-node-type-structural-issue",
-      "description": "Nodes property has wrong type (string instead of array). Structural validation catches this independently. Umpire availability shows nodes as satisfied: false for the string value (non-empty string is a present array-like value).",
+      "description": "Nodes property has wrong type (string instead of array). Structural validation catches this independently.",
       "values": {
         "nodes": "not-an-array",
         "title": "Broken"
@@ -451,66 +451,6 @@
             "path": "/nodes"
           }
         ]
-      },
-      "expectedAvailability": {
-        "nodes": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": true,
-          "reason": null,
-          "reasons": []
-        },
-        "edges": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "title": {
-          "enabled": true,
-          "satisfied": true,
-          "fair": true,
-          "required": true,
-          "reason": null,
-          "reasons": []
-        },
-        "workflowType": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "version": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "status": {
-          "enabled": false,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": "Status editing is disabled",
-          "reasons": [
-            "Status editing is disabled"
-          ]
-        },
-        "maxAttempts": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        }
       }
     },
     {
@@ -539,66 +479,6 @@
             "path": "/title"
           }
         ]
-      },
-      "expectedAvailability": {
-        "nodes": {
-          "enabled": true,
-          "satisfied": true,
-          "fair": true,
-          "required": true,
-          "reason": null,
-          "reasons": []
-        },
-        "edges": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "title": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": true,
-          "reason": null,
-          "reasons": []
-        },
-        "workflowType": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "version": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "status": {
-          "enabled": false,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": "Status editing is disabled",
-          "reasons": [
-            "Status editing is disabled"
-          ]
-        },
-        "maxAttempts": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        }
       }
     },
     {
@@ -713,7 +593,7 @@
     },
     {
       "id": "explicit-null-fails-type",
-      "description": "Explicit JSON null value fails type validation. Structural validation catches it even though Umpire would treat it as an absent-like value.",
+      "description": "Explicit JSON null value fails type validation.",
       "values": {
         "nodes": [
           {
@@ -739,66 +619,6 @@
             "path": "/workflowType"
           }
         ]
-      },
-      "expectedAvailability": {
-        "nodes": {
-          "enabled": true,
-          "satisfied": true,
-          "fair": true,
-          "required": true,
-          "reason": null,
-          "reasons": []
-        },
-        "edges": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "title": {
-          "enabled": true,
-          "satisfied": true,
-          "fair": true,
-          "required": true,
-          "reason": null,
-          "reasons": []
-        },
-        "workflowType": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "version": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "status": {
-          "enabled": false,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": "Status editing is disabled",
-          "reasons": [
-            "Status editing is disabled"
-          ]
-        },
-        "maxAttempts": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        }
       }
     },
     {
@@ -1207,7 +1027,7 @@
     },
     {
       "id": "empty-nodes-satisfied-false-structural-issue",
-      "description": "nodes is an empty array (fails minItems). Umpire reports satisfied: false for array isEmpty with empty array. Structural validation reports minItems.",
+      "description": "nodes is an empty array and fails minItems.",
       "values": {
         "nodes": [],
         "title": "Test"
@@ -1224,66 +1044,6 @@
             "path": "/nodes"
           }
         ]
-      },
-      "expectedAvailability": {
-        "nodes": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": true,
-          "reason": null,
-          "reasons": []
-        },
-        "edges": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "title": {
-          "enabled": true,
-          "satisfied": true,
-          "fair": true,
-          "required": true,
-          "reason": null,
-          "reasons": []
-        },
-        "workflowType": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "version": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        },
-        "status": {
-          "enabled": false,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": "Status editing is disabled",
-          "reasons": [
-            "Status editing is disabled"
-          ]
-        },
-        "maxAttempts": {
-          "enabled": true,
-          "satisfied": false,
-          "fair": true,
-          "required": false,
-          "reason": null,
-          "reasons": []
-        }
       }
     }
   ]

--- a/packages/json-schema/schemas/.synced-at-version
+++ b/packages/json-schema/schemas/.synced-at-version
@@ -1,5 +1,5 @@
 {
-  "version": "v1.1.0-rc.2",
-  "tarballSha256": "560184f267e4224f00dd5bed8a6a66bcafdb906153c80699c0f074ec30144240",
+  "version": "v1.1.0-rc.3",
+  "tarballSha256": "392aabcd711ab26df3a1e90b0789a23faf875a922c955445e05f3ccadff75d1c",
   "fixtureDigest": "79b48ddc7579ee0b5c923f5d35e4b1ab117eb10b52eb33487ee3de034c35ac76"
 }

--- a/packages/json-schema/src/compile.ts
+++ b/packages/json-schema/src/compile.ts
@@ -15,7 +15,7 @@ import type {
 import { DEFINITION_ISSUE_CODES } from './schema.js'
 import type { FieldStatus, InputValues } from '@umpire/core'
 import { PROFILE_META_SCHEMA, checkProfileConsistency } from './consistency.js'
-import { applyDiscriminators } from './discriminator.js'
+import { prepareValueSchema } from './discriminator.js'
 import { normalizeAjvErrors, suppressTypeDependents } from './issues.js'
 
 const C = DEFINITION_ISSUE_CODES
@@ -80,10 +80,21 @@ export function compileProfile<
   //    bare `oneOf` without `type: "object"` on the union node itself, which
   //    AJV's strictTypes rule would otherwise flag. Profile-definition
   //    rejection is owned by the closed-vocabulary + consistency checks.
-  const vsAjv = new Ajv({ allErrors: true, discriminator: true, strict: false })
+  const vsAjv = new Ajv({
+    allErrors: true,
+    discriminator: true,
+    strict: false,
+    strictNumbers: true,
+  })
+  vsAjv.addKeyword({
+    keyword: 'safeInteger',
+    type: 'number',
+    schemaType: 'boolean',
+    validate: (_schema: boolean, value: number) => Number.isSafeInteger(value),
+  })
   let valueValidate: ReturnType<typeof vsAjv.compile>
   try {
-    valueValidate = vsAjv.compile(applyDiscriminators(profile.valueSchema))
+    valueValidate = vsAjv.compile(prepareValueSchema(profile.valueSchema))
   } catch (err) {
     return {
       ok: false,

--- a/packages/json-schema/src/compile.ts
+++ b/packages/json-schema/src/compile.ts
@@ -90,7 +90,8 @@ export function compileProfile<
     keyword: 'safeInteger',
     type: 'number',
     schemaType: 'boolean',
-    validate: (_schema: boolean, value: number) => Number.isSafeInteger(value),
+    validate: (_schema: boolean, value: number) =>
+      !Number.isInteger(value) || Number.isSafeInteger(value),
   })
   let valueValidate: ReturnType<typeof vsAjv.compile>
   try {
@@ -195,12 +196,12 @@ function validateDefaults(
     if (ok) continue
     const errs = validate.errors ?? []
     const ownIssue = normalizeAjvErrors(errs, probe).some(
-      (i) => i.path === `/${name}`,
+      (i) => i.path === `/${escapePointerToken(name)}`,
     )
     if (ownIssue) {
       issues.push({
         code: C.INVALID_DEFAULT,
-        path: `/umpire/fields/${name}/default`,
+        path: `/umpire/fields/${escapePointerToken(name)}/default`,
         message: `Default ${JSON.stringify(fd.default)} does not validate against property schema`,
       })
     }
@@ -211,6 +212,10 @@ function validateDefaults(
 /**
  * Validate the basic shape of a profile document before full validation.
  */
+function escapePointerToken(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1')
+}
+
 function validateProfileShape(raw: unknown): ProfileDefinitionIssue[] {
   const issues: ProfileDefinitionIssue[] = []
 

--- a/packages/json-schema/src/consistency.ts
+++ b/packages/json-schema/src/consistency.ts
@@ -5,7 +5,6 @@ import { DEFINITION_ISSUE_CODES } from './schema.js'
 
 export { PROFILE_META_SCHEMA } from './profile-meta.js'
 
-// ── Closed profile v1 vocabulary ──
 const SUPPORTED = new Set([
   '$schema',
   '$defs',
@@ -40,6 +39,63 @@ const ALLOWED_TYPES = new Set([
 ])
 
 const SCALAR_TYPES = new Set(['string', 'number', 'integer', 'boolean'])
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER
+const C = DEFINITION_ISSUE_CODES
+
+const GO_KEYWORDS = new Set([
+  'break',
+  'default',
+  'func',
+  'interface',
+  'select',
+  'case',
+  'defer',
+  'go',
+  'map',
+  'struct',
+  'chan',
+  'else',
+  'goto',
+  'package',
+  'switch',
+  'const',
+  'fallthrough',
+  'if',
+  'range',
+  'type',
+  'continue',
+  'for',
+  'import',
+  'return',
+  'var',
+])
+
+const COMMON_KEYWORDS = new Set([
+  'type',
+  'title',
+  'description',
+  'enum',
+  'const',
+])
+
+const TYPE_KEYWORDS: Record<string, ReadonlySet<string>> = {
+  string: new Set(['minLength', 'maxLength']),
+  number: new Set([
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+  ]),
+  integer: new Set([
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+  ]),
+  boolean: new Set(),
+  array: new Set(['items', 'minItems', 'maxItems']),
+  object: new Set(['properties', 'required', 'additionalProperties']),
+}
 
 const IS_EMPTY_OK: Record<string, readonly string[]> = {
   string: ['string'],
@@ -50,7 +106,11 @@ const IS_EMPTY_OK: Record<string, readonly string[]> = {
   present: ['string', 'number', 'integer', 'boolean', 'array', 'object'],
 }
 
-const C = DEFINITION_ISSUE_CODES
+type WalkContext = {
+  root?: boolean
+  allowUntypedConst?: boolean
+  allowUntypedConstNames?: ReadonlySet<string>
+}
 
 function issue(
   code: string,
@@ -60,15 +120,32 @@ function issue(
   return { code, path, message }
 }
 
-// ── Entry point ──
-// eslint-disable-next-line complexity -- closed-vocabulary profile checks are a flat chain of independent guard checks over a finite keyword set
+/** Validate Profile v1 consistency and its closed, code-generatable vocabulary. */
 export function checkProfileConsistency(
   vs: Record<string, unknown>,
   umpire: UmpireJsonSchema,
 ): ProfileDefinitionIssue[] {
   const issues: ProfileDefinitionIssue[] = []
 
-  // 1. Dialect check
+  checkDialect(vs, issues)
+  checkRootShape(vs, issues)
+  checkFieldCorrespondence(vs, umpire, issues)
+
+  const defs = isPlainRecord(vs.$defs)
+    ? (vs.$defs as Record<string, unknown>)
+    : {}
+  walkSchema(vs, '/valueSchema', issues, defs, { root: true })
+  checkReferenceCycles(defs, issues)
+  checkCrossFieldCompatibility(vs, umpire, defs, issues)
+  checkGoNames(vs, umpire, issues)
+
+  return dedupeAndSortIssues(issues)
+}
+
+function checkDialect(
+  vs: Record<string, unknown>,
+  issues: ProfileDefinitionIssue[],
+): void {
   if (typeof vs.$schema !== 'string') {
     issues.push(
       issue(
@@ -86,12 +163,17 @@ export function checkProfileConsistency(
       ),
     )
   }
+}
 
-  // 2. Root shape
-  if (vs.type !== 'object')
+function checkRootShape(
+  vs: Record<string, unknown>,
+  issues: ProfileDefinitionIssue[],
+): void {
+  if (vs.type !== 'object') {
     issues.push(
       issue(C.INVALID_PROFILE, '/valueSchema', 'Root type must be "object"'),
     )
+  }
   if (
     !isPlainRecord(vs.properties) ||
     Object.keys(vs.properties).length === 0
@@ -100,422 +182,1053 @@ export function checkProfileConsistency(
       issue(
         C.INVALID_PROFILE,
         '/valueSchema',
-        'Must include a non-empty properties object',
+        'Root must include a non-empty properties object',
       ),
     )
   }
-  if (vs.additionalProperties !== false) {
+  if (vs.additionalProperties === undefined) {
     issues.push(
       issue(
         C.INVALID_PROFILE,
         '/valueSchema',
-        'Must declare additionalProperties: false at root',
+        'Root must declare additionalProperties: false',
+      ),
+    )
+  } else if (vs.additionalProperties !== false) {
+    issues.push(
+      issue(
+        C.INVALID_PROFILE,
+        '/valueSchema/additionalProperties',
+        'Root additionalProperties must be false',
       ),
     )
   }
+}
 
-  // 3. Field ↔ property correspondence
+function checkFieldCorrespondence(
+  vs: Record<string, unknown>,
+  umpire: UmpireJsonSchema,
+  issues: ProfileDefinitionIssue[],
+): void {
   const valueProps = isPlainRecord(vs.properties)
     ? Object.keys(vs.properties)
     : []
   const umpFields = Object.keys(umpire.fields ?? {})
-  const valSet = new Set(valueProps)
-  const umpSet = new Set(umpFields)
-  for (const f of umpFields)
-    if (!valSet.has(f))
-      issues.push(
-        issue(
-          C.FIELD_MISMATCH,
-          '/valueSchema',
-          `Umpire field "${f}" has no matching value schema property`,
-        ),
-      )
-  for (const p of valueProps)
-    if (!umpSet.has(p))
-      issues.push(
-        issue(
-          C.FIELD_MISMATCH,
-          '/valueSchema',
-          `Value schema property "${p}" has no matching Umpire field`,
-        ),
-      )
+  const valueNames = new Set(valueProps)
+  const umpireNames = new Set(umpFields)
 
-  // 5. isEmpty compatibility
-  if (isPlainRecord(vs.properties)) {
-    for (const [name, fd] of Object.entries(umpire.fields ?? {})) {
-      if (!fd.isEmpty) continue
-      const ps = vs.properties[name] as Record<string, unknown> | undefined
-      if (!ps) continue
-      const compat = IS_EMPTY_OK[fd.isEmpty]
-      if (compat && typeof ps.type === 'string' && !compat.includes(ps.type)) {
-        issues.push(
-          issue(
-            C.INCOMPATIBLE_IS_EMPTY,
-            `/umpire/fields/${name}`,
-            `isEmpty "${fd.isEmpty}" incompatible with schema type "${ps.type}"`,
-          ),
-        )
-      }
+  for (const name of umpFields) {
+    if (!valueNames.has(name)) {
+      issues.push(
+        issue(
+          C.FIELD_MISMATCH,
+          '/valueSchema',
+          `Umpire field "${name}" has no matching value schema property`,
+        ),
+      )
     }
   }
-
-  // 6. Root required references
-  if (Array.isArray(vs.required)) {
-    for (const r of vs.required)
-      if (typeof r === 'string' && !valSet.has(r)) {
-        issues.push(
-          issue(
-            C.INVALID_PROFILE,
-            '/valueSchema/required',
-            `Required property "${r}" not declared in properties`,
-          ),
-        )
-      }
+  for (const name of valueProps) {
+    if (!umpireNames.has(name)) {
+      issues.push(
+        issue(
+          C.FIELD_MISMATCH,
+          '/valueSchema',
+          `Value schema property "${name}" has no matching Umpire field`,
+        ),
+      )
+    }
   }
-
-  // 7. Closed-vocabulary walk. `activeDefs` tracks the $defs currently being
-  //    expanded from the root. Following references detects cycles at the
-  //    $defs level (the reported path is the definition closing the cycle)
-  //    and expands each referenced definition's vocabulary once.
-  const defs = isPlainRecord(vs.$defs)
-    ? (vs.$defs as Record<string, unknown>)
-    : {}
-  walk(vs, '/valueSchema', issues, [], defs)
-  return dedupeIssues(issues)
 }
 
-// A shared $defs can be expanded via several reference paths, so the same
-// definition issue can be reported more than once. Collapse to one issue per
-// (code, path).
-function dedupeIssues(
-  issues: ProfileDefinitionIssue[],
-): ProfileDefinitionIssue[] {
-  const seen = new Set<string>()
-  const out: ProfileDefinitionIssue[] = []
-  for (const i of issues) {
-    const key = `${i.code}|${i.path}`
-    if (seen.has(key)) continue
-    seen.add(key)
-    out.push(i)
-  }
-  return out
-}
-
-// ── Recursive schema walk ──
-// eslint-disable-next-line complexity -- depth-first walk over a closed finite JSON Schema vocabulary with cycle detection
-function walk(
+// eslint-disable-next-line complexity -- recursive validation over a deliberately closed schema vocabulary
+function walkSchema(
   node: unknown,
   ptr: string,
   issues: ProfileDefinitionIssue[],
-  activeDefs: string[],
   defs: Record<string, unknown>,
+  context: WalkContext = {},
 ): void {
-  if (!isPlainRecord(node)) return
+  if (!isPlainRecord(node)) {
+    issues.push(issue(C.INVALID_PROFILE, ptr, 'Schema node must be an object'))
+    return
+  }
 
-  // $ref: validate form, then follow the reference to expand its target.
-  if (typeof node.$ref === 'string') {
-    const ref = node.$ref
-    const isLocalDef = /^#\/\$defs\//.test(ref)
-    if (!isLocalDef) {
+  let hasUnsupportedKeyword = false
+  for (const key of Object.keys(node)) {
+    const rootOnly = (key === '$schema' || key === '$defs') && !context.root
+    if (!SUPPORTED.has(key) || rootOnly) {
+      hasUnsupportedKeyword = true
       issues.push(
         issue(
-          C.INVALID_REFERENCE,
-          `${ptr}/\$ref`,
-          `Only #/\$defs/<name> references are supported, got "${ref}"`,
+          C.UNSUPPORTED_KEYWORD,
+          `${ptr}/${escapePointerToken(key)}`,
+          `Unsupported keyword "${key}"`,
         ),
       )
-      return
     }
-    // Reject sibling keywords
-    const sk = Object.keys(node).filter((k) => k !== '$ref')
-    if (sk.length)
+  }
+
+  checkAnnotations(node, ptr, issues)
+
+  if ('$ref' in node) {
+    checkReference(node, ptr, defs, issues)
+    return
+  }
+
+  if ('oneOf' in node) {
+    if (context.root) {
       issues.push(
         issue(
-          C.INVALID_REFERENCE,
+          C.UNSUPPORTED_KEYWORD,
+          `${ptr}/oneOf`,
+          'Root unions are not supported',
+        ),
+      )
+    } else {
+      checkTaggedUnion(node, ptr, issues, defs)
+      return
+    }
+  }
+
+  if (
+    context.allowUntypedConst &&
+    !('type' in node) &&
+    isConstOnlySchema(node)
+  ) {
+    if (typeof node.const !== 'string') {
+      issues.push(
+        issue(
+          C.INVALID_DISCRIMINATOR,
           ptr,
-          `$ref must not have sibling keywords: ${sk.join(', ')}`,
+          'A discriminator const must be a string',
         ),
       )
+    }
+    return
+  }
 
-    const name = ref.slice('#/$defs/'.length)
-    if (activeDefs.includes(name)) {
+  if (!('type' in node)) {
+    if (!hasUnsupportedKeyword) {
       issues.push(
-        issue(
-          C.REFERENCE_CYCLE,
-          `/valueSchema/\$defs/${activeDefs[activeDefs.length - 1]}`,
-          `Circular reference "${ref}"`,
-        ),
+        issue(C.INVALID_PROFILE, ptr, 'Schema must declare an explicit type'),
       )
-      return
     }
-    const target = defs[name]
-    if (target === undefined) {
-      issues.push(
-        issue(
-          C.INVALID_REFERENCE,
-          `${ptr}/\$ref`,
-          `Unresolved $defs reference "${ref}"`,
-        ),
-      )
-      return
-    }
-    walk(
-      target,
-      `/valueSchema/\$defs/${name}`,
-      issues,
-      [...activeDefs, name],
-      defs,
+    return
+  }
+
+  if (typeof node.type !== 'string' || !ALLOWED_TYPES.has(node.type)) {
+    issues.push(
+      issue(
+        C.INVALID_PROFILE,
+        `${ptr}/type`,
+        'Schema type must be one supported scalar, array, or object type',
+      ),
     )
     return
   }
 
-  // Unsupported keyword check
-  for (const k of Object.keys(node)) {
-    if (!SUPPORTED.has(k)) {
+  checkKeywordPlacement(node, node.type, ptr, issues, context.root === true)
+  checkEnumAndConst(node, node.type, ptr, issues)
+  checkNumericKeywords(node, node.type, ptr, issues)
+
+  if (node.type === 'object') {
+    walkObject(node, ptr, issues, defs, context)
+  } else if (node.type === 'array') {
+    walkArray(node, ptr, issues, defs)
+  }
+}
+
+function checkAnnotations(
+  node: Record<string, unknown>,
+  ptr: string,
+  issues: ProfileDefinitionIssue[],
+): void {
+  for (const key of ['title', 'description'] as const) {
+    if (key in node && typeof node[key] !== 'string') {
+      issues.push(
+        issue(C.INVALID_PROFILE, `${ptr}/${key}`, `${key} must be a string`),
+      )
+    }
+  }
+}
+
+function checkReference(
+  node: Record<string, unknown>,
+  ptr: string,
+  defs: Record<string, unknown>,
+  issues: ProfileDefinitionIssue[],
+): void {
+  const ref = node.$ref
+  const name = typeof ref === 'string' ? localDefinitionName(ref) : null
+  if (name === null || !(name in defs)) {
+    issues.push(
+      issue(
+        C.INVALID_REFERENCE,
+        `${ptr}/$ref`,
+        `Reference ${JSON.stringify(ref)} is not a resolvable root $defs reference`,
+      ),
+    )
+  }
+
+  if (Object.keys(node).some((key) => key !== '$ref')) {
+    issues.push(
+      issue(C.INVALID_REFERENCE, ptr, '$ref must not have sibling keywords'),
+    )
+  }
+}
+
+function checkKeywordPlacement(
+  node: Record<string, unknown>,
+  schemaType: string,
+  ptr: string,
+  issues: ProfileDefinitionIssue[],
+  root: boolean,
+): void {
+  const typeKeywords = TYPE_KEYWORDS[schemaType]
+  for (const key of Object.keys(node)) {
+    if (!SUPPORTED.has(key)) continue
+    if (COMMON_KEYWORDS.has(key) || typeKeywords.has(key)) continue
+    if (root && (key === '$schema' || key === '$defs')) continue
+    if (key === 'oneOf') continue
+    issues.push(
+      issue(
+        C.INVALID_PROFILE,
+        `${ptr}/${escapePointerToken(key)}`,
+        `Keyword "${key}" is not valid for type "${schemaType}"`,
+      ),
+    )
+  }
+}
+
+// eslint-disable-next-line complexity -- strict object invariants are independent checks over one closed schema shape
+function walkObject(
+  node: Record<string, unknown>,
+  ptr: string,
+  issues: ProfileDefinitionIssue[],
+  defs: Record<string, unknown>,
+  context: WalkContext,
+): void {
+  if (!isPlainRecord(node.properties)) {
+    issues.push(
+      issue(C.INVALID_PROFILE, ptr, 'Object schemas require properties'),
+    )
+    return
+  }
+
+  if (node.additionalProperties === undefined) {
+    issues.push(
+      issue(
+        C.INVALID_PROFILE,
+        ptr,
+        'Object schemas must declare additionalProperties: false',
+      ),
+    )
+  } else if (node.additionalProperties !== false) {
+    issues.push(
+      issue(
+        C.INVALID_PROFILE,
+        `${ptr}/additionalProperties`,
+        'Object schemas must set additionalProperties to false',
+      ),
+    )
+  }
+
+  const properties = node.properties
+  if ('required' in node) {
+    const required = node.required
+    const valid =
+      Array.isArray(required) &&
+      required.every((name) => typeof name === 'string') &&
+      new Set(required).size === required.length &&
+      required.every((name) => name in properties)
+    if (!valid) {
       issues.push(
         issue(
-          C.UNSUPPORTED_KEYWORD,
-          `${ptr}/${k}`,
-          `Unsupported keyword "${k}"`,
+          C.INVALID_PROFILE,
+          `${ptr}/required`,
+          'required must contain unique names declared in properties',
         ),
       )
     }
   }
 
-  // Type check
-  if (node.type !== undefined) {
-    if (typeof node.type === 'string' && !ALLOWED_TYPES.has(node.type)) {
-      issues.push(
-        issue(
-          C.UNSUPPORTED_KEYWORD,
-          `${ptr}/type`,
-          `Unsupported type "${node.type}"`,
-        ),
-      )
-    }
-    if (Array.isArray(node.type)) {
-      issues.push(
-        issue(
-          C.UNSUPPORTED_KEYWORD,
-          `${ptr}/type`,
-          'Nullable type arrays not supported',
-        ),
-      )
-    }
+  for (const [name, child] of Object.entries(properties)) {
+    const allowUntypedConst =
+      context.allowUntypedConstNames?.has(name) === true &&
+      isPlainRecord(child) &&
+      'const' in child
+    walkSchema(
+      child,
+      `${ptr}/properties/${escapePointerToken(name)}`,
+      issues,
+      defs,
+      { allowUntypedConst },
+    )
   }
 
-  // Enum/const value compatibility
-  if (
-    Array.isArray(node.enum) &&
-    typeof node.type === 'string' &&
-    SCALAR_TYPES.has(node.type)
-  ) {
-    for (const v of node.enum)
-      if (!compat(v, node.type)) {
-        issues.push(
-          issue(
-            C.INVALID_PROFILE,
-            `${ptr}/enum`,
-            `Enum value ${JSON.stringify(v)} incompatible with type "${node.type}"`,
-          ),
+  if (context.root && '$defs' in node) {
+    if (!isPlainRecord(node.$defs)) {
+      issues.push(
+        issue(C.INVALID_PROFILE, `${ptr}/$defs`, '$defs must be an object'),
+      )
+    } else {
+      for (const [name, child] of Object.entries(node.$defs)) {
+        walkSchema(
+          child,
+          `${ptr}/$defs/${escapePointerToken(name)}`,
+          issues,
+          defs,
         )
       }
+    }
   }
-  if (
-    node.const !== undefined &&
-    typeof node.type === 'string' &&
-    SCALAR_TYPES.has(node.type)
-  ) {
-    if (!compat(node.const, node.type)) {
+}
+
+function walkArray(
+  node: Record<string, unknown>,
+  ptr: string,
+  issues: ProfileDefinitionIssue[],
+  defs: Record<string, unknown>,
+): void {
+  if (!('items' in node)) {
+    issues.push(
+      issue(C.INVALID_PROFILE, ptr, 'Array schemas must declare items'),
+    )
+    return
+  }
+  if (!isPlainRecord(node.items)) {
+    issues.push(
+      issue(
+        C.INVALID_PROFILE,
+        `${ptr}/items`,
+        'Array items must be one homogeneous schema object',
+      ),
+    )
+    return
+  }
+  walkSchema(node.items, `${ptr}/items`, issues, defs)
+}
+
+function checkTaggedUnion(
+  node: Record<string, unknown>,
+  ptr: string,
+  issues: ProfileDefinitionIssue[],
+  defs: Record<string, unknown>,
+): void {
+  const oneOfPath = `${ptr}/oneOf`
+  const branches = node.oneOf
+  let invalid =
+    !Array.isArray(branches) ||
+    branches.length === 0 ||
+    Object.keys(node).some(
+      (key) => key !== 'oneOf' && key !== 'title' && key !== 'description',
+    )
+  let discriminator: string | null = null
+
+  if (!Array.isArray(branches)) {
+    issues.push(
+      issue(
+        C.INVALID_DISCRIMINATOR,
+        oneOfPath,
+        'oneOf must be a non-empty tagged-union branch array',
+      ),
+    )
+    return
+  }
+
+  const derived = deriveTaggedDiscriminator(branches)
+  if (derived) discriminator = derived.name
+  else invalid = true
+
+  if (invalid || discriminator === null) {
+    issues.push(
+      issue(
+        C.INVALID_DISCRIMINATOR,
+        oneOfPath,
+        'Branches must share one required discriminator with distinct string const values',
+      ),
+    )
+  }
+
+  for (let index = 0; index < branches.length; index++) {
+    walkSchema(branches[index], `${oneOfPath}/${index}`, issues, defs, {
+      allowUntypedConstNames:
+        discriminator === null ? new Set() : new Set([discriminator]),
+    })
+  }
+}
+
+function checkEnumAndConst(
+  node: Record<string, unknown>,
+  schemaType: string,
+  ptr: string,
+  issues: ProfileDefinitionIssue[],
+): void {
+  if ('enum' in node) {
+    const values = node.enum
+    const valid =
+      SCALAR_TYPES.has(schemaType) &&
+      Array.isArray(values) &&
+      values.length > 0 &&
+      values.every((value) => valueMatchesType(value, schemaType)) &&
+      new Set(values).size === values.length
+    if (!valid) {
+      issues.push(
+        issue(
+          C.INVALID_PROFILE,
+          `${ptr}/enum`,
+          'enum must be non-empty, unique, and compatible with its explicit scalar type',
+        ),
+      )
+    }
+    if (
+      Array.isArray(values) &&
+      values.some((value) => isUnsafeValue(value, schemaType))
+    ) {
+      issues.push(
+        issue(
+          C.UNSAFE_NUMBER,
+          `${ptr}/enum`,
+          'enum contains a number outside Profile v1 numeric limits',
+        ),
+      )
+    }
+  }
+
+  if ('const' in node) {
+    if (
+      !SCALAR_TYPES.has(schemaType) ||
+      !valueMatchesType(node.const, schemaType)
+    ) {
       issues.push(
         issue(
           C.INVALID_PROFILE,
           `${ptr}/const`,
-          `Const value ${JSON.stringify(node.const)} incompatible with type "${node.type}"`,
+          'const must be compatible with its explicit scalar type',
+        ),
+      )
+    }
+    if (isUnsafeValue(node.const, schemaType)) {
+      issues.push(
+        issue(
+          C.UNSAFE_NUMBER,
+          `${ptr}/const`,
+          'const is outside Profile v1 numeric limits',
         ),
       )
     }
   }
-
-  // Array without items
-  if (node.type === 'array' && node.items === undefined) {
-    issues.push(
-      issue(
-        C.UNSUPPORTED_KEYWORD,
-        `${ptr}/items`,
-        'Arrays must declare a homogeneous items schema',
-      ),
-    )
-  }
-  if (Array.isArray(node.items)) {
-    issues.push(
-      issue(
-        C.UNSUPPORTED_KEYWORD,
-        `${ptr}/items`,
-        'Tuple arrays not supported',
-      ),
-    )
-  }
-
-  // oneOf tagged-union validation
-  if (Array.isArray(node.oneOf)) {
-    validateOneOf(node.oneOf as Record<string, unknown>[], ptr, issues)
-  }
-
-  // Recurse
-  if (isPlainRecord(node.properties)) {
-    for (const k of Object.keys(node.properties)) {
-      walk(
-        node.properties[k],
-        `${ptr}/properties/${k}`,
-        issues,
-        activeDefs,
-        defs,
-      )
-    }
-  }
-  if (isPlainRecord(node.items)) {
-    walk(node.items, `${ptr}/items`, issues, activeDefs, defs)
-  }
-  if (isPlainRecord(node.$defs)) {
-    for (const k of Object.keys(node.$defs)) {
-      walk(node.$defs[k], `/valueSchema/\$defs/${k}`, issues, [k], defs)
-    }
-  }
-  if (Array.isArray(node.oneOf)) {
-    for (let i = 0; i < node.oneOf.length; i++) {
-      walk(node.oneOf[i], `${ptr}/oneOf/${i}`, issues, activeDefs, defs)
-    }
-  }
 }
 
-// ── Tagged-union validation (single pass) ──
-// eslint-disable-next-line complexity -- single-pass tagged-union shape validation
-function validateOneOf(
-  branches: Record<string, unknown>[],
+function checkNumericKeywords(
+  node: Record<string, unknown>,
+  schemaType: string,
   ptr: string,
   issues: ProfileDefinitionIssue[],
 ): void {
-  let discName: string | null = null
-  const seenVals = new Set<unknown>()
-
-  for (let i = 0; i < branches.length; i++) {
-    const b = branches[i]
-    if (!isPlainRecord(b)) {
+  for (const key of ['minItems', 'maxItems', 'minLength', 'maxLength']) {
+    if (!(key in node)) continue
+    const value = node[key]
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
       issues.push(
         issue(
           C.INVALID_PROFILE,
-          `${ptr}/oneOf/${i}`,
-          `Branch ${i} must be an object schema`,
+          `${ptr}/${key}`,
+          `${key} must be a non-negative integer`,
         ),
       )
-      continue
-    }
-    if (b.type !== 'object') {
+    } else if (!Number.isSafeInteger(value)) {
       issues.push(
         issue(
-          C.INVALID_DISCRIMINATOR,
-          `${ptr}/oneOf/${i}/type`,
-          `Branch ${i} must be object for tagged unions`,
-        ),
-      )
-      continue
-    }
-
-    // Find the discriminator const property
-    const props = isPlainRecord(b.properties)
-      ? (b.properties as Record<string, unknown>)
-      : {}
-    let foundDisc = false
-    for (const [pk, pv] of Object.entries(props)) {
-      if (!isPlainRecord(pv as Record<string, unknown>)) continue
-      const cv = (pv as Record<string, unknown>).const
-      if (cv === undefined) continue
-
-      // Profile v1 tagged unions require a distinct string discriminator const.
-      if (typeof cv !== 'string') {
-        issues.push(
-          issue(
-            C.INVALID_DISCRIMINATOR,
-            `${ptr}/oneOf`,
-            `Discriminator const must be a string (branch ${i}, property "${pk}")`,
-          ),
-        )
-      }
-
-      if (discName === null) discName = pk
-      if (pk !== discName) continue // skip if this branch uses a different discriminator — caught below
-      if (seenVals.has(cv)) {
-        issues.push(
-          issue(
-            C.INVALID_DISCRIMINATOR,
-            `${ptr}/oneOf/${i}`,
-            `Duplicate discriminator const ${JSON.stringify(cv)}`,
-          ),
-        )
-      }
-      seenVals.add(cv)
-      foundDisc = true
-
-      // Check it's in required
-      const req = Array.isArray(b.required) ? (b.required as string[]) : []
-      if (!req.includes(pk)) {
-        issues.push(
-          issue(
-            C.INVALID_DISCRIMINATOR,
-            `${ptr}/oneOf/${i}/required`,
-            `Branch ${i} must include "${pk}" in required`,
-          ),
-        )
-      }
-    }
-    if (!foundDisc) {
-      issues.push(
-        issue(
-          C.INVALID_DISCRIMINATOR,
-          `${ptr}/oneOf/${i}`,
-          `Branch ${i} must have a discriminator property with const`,
+          C.UNSAFE_NUMBER,
+          `${ptr}/${key}`,
+          `${key} must be a safe integer`,
         ),
       )
     }
   }
 
-  // Check uniform discriminator name
-  let actualDisc: string | null = null
-  for (const b of branches) {
-    if (!isPlainRecord(b)) continue
-    const props = isPlainRecord(b.properties)
-      ? (b.properties as Record<string, unknown>)
-      : {}
-    for (const [pk, pv] of Object.entries(props)) {
-      if (
-        isPlainRecord(pv as Record<string, unknown>) &&
-        (pv as Record<string, unknown>).const !== undefined
-      ) {
-        if (actualDisc === null) actualDisc = pk
-        else if (pk !== actualDisc) {
-          issues.push(
-            issue(
-              C.INVALID_DISCRIMINATOR,
-              `${ptr}/oneOf`,
-              `Branches must use the same discriminator property. Found "${actualDisc}" and "${pk}"`,
-            ),
-          )
-          return // suppress duplicate messages
-        }
-      }
+  for (const key of [
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+  ]) {
+    if (!(key in node)) continue
+    const value = node[key]
+    const unsafe =
+      typeof value !== 'number' ||
+      !Number.isFinite(value) ||
+      (schemaType === 'integer' && Math.abs(value) > MAX_SAFE_INTEGER)
+    if (unsafe) {
+      issues.push(
+        issue(
+          C.UNSAFE_NUMBER,
+          `${ptr}/${key}`,
+          `${key} is outside Profile v1 numeric limits`,
+        ),
+      )
     }
   }
 }
 
-function compat(val: unknown, type: string): boolean {
-  return type === 'string'
-    ? typeof val === 'string'
-    : type === 'number'
-      ? typeof val === 'number' && Number.isFinite(val)
-      : type === 'integer'
-        ? typeof val === 'number' && Number.isInteger(val)
-        : type === 'boolean'
-          ? typeof val === 'boolean'
-          : false
+function valueMatchesType(value: unknown, schemaType: string): boolean {
+  switch (schemaType) {
+    case 'string':
+      return typeof value === 'string'
+    case 'boolean':
+      return typeof value === 'boolean'
+    case 'number':
+      return typeof value === 'number'
+    case 'integer':
+      return (
+        typeof value === 'number' &&
+        (!Number.isFinite(value) || Number.isInteger(value))
+      )
+    default:
+      return false
+  }
+}
+
+function isUnsafeValue(value: unknown, schemaType: string): boolean {
+  if (typeof value !== 'number') return false
+  if (!Number.isFinite(value)) return true
+  return schemaType === 'integer' && !Number.isSafeInteger(value)
+}
+
+function checkCrossFieldCompatibility(
+  vs: Record<string, unknown>,
+  umpire: UmpireJsonSchema,
+  defs: Record<string, unknown>,
+  issues: ProfileDefinitionIssue[],
+): void {
+  if (!isPlainRecord(vs.properties)) return
+
+  for (const [name, field] of Object.entries(umpire.fields ?? {})) {
+    const propertySchema = vs.properties[name]
+    const schemaType = resolveSchemaType(propertySchema, defs)
+    if (field.isEmpty) {
+      const compatible = IS_EMPTY_OK[field.isEmpty]
+      if (schemaType && compatible && !compatible.includes(schemaType)) {
+        issues.push(
+          issue(
+            C.INCOMPATIBLE_IS_EMPTY,
+            `/umpire/fields/${escapePointerToken(name)}`,
+            `isEmpty "${field.isEmpty}" is incompatible with schema type "${schemaType}"`,
+          ),
+        )
+      }
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(field, 'default') &&
+      typeof field.default === 'number' &&
+      ((!Number.isFinite(field.default) &&
+        (schemaType === 'number' || schemaType === 'integer')) ||
+        (schemaType === 'integer' && !Number.isSafeInteger(field.default)))
+    ) {
+      issues.push(
+        issue(
+          C.INVALID_DEFAULT,
+          `/umpire/fields/${escapePointerToken(name)}/default`,
+          'Default is outside Profile v1 numeric limits',
+        ),
+      )
+    }
+  }
+}
+
+function resolveSchemaType(
+  raw: unknown,
+  defs: Record<string, unknown>,
+): string | undefined {
+  const seen = new Set<string>()
+  let node = raw
+  while (isPlainRecord(node)) {
+    if (typeof node.type === 'string') return node.type
+    if (typeof node.$ref !== 'string') return undefined
+    const name = localDefinitionName(node.$ref)
+    if (name === null || seen.has(name)) return undefined
+    seen.add(name)
+    node = defs[name]
+  }
+  return undefined
+}
+
+function checkReferenceCycles(
+  defs: Record<string, unknown>,
+  issues: ProfileDefinitionIssue[],
+): void {
+  const graph = new Map<string, string[]>()
+  for (const name of Object.keys(defs).sort()) {
+    graph.set(
+      name,
+      collectReferences(defs[name]).filter((ref) => ref in defs),
+    )
+  }
+
+  const state = new Map<string, 'active' | 'done'>()
+  const reported = new Set<string>()
+  const visit = (name: string): void => {
+    state.set(name, 'active')
+    for (const target of [...(graph.get(name) ?? [])].sort()) {
+      if (state.get(target) === 'active') {
+        if (!reported.has(name)) {
+          reported.add(name)
+          issues.push(
+            issue(
+              C.REFERENCE_CYCLE,
+              `/valueSchema/$defs/${escapePointerToken(name)}`,
+              `Definition "${name}" closes a reference cycle`,
+            ),
+          )
+        }
+      } else if (state.get(target) !== 'done') {
+        visit(target)
+      }
+    }
+    state.set(name, 'done')
+  }
+
+  for (const name of [...graph.keys()].sort()) {
+    if (!state.has(name)) visit(name)
+  }
+}
+
+function collectReferences(node: unknown): string[] {
+  if (Array.isArray(node)) return node.flatMap(collectReferences)
+  if (!isPlainRecord(node)) return []
+
+  const refs: string[] = []
+  if (typeof node.$ref === 'string') {
+    const name = localDefinitionName(node.$ref)
+    if (name !== null) refs.push(name)
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key !== '$ref') refs.push(...collectReferences(value))
+  }
+  return refs
+}
+
+function localDefinitionName(ref: string): string | null {
+  const prefix = '#/$defs/'
+  if (!ref.startsWith(prefix)) return null
+  const token = ref.slice(prefix.length)
+  if (!token || token.includes('/')) return null
+  try {
+    return unescapePointerToken(token)
+  } catch {
+    return null
+  }
+}
+
+function unescapePointerToken(token: string): string {
+  let out = ''
+  for (let index = 0; index < token.length; index++) {
+    const char = token[index]
+    if (char !== '~') {
+      out += char
+      continue
+    }
+    const escaped = token[++index]
+    if (escaped === '0') out += '~'
+    else if (escaped === '1') out += '/'
+    else throw new Error('Invalid RFC 6901 escape')
+  }
+  return out
+}
+
+function isConstOnlySchema(node: Record<string, unknown>): boolean {
+  return Object.keys(node).every((key) =>
+    ['const', 'title', 'description'].includes(key),
+  )
+}
+
+function escapePointerToken(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1')
+}
+
+function dedupeAndSortIssues(
+  issues: ProfileDefinitionIssue[],
+): ProfileDefinitionIssue[] {
+  const byKey = new Map<string, ProfileDefinitionIssue>()
+  for (const current of issues) {
+    const key = `${current.code}|${current.path}`
+    if (!byKey.has(key)) byKey.set(key, current)
+  }
+  return [...byKey.values()].sort(
+    (left, right) =>
+      left.path.localeCompare(right.path) ||
+      left.code.localeCompare(right.code),
+  )
+}
+
+// ---- Go code-generation name audit ----
+
+function checkGoNames(
+  vs: Record<string, unknown>,
+  umpire: UmpireJsonSchema,
+  issues: ProfileDefinitionIssue[],
+): void {
+  // `Schema` is a neutral stand-in for the caller's configured prefix. Every
+  // compared package symbol carries the same prefix, so collision outcomes do
+  // not depend on the eventual SchemaName.
+  const packageSymbols = new GeneratedSymbolTable(issues)
+  for (const helper of [
+    'Schema',
+    'SchemaFields',
+    'SchemaConditions',
+    'SchemaAvailability',
+    'SchemaStructuralIssue',
+    'SchemaStructuralError',
+    'ValidateSchemaJSON',
+    'DecodeSchema',
+  ]) {
+    packageSymbols.reserve(helper)
+  }
+
+  if (isPlainRecord(vs.properties)) {
+    checkNameCollection(
+      Object.keys(vs.properties),
+      '/valueSchema/properties',
+      issues,
+    )
+    walkGeneratedNames(
+      vs,
+      'SchemaFields',
+      '/valueSchema',
+      issues,
+      packageSymbols,
+      { root: true, ownerDeclared: true },
+    )
+  }
+
+  if (isPlainRecord(vs.$defs)) {
+    checkNameCollection(Object.keys(vs.$defs), '/valueSchema/$defs', issues)
+    for (const [name, schema] of Object.entries(vs.$defs)) {
+      const owner = `Schema${goFieldName(name)}`
+      packageSymbols.add(
+        owner,
+        `/valueSchema/$defs/${escapePointerToken(name)}`,
+      )
+      walkGeneratedNames(
+        schema,
+        owner,
+        `/valueSchema/$defs/${escapePointerToken(name)}`,
+        issues,
+        packageSymbols,
+        { ownerDeclared: true },
+      )
+    }
+  }
+
+  if (isPlainRecord(umpire.conditions)) {
+    checkNameCollection(
+      Object.keys(umpire.conditions),
+      '/umpire/conditions',
+      issues,
+    )
+  }
+  checkRuleNames(umpire.rules, issues, packageSymbols)
+}
+
+// eslint-disable-next-line complexity -- recursively inventories each supported generated symbol category
+function walkGeneratedNames(
+  node: unknown,
+  owner: string,
+  ptr: string,
+  issues: ProfileDefinitionIssue[],
+  symbols: GeneratedSymbolTable,
+  context: { root?: boolean; ownerDeclared?: boolean } = {},
+): void {
+  if (!isPlainRecord(node) || '$ref' in node) return
+
+  if (Array.isArray(node.enum)) {
+    const enumType = context.ownerDeclared ? owner : `${owner}Value`
+    if (!context.ownerDeclared) symbols.add(enumType, `${ptr}/enum`)
+    const constantNames = node.enum.map((value, index) =>
+      enumConstantName(value, index),
+    )
+    checkConvertedValues(constantNames, `${ptr}/enum`, issues)
+    for (const name of constantNames) {
+      symbols.add(`${enumType}${goFieldName(name)}`, `${ptr}/enum`)
+    }
+  }
+
+  if (Array.isArray(node.oneOf)) {
+    const unionType = context.ownerDeclared ? owner : `${owner}Value`
+    if (!context.ownerDeclared) symbols.add(unionType, `${ptr}/oneOf`)
+    const values = discriminatorValues(node.oneOf)
+    checkConvertedValues(values, `${ptr}/oneOf`, issues)
+    for (const value of values) {
+      symbols.add(`${unionType}${goFieldName(value)}`, `${ptr}/oneOf`)
+    }
+    for (let index = 0; index < node.oneOf.length; index++) {
+      walkGeneratedNames(
+        node.oneOf[index],
+        `${unionType}${goFieldName(values[index] ?? `Variant${index + 1}`)}`,
+        `${ptr}/oneOf/${index}`,
+        issues,
+        symbols,
+        { ownerDeclared: true },
+      )
+    }
+    return
+  }
+
+  if (node.type === 'object' && isPlainRecord(node.properties)) {
+    checkNameCollection(
+      Object.keys(node.properties),
+      `${ptr}/properties`,
+      issues,
+    )
+    for (const [name, child] of Object.entries(node.properties)) {
+      const childPtr = `${ptr}/properties/${escapePointerToken(name)}`
+      const childOwner = `${owner}${goFieldName(name)}`
+      if (isGeneratedNamedSchema(child)) symbols.add(childOwner, childPtr)
+      walkGeneratedNames(child, childOwner, childPtr, issues, symbols, {
+        ownerDeclared: isGeneratedNamedSchema(child),
+      })
+    }
+  }
+
+  if (node.type === 'array' && isPlainRecord(node.items)) {
+    const itemOwner = `${owner}Item`
+    if (isGeneratedNamedSchema(node.items))
+      symbols.add(itemOwner, `${ptr}/items`)
+    walkGeneratedNames(node.items, itemOwner, `${ptr}/items`, issues, symbols, {
+      ownerDeclared: isGeneratedNamedSchema(node.items),
+    })
+  }
+
+  if (context.root && isPlainRecord(node.$defs)) {
+    // Root definitions are handled once above so their package symbols use the
+    // documented Schema+DefName owner rather than the property traversal owner.
+  }
+}
+
+function isGeneratedNamedSchema(node: unknown): boolean {
+  return isPlainRecord(node) && node.type === 'object'
+}
+
+function deriveTaggedDiscriminator(
+  branches: unknown[],
+): { name: string; values: string[] } | null {
+  const branchCandidates: Array<Map<string, string>> = []
+  for (const branch of branches) {
+    if (
+      !isPlainRecord(branch) ||
+      branch.type !== 'object' ||
+      !isPlainRecord(branch.properties) ||
+      !Array.isArray(branch.required)
+    ) {
+      return null
+    }
+    const required = new Set(
+      branch.required.filter(
+        (name): name is string => typeof name === 'string',
+      ),
+    )
+    const candidates = new Map<string, string>()
+    for (const [name, schema] of Object.entries(branch.properties)) {
+      if (
+        required.has(name) &&
+        isPlainRecord(schema) &&
+        typeof schema.const === 'string'
+      ) {
+        candidates.set(name, schema.const)
+      }
+    }
+    branchCandidates.push(candidates)
+  }
+
+  const names = [...(branchCandidates[0]?.keys() ?? [])].filter((name) => {
+    const values = branchCandidates.map((candidates) => candidates.get(name))
+    return (
+      values.every((value): value is string => value !== undefined) &&
+      new Set(values).size === branches.length
+    )
+  })
+  if (names.length !== 1) return null
+  return {
+    name: names[0],
+    values: branchCandidates.map((candidates) => candidates.get(names[0])!),
+  }
+}
+
+function discriminatorValues(branches: unknown[]): string[] {
+  return deriveTaggedDiscriminator(branches)?.values ?? []
+}
+
+function enumConstantName(value: unknown, index: number): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'boolean') return value ? 'True' : 'False'
+  return `Value${index + 1}`
+}
+
+function checkRuleNames(
+  rules: UmpireJsonSchema['rules'],
+  issues: ProfileDefinitionIssue[],
+  symbols: GeneratedSymbolTable,
+  prefix = '/umpire/rules',
+): void {
+  const groups: string[] = []
+  for (let index = 0; index < rules.length; index++) {
+    const rule = rules[index]
+    const ptr = `${prefix}/${index}`
+    if (rule.type === 'oneOf' || rule.type === 'eitherOf') {
+      groups.push(rule.group)
+      checkSingleGoName(rule.group, `${ptr}/group`, issues)
+      const branches = Object.keys(rule.branches)
+      checkNameCollection(branches, `${ptr}/branches`, issues)
+      const groupType = `Schema${goFieldName(rule.group)}Branch`
+      symbols.add(groupType, `${ptr}/group`)
+      for (const branch of branches) {
+        symbols.add(
+          `${groupType}${goFieldName(branch)}`,
+          `${ptr}/branches/${escapePointerToken(branch)}`,
+        )
+      }
+      if (rule.type === 'eitherOf') {
+        for (const [branch, branchRules] of Object.entries(rule.branches)) {
+          checkRuleNames(
+            branchRules,
+            issues,
+            symbols,
+            `${ptr}/branches/${escapePointerToken(branch)}`,
+          )
+        }
+      }
+    } else if (rule.type === 'anyOf') {
+      checkRuleNames(rule.rules, issues, symbols, `${ptr}/rules`)
+    }
+  }
+  checkConvertedValues(groups, prefix, issues)
+}
+
+function checkNameCollection(
+  names: string[],
+  containerPath: string,
+  issues: ProfileDefinitionIssue[],
+): void {
+  const converted = new Map<string, string>()
+  for (const name of names) {
+    const itemPath = `${containerPath}/${escapePointerToken(name)}`
+    const goName = checkSingleGoName(name, itemPath, issues)
+    if (!goName) continue
+    const prior = converted.get(goName)
+    if (prior !== undefined && prior !== name) {
+      issues.push(
+        issue(
+          C.NAME_COLLISION,
+          containerPath,
+          `Names "${prior}" and "${name}" both generate "${goName}"`,
+        ),
+      )
+    } else {
+      converted.set(goName, name)
+    }
+  }
+}
+
+function checkConvertedValues(
+  values: string[],
+  path: string,
+  issues: ProfileDefinitionIssue[],
+): void {
+  const converted = new Set<string>()
+  for (const value of values) {
+    const goName = checkSingleGoName(value, path, issues)
+    if (!goName) continue
+    if (converted.has(goName)) {
+      issues.push(
+        issue(C.NAME_COLLISION, path, `Generated name "${goName}" collides`),
+      )
+    }
+    converted.add(goName)
+  }
+}
+
+function checkSingleGoName(
+  name: string,
+  path: string,
+  issues: ProfileDefinitionIssue[],
+): string | null {
+  const converted = goFieldName(name)
+  if (!isValidGeneratedGoIdentifier(converted) || GO_KEYWORDS.has(name)) {
+    issues.push(
+      issue(
+        C.INVALID_NAME,
+        path,
+        `"${name}" does not generate a valid, non-keyword Go identifier`,
+      ),
+    )
+    return null
+  }
+  return converted
+}
+
+/** Mirror codegen.GoFieldName: upper-case the first rune and separators' successor. */
+function goFieldName(name: string): string {
+  const runes = Array.from(name)
+  if (runes.length === 0) return ''
+
+  const output: string[] = [simpleUpper(runes[0])]
+  let skipNext = false
+  for (let index = 1; index < runes.length; index++) {
+    const rune = runes[index]
+    if (skipNext) {
+      output.push(simpleUpper(rune))
+      skipNext = false
+    } else if (rune === '_' || !isGoLetterOrDigit(rune)) {
+      skipNext = true
+    } else {
+      output.push(rune)
+    }
+  }
+  return output.join('')
+}
+
+function simpleUpper(rune: string): string {
+  const upper = rune.toUpperCase()
+  return Array.from(upper).length === 1 ? upper : rune
+}
+
+function isGoLetterOrDigit(rune: string): boolean {
+  return /[\p{L}\p{Nd}]/u.test(rune)
+}
+
+function isValidGeneratedGoIdentifier(name: string): boolean {
+  return /^\p{Lu}[\p{L}\p{Nd}]*$/u.test(name)
+}
+
+class GeneratedSymbolTable {
+  readonly #symbols = new Map<string, string | null>()
+  readonly #issues: ProfileDefinitionIssue[]
+
+  constructor(issues: ProfileDefinitionIssue[]) {
+    this.#issues = issues
+  }
+
+  reserve(name: string): void {
+    this.#symbols.set(name, null)
+  }
+
+  add(name: string, path: string): void {
+    const prior = this.#symbols.get(name)
+    if (prior !== undefined) {
+      this.#issues.push(
+        issue(
+          C.NAME_COLLISION,
+          path,
+          prior === null
+            ? `Generated symbol "${name}" collides with a reserved helper`
+            : `Generated symbol "${name}" also comes from ${prior}`,
+        ),
+      )
+      return
+    }
+    this.#symbols.set(name, path)
+  }
 }

--- a/packages/json-schema/src/consistency.ts
+++ b/packages/json-schema/src/consistency.ts
@@ -213,7 +213,9 @@ function checkFieldCorrespondence(
   const valueProps = isPlainRecord(vs.properties)
     ? Object.keys(vs.properties)
     : []
-  const umpFields = Object.keys(umpire.fields ?? {})
+  const umpFields = isPlainRecord(umpire.fields)
+    ? Object.keys(umpire.fields)
+    : []
   const valueNames = new Set(valueProps)
   const umpireNames = new Set(umpFields)
 
@@ -296,15 +298,6 @@ function walkSchema(
     !('type' in node) &&
     isConstOnlySchema(node)
   ) {
-    if (typeof node.const !== 'string') {
-      issues.push(
-        issue(
-          C.INVALID_DISCRIMINATOR,
-          ptr,
-          'A discriminator const must be a string',
-        ),
-      )
-    }
     return
   }
 
@@ -328,7 +321,7 @@ function walkSchema(
     return
   }
 
-  checkKeywordPlacement(node, node.type, ptr, issues, context.root === true)
+  checkKeywordPlacement(node, node.type, ptr, issues)
   checkEnumAndConst(node, node.type, ptr, issues)
   checkNumericKeywords(node, node.type, ptr, issues)
 
@@ -361,7 +354,7 @@ function checkReference(
 ): void {
   const ref = node.$ref
   const name = typeof ref === 'string' ? localDefinitionName(ref) : null
-  if (name === null || !(name in defs)) {
+  if (name === null || !hasOwn(defs, name)) {
     issues.push(
       issue(
         C.INVALID_REFERENCE,
@@ -383,13 +376,12 @@ function checkKeywordPlacement(
   schemaType: string,
   ptr: string,
   issues: ProfileDefinitionIssue[],
-  root: boolean,
 ): void {
   const typeKeywords = TYPE_KEYWORDS[schemaType]
   for (const key of Object.keys(node)) {
     if (!SUPPORTED.has(key)) continue
     if (COMMON_KEYWORDS.has(key) || typeKeywords.has(key)) continue
-    if (root && (key === '$schema' || key === '$defs')) continue
+    if (key === '$schema' || key === '$defs') continue
     if (key === 'oneOf') continue
     issues.push(
       issue(
@@ -441,7 +433,7 @@ function walkObject(
       Array.isArray(required) &&
       required.every((name) => typeof name === 'string') &&
       new Set(required).size === required.length &&
-      required.every((name) => name in properties)
+      required.every((name) => hasOwn(properties, name))
     if (!valid) {
       issues.push(
         issue(
@@ -551,10 +543,13 @@ function checkTaggedUnion(
     )
   }
 
+  const untypedConstNames =
+    discriminator === null
+      ? collectUnionConstNames(branches)
+      : new Set([discriminator])
   for (let index = 0; index < branches.length; index++) {
     walkSchema(branches[index], `${oneOfPath}/${index}`, issues, defs, {
-      allowUntypedConstNames:
-        discriminator === null ? new Set() : new Set([discriminator]),
+      allowUntypedConstNames: untypedConstNames,
     })
   }
 }
@@ -705,10 +700,10 @@ function checkCrossFieldCompatibility(
 ): void {
   if (!isPlainRecord(vs.properties)) return
 
-  for (const [name, field] of Object.entries(umpire.fields ?? {})) {
+  for (const [name, field] of plainRecordEntries(umpire.fields)) {
     const propertySchema = vs.properties[name]
     const schemaType = resolveSchemaType(propertySchema, defs)
-    if (field.isEmpty) {
+    if (typeof field.isEmpty === 'string') {
       const compatible = IS_EMPTY_OK[field.isEmpty]
       if (schemaType && compatible && !compatible.includes(schemaType)) {
         issues.push(
@@ -739,6 +734,17 @@ function checkCrossFieldCompatibility(
   }
 }
 
+function plainRecordEntries(
+  value: unknown,
+): Array<[string, Record<string, unknown>]> {
+  if (!isPlainRecord(value)) return []
+  const entries: Array<[string, Record<string, unknown>]> = []
+  for (const [name, entry] of Object.entries(value)) {
+    if (isPlainRecord(entry)) entries.push([name, entry])
+  }
+  return entries
+}
+
 function resolveSchemaType(
   raw: unknown,
   defs: Record<string, unknown>,
@@ -746,10 +752,18 @@ function resolveSchemaType(
   const seen = new Set<string>()
   let node = raw
   while (isPlainRecord(node)) {
-    if (typeof node.type === 'string') return node.type
+    if (typeof node.type === 'string' && ALLOWED_TYPES.has(node.type)) {
+      return node.type
+    }
+    if (
+      Array.isArray(node.oneOf) &&
+      deriveTaggedDiscriminator(node.oneOf) !== null
+    ) {
+      return 'object'
+    }
     if (typeof node.$ref !== 'string') return undefined
     const name = localDefinitionName(node.$ref)
-    if (name === null || seen.has(name)) return undefined
+    if (name === null || seen.has(name) || !hasOwn(defs, name)) return undefined
     seen.add(name)
     node = defs[name]
   }
@@ -764,7 +778,7 @@ function checkReferenceCycles(
   for (const name of Object.keys(defs).sort()) {
     graph.set(
       name,
-      collectReferences(defs[name]).filter((ref) => ref in defs),
+      collectReferences(defs[name]).filter((ref) => hasOwn(defs, ref)),
     )
   }
 
@@ -847,6 +861,10 @@ function isConstOnlySchema(node: Record<string, unknown>): boolean {
 
 function escapePointerToken(token: string): string {
   return token.replace(/~/g, '~0').replace(/\//g, '~1')
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key)
 }
 
 function dedupeAndSortIssues(
@@ -957,9 +975,12 @@ function walkGeneratedNames(
   }
 
   if (Array.isArray(node.oneOf)) {
+    const tagged = deriveTaggedDiscriminator(node.oneOf)
+    if (tagged === null) return
+
     const unionType = context.ownerDeclared ? owner : `${owner}Value`
     if (!context.ownerDeclared) symbols.add(unionType, `${ptr}/oneOf`)
-    const values = discriminatorValues(node.oneOf)
+    const values = tagged.values
     checkConvertedValues(values, `${ptr}/oneOf`, issues)
     for (const value of values) {
       symbols.add(`${unionType}${goFieldName(value)}`, `${ptr}/oneOf`)
@@ -1057,8 +1078,15 @@ function deriveTaggedDiscriminator(
   }
 }
 
-function discriminatorValues(branches: unknown[]): string[] {
-  return deriveTaggedDiscriminator(branches)?.values ?? []
+function collectUnionConstNames(branches: unknown[]): ReadonlySet<string> {
+  const names = new Set<string>()
+  for (const branch of branches) {
+    if (!isPlainRecord(branch) || !isPlainRecord(branch.properties)) continue
+    for (const [name, schema] of Object.entries(branch.properties)) {
+      if (isPlainRecord(schema) && isConstOnlySchema(schema)) names.add(name)
+    }
+  }
+  return names
 }
 
 function enumConstantName(value: unknown, index: number): string {
@@ -1068,25 +1096,36 @@ function enumConstantName(value: unknown, index: number): string {
 }
 
 function checkRuleNames(
-  rules: UmpireJsonSchema['rules'],
+  rules: unknown,
   issues: ProfileDefinitionIssue[],
   symbols: GeneratedSymbolTable,
   prefix = '/umpire/rules',
 ): void {
+  if (!Array.isArray(rules)) return
+
   const groups: string[] = []
   for (let index = 0; index < rules.length; index++) {
     const rule = rules[index]
+    if (!isPlainRecord(rule)) continue
+
     const ptr = `${prefix}/${index}`
     if (rule.type === 'oneOf' || rule.type === 'eitherOf') {
+      if (typeof rule.group !== 'string' || !isPlainRecord(rule.branches)) {
+        continue
+      }
       groups.push(rule.group)
       checkSingleGoName(rule.group, `${ptr}/group`, issues)
       const branches = Object.keys(rule.branches)
       checkNameCollection(branches, `${ptr}/branches`, issues)
       const groupType = `Schema${goFieldName(rule.group)}Branch`
       symbols.add(groupType, `${ptr}/group`)
+      const branchSymbols = new Set<string>()
       for (const branch of branches) {
+        const branchSymbol = `${groupType}${goFieldName(branch)}`
+        if (branchSymbols.has(branchSymbol)) continue
+        branchSymbols.add(branchSymbol)
         symbols.add(
-          `${groupType}${goFieldName(branch)}`,
+          branchSymbol,
           `${ptr}/branches/${escapePointerToken(branch)}`,
         )
       }

--- a/packages/json-schema/src/consistency.ts
+++ b/packages/json-schema/src/consistency.ts
@@ -1195,7 +1195,7 @@ function checkSingleGoName(
   issues: ProfileDefinitionIssue[],
 ): string | null {
   const converted = goFieldName(name)
-  if (!isValidGeneratedGoIdentifier(converted) || GO_KEYWORDS.has(name)) {
+  if (!isValidGeneratedGoIdentifier(converted) || GO_KEYWORDS.has(converted)) {
     issues.push(
       issue(
         C.INVALID_NAME,

--- a/packages/json-schema/src/discriminator.ts
+++ b/packages/json-schema/src/discriminator.ts
@@ -10,16 +10,18 @@ import { isPlainRecord } from '@umpire/core/guards'
  * The closed-vocabulary consistency walk validates the original document, so
  * it must stay untouched. Because the canonical profile schema declares unions
  * with a bare `oneOf`, we derive the discriminator from the branches and inject
- * the keyword into a clone before AJV compilation.
+ * the keyword into a clone before AJV compilation. Integer nodes also receive
+ * the implementation-only `safeInteger` keyword used by runtime validation.
  */
-export function applyDiscriminators(
+export function prepareValueSchema(
   schema: Record<string, unknown>,
 ): Record<string, unknown> {
-  const out = JSON.parse(JSON.stringify(schema)) as Record<string, unknown>
+  const out = structuredClone(schema)
   walk(out)
   return out
 }
 
+// eslint-disable-next-line complexity -- recursively decorates each supported schema container without changing the source document
 function walk(node: unknown): void {
   if (!node || typeof node !== 'object') return
   if (Array.isArray(node)) {
@@ -27,6 +29,10 @@ function walk(node: unknown): void {
     return
   }
   if (!isPlainRecord(node)) return
+
+  if (node.type === 'integer') {
+    node.safeInteger = true
+  }
 
   if (Array.isArray(node.oneOf)) {
     const tag = sharedDiscriminator(node.oneOf)
@@ -55,26 +61,45 @@ function walk(node: unknown): void {
 
 /**
  * Return the shared discriminator property name for a tagged union, or `null`
- * if the branches do not describe a valid tagged union. A discriminator
- * property is any branch property carrying a `const`. Every branch must use
- * the same property name.
+ * if the branches do not describe a valid tagged union. The property must be
+ * required in every branch and carry a distinct string `const`; other constant
+ * properties do not affect discriminator selection.
  */
 function sharedDiscriminator(branches: unknown[]): string | null {
-  let tag: string | null = null
+  const branchCandidates: Array<Map<string, string>> = []
   for (const branch of branches) {
-    if (!isPlainRecord(branch) || branch.type !== 'object') return null
-    const props = isPlainRecord(branch.properties)
-      ? (branch.properties as Record<string, unknown>)
-      : {}
-    let found = false
-    for (const [name, propSchema] of Object.entries(props)) {
-      if (!isPlainRecord(propSchema) || propSchema.const === undefined) continue
-      if (tag === null) tag = name
-      if (tag !== name) return null
-      found = true
-      break
+    if (
+      !isPlainRecord(branch) ||
+      branch.type !== 'object' ||
+      !isPlainRecord(branch.properties) ||
+      !Array.isArray(branch.required)
+    ) {
+      return null
     }
-    if (!found) return null
+    const required = new Set(
+      branch.required.filter(
+        (name): name is string => typeof name === 'string',
+      ),
+    )
+    const candidates = new Map<string, string>()
+    for (const [name, propSchema] of Object.entries(branch.properties)) {
+      if (
+        required.has(name) &&
+        isPlainRecord(propSchema) &&
+        typeof propSchema.const === 'string'
+      ) {
+        candidates.set(name, propSchema.const)
+      }
+    }
+    branchCandidates.push(candidates)
   }
-  return tag
+
+  const names = [...(branchCandidates[0]?.keys() ?? [])].filter((name) => {
+    const values = branchCandidates.map((candidates) => candidates.get(name))
+    return (
+      values.every((value): value is string => value !== undefined) &&
+      new Set(values).size === branches.length
+    )
+  })
+  return names.length === 1 ? names[0] : null
 }

--- a/packages/json-schema/src/issues.ts
+++ b/packages/json-schema/src/issues.ts
@@ -66,14 +66,16 @@ export function normalizeAjvErrors(
       const missing =
         params.error === 'tag' && !propertyPresent(rawValue, ip, tagName)
       code = missing ? 'required' : 'discriminator'
-      path = `${ip}/${tagName}`
+      path = `${ip}/${escapePointerToken(tagName)}`
     } else if (err.keyword === 'required') {
       const mp = err.params?.missingProperty as string
-      path = ip ? `${ip}/${mp}` : `/${mp}`
+      const token = escapePointerToken(mp)
+      path = ip ? `${ip}/${token}` : `/${token}`
       code = err.keyword
     } else if (err.keyword === 'additionalProperties') {
       const ap = err.params?.additionalProperty as string
-      path = ip ? `${ip}/${ap}` : `/${ap}`
+      const token = escapePointerToken(ap)
+      path = ip ? `${ip}/${token}` : `/${token}`
       code = err.keyword
     } else {
       path = ip || '/'
@@ -137,10 +139,11 @@ function propertyPresent(
   if (node === null || typeof node !== 'object' || Array.isArray(node)) {
     return false
   }
-  return Object.prototype.hasOwnProperty.call(
-    node,
-    unescapePointerSegment(property),
-  )
+  return Object.prototype.hasOwnProperty.call(node, property)
+}
+
+function escapePointerToken(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1')
 }
 
 /** Drop structural issues whose first path token names a disabled Umpire field. */

--- a/packages/json/conformance/.synced-at-version
+++ b/packages/json/conformance/.synced-at-version
@@ -1,5 +1,5 @@
 {
-  "version": "v1.1.0-rc.2",
-  "tarballSha256": "560184f267e4224f00dd5bed8a6a66bcafdb906153c80699c0f074ec30144240",
+  "version": "v1.1.0-rc.3",
+  "tarballSha256": "392aabcd711ab26df3a1e90b0789a23faf875a922c955445e05f3ccadff75d1c",
   "fixtureDigest": "a79edf0289b53d8597b20ee09c32334b63d7cda2fce52b53bc100e9d370f8323"
 }

--- a/umpire-spec.pin.json
+++ b/umpire-spec.pin.json
@@ -1,7 +1,7 @@
 {
-  "version": "v1.1.0-rc.2",
-  "url": "https://github.com/umpire-tools/umpire-spec/archive/refs/tags/v1.1.0-rc.2.tar.gz",
-  "sha256": "560184f267e4224f00dd5bed8a6a66bcafdb906153c80699c0f074ec30144240",
+  "version": "v1.1.0-rc.3",
+  "url": "https://github.com/umpire-tools/umpire-spec/archive/refs/tags/v1.1.0-rc.3.tar.gz",
+  "sha256": "392aabcd711ab26df3a1e90b0789a23faf875a922c955445e05f3ccadff75d1c",
   "targets": [
     {
       "dir": "packages/json/conformance",
@@ -11,7 +11,7 @@
     {
       "dir": "packages/json-schema/conformance",
       "sources": ["profiles/conformance"],
-      "fixtureDigest": "74c7bcbebc33ff21cf7df964cf05bc0f602d925f1d6e98a76de80119052eac6a"
+      "fixtureDigest": "32eed92fd3937519cc76918cad0ca1f5f656b47170e016812e3f6f4f0b1cb4f7"
     },
     {
       "dir": "packages/json-schema/schemas",


### PR DESCRIPTION
## Summary
- aligns `@umpire/json-schema` with the complete Profile v1 closed vocabulary and RC3 definition contract
- validates strict nested objects, references, tagged unions, defaults, safe numbers, and deterministic generated Go names
- pins and vendors `umpire-spec v1.1.0-rc.3`

## Verification
- full root typecheck, test, build, lint, format, and docs gates
- alias-disabled package tests
- sync checksum verification
- package tarball inspection