### PR TITLE
feat(json-schema): release 0.1.0

### DIFF
--- a/.changeset/json-schema-proto.md
+++ b/.changeset/json-schema-proto.md
@@ -1,5 +1,0 @@
----
-"@umpire/json-schema": minor
----
-
-Release `@umpire/json-schema` 0.1.0, the JSON Schema composition profile. Adds `compileProfile()`, `compileSchemas()`, `CompiledProfile` with separate `check()`/`validateStructure()`/`evaluate()` APIs, and `filterStructuralIssues()` UI helper. Structural validation uses AJV 2020-12, conforms to `umpire-spec` v1.1.0, and remains independent of Umpire availability evaluation.

--- a/.changeset/json-v1-contract.md
+++ b/.changeset/json-v1-contract.md
@@ -1,5 +1,0 @@
----
-"@umpire/json": patch
----
-
-Align portable schema validation with the canonical Umpire v1 acceptance contract and ship the pinned v1.0.1 conformance fixtures.

--- a/packages/json-schema/CHANGELOG.md
+++ b/packages/json-schema/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @umpire/json-schema
+
+## 0.1.0
+
+### Minor Changes
+
+- 7df3778: Release `@umpire/json-schema` 0.1.0, the JSON Schema composition profile. Adds `compileProfile()`, `compileSchemas()`, `CompiledProfile` with separate `check()`/`validateStructure()`/`evaluate()` APIs, and `filterStructuralIssues()` UI helper. Structural validation uses AJV 2020-12, conforms to `umpire-spec` v1.1.0, and remains independent of Umpire availability evaluation.
+
+### Patch Changes
+
+- Updated dependencies [705c8c4]
+  - @umpire/json@1.0.2

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umpire/json-schema",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "JSON Schema composition profile for @umpire/core — portable nested value-shape validation alongside field availability evaluation",
   "license": "MIT",
   "type": "module",

--- a/packages/json/CHANGELOG.md
+++ b/packages/json/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @umpire/json
 
+## 1.0.2
+
+### Patch Changes
+
+- 705c8c4: Align portable schema validation with the canonical Umpire v1 acceptance contract and ship the pinned v1.0.1 conformance fixtures.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umpire/json",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "JSON schema parsing and portable named checks for @umpire/core",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- sets `@umpire/json-schema` to `0.1.0` for its first manual publish
- applies the pending `@umpire/json` v1 contract patch as `1.0.2`
- updates both package changelogs through Changesets

## Verification
- root build and typecheck
- package and alias-disabled tests
- final spec sync check
- versioned tarball inspection