### PR TITLE
chore(json-schema): pin umpire-spec v1.1.0

### DIFF
--- a/.changeset/json-schema-proto.md
+++ b/.changeset/json-schema-proto.md
@@ -2,4 +2,4 @@
 "@umpire/json-schema": minor
 ---
 
-Release `@umpire/json-schema` 0.1.0, the JSON Schema composition profile. Adds `compileProfile()`, `compileSchemas()`, `CompiledProfile` with separate `check()`/`validateStructure()`/`evaluate()` APIs, and `filterStructuralIssues()` UI helper. Structural validation uses AJV 2020-12, conforms to `umpire-spec` v1.1.0-rc.3, and remains independent of Umpire availability evaluation.
+Release `@umpire/json-schema` 0.1.0, the JSON Schema composition profile. Adds `compileProfile()`, `compileSchemas()`, `CompiledProfile` with separate `check()`/`validateStructure()`/`evaluate()` APIs, and `filterStructuralIssues()` UI helper. Structural validation uses AJV 2020-12, conforms to `umpire-spec` v1.1.0, and remains independent of Umpire availability evaluation.

--- a/packages/json-schema/conformance/.synced-at-version
+++ b/packages/json-schema/conformance/.synced-at-version
@@ -1,5 +1,5 @@
 {
-  "version": "v1.1.0-rc.3",
-  "tarballSha256": "392aabcd711ab26df3a1e90b0789a23faf875a922c955445e05f3ccadff75d1c",
+  "version": "v1.1.0",
+  "tarballSha256": "11d3f3465e91b4033e62e4a5da08845c76726ef05b43662c59b88ae647d55aa4",
   "fixtureDigest": "32eed92fd3937519cc76918cad0ca1f5f656b47170e016812e3f6f4f0b1cb4f7"
 }

--- a/packages/json-schema/schemas/.synced-at-version
+++ b/packages/json-schema/schemas/.synced-at-version
@@ -1,5 +1,5 @@
 {
-  "version": "v1.1.0-rc.3",
-  "tarballSha256": "392aabcd711ab26df3a1e90b0789a23faf875a922c955445e05f3ccadff75d1c",
+  "version": "v1.1.0",
+  "tarballSha256": "11d3f3465e91b4033e62e4a5da08845c76726ef05b43662c59b88ae647d55aa4",
   "fixtureDigest": "79b48ddc7579ee0b5c923f5d35e4b1ab117eb10b52eb33487ee3de034c35ac76"
 }

--- a/packages/json/conformance/.synced-at-version
+++ b/packages/json/conformance/.synced-at-version
@@ -1,5 +1,5 @@
 {
-  "version": "v1.1.0-rc.3",
-  "tarballSha256": "392aabcd711ab26df3a1e90b0789a23faf875a922c955445e05f3ccadff75d1c",
+  "version": "v1.1.0",
+  "tarballSha256": "11d3f3465e91b4033e62e4a5da08845c76726ef05b43662c59b88ae647d55aa4",
   "fixtureDigest": "a79edf0289b53d8597b20ee09c32334b63d7cda2fce52b53bc100e9d370f8323"
 }

--- a/umpire-spec.pin.json
+++ b/umpire-spec.pin.json
@@ -1,7 +1,7 @@
 {
-  "version": "v1.1.0-rc.3",
-  "url": "https://github.com/umpire-tools/umpire-spec/archive/refs/tags/v1.1.0-rc.3.tar.gz",
-  "sha256": "392aabcd711ab26df3a1e90b0789a23faf875a922c955445e05f3ccadff75d1c",
+  "version": "v1.1.0",
+  "url": "https://github.com/umpire-tools/umpire-spec/archive/refs/tags/v1.1.0.tar.gz",
+  "sha256": "11d3f3465e91b4033e62e4a5da08845c76726ef05b43662c59b88ae647d55aa4",
   "targets": [
     {
       "dir": "packages/json/conformance",


### PR DESCRIPTION
## Summary
- updates `@umpire/json-schema` fixtures and schemas to `umpire-spec v1.1.0`
- records the final checksum and synced fixture digests

## Verification
- `yarn sync:umpire-spec:check`
- alias-disabled package tests
- repository build