### PR TITLE
♿ Make the Minesweeper demo keyboard accessible

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "bun test"
   },
   "dependencies": {
     "@astrojs/preact": "^4.0.0",

--- a/docs/src/components/MinesweeperDemo.tsx
+++ b/docs/src/components/MinesweeperDemo.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 // useUmpireWithDevtools powers the named instance in the optional panel on this page.
 // Swap back to: import { useUmpire } from '@umpire/react'  (remove leading id arg)
 import { useUmpireWithDevtools } from "@umpire/devtools/react";
@@ -20,6 +20,10 @@ import {
   type GameConditions,
   type Values,
 } from "../lib/minesweeper-engine.js";
+import {
+  moveFocus,
+  type FocusDirection,
+} from "../lib/minesweeper-focus.js";
 
 const BOARD_WIDTH = 8;
 const BOARD_HEIGHT = 8;
@@ -143,11 +147,30 @@ export default function MinesweeperDemo({
     gameStatus: "playing",
     flagMode: false,
   });
+  const [activeCell, setActiveCell] = useState({ x: 0, y: 0 });
+  const [announcement, setAnnouncement] = useState("");
+  const announcementTimeoutRef = useRef<number | undefined>(undefined);
+  const cellRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const [inspectedCell, setInspectedCell] = useState<CellInspector>({
     key: cellKey(0, 0),
     x: 0,
     y: 0,
   });
+
+  useEffect(() => {
+    announce("Game started");
+
+    return () => window.clearTimeout(announcementTimeoutRef.current);
+  }, []);
+
+  function announce(message: string) {
+    window.clearTimeout(announcementTimeoutRef.current);
+    setAnnouncement("");
+    announcementTimeoutRef.current = window.setTimeout(
+      () => setAnnouncement(message),
+      0,
+    );
+  }
 
   const activeBoard = board ?? EMPTY_BOARD;
   const activeUmp = useMemo(
@@ -222,11 +245,13 @@ export default function MinesweeperDemo({
     setSeed(Date.now());
     setValues({});
     setConditions({ gameStatus: "playing", flagMode: false });
+    setActiveCell({ x: 0, y: 0 });
     setInspectedCell({
       key: cellKey(0, 0),
       x: 0,
       y: 0,
     });
+    announce("Game started");
   }
 
   function toggleFlag(cell: CellMeta) {
@@ -241,6 +266,12 @@ export default function MinesweeperDemo({
     if (values[key] === "revealed") {
       return;
     }
+
+    const wasFlagged = values[key] === "flagged";
+
+    announce(
+      `${wasFlagged ? "Flag removed from" : "Flag placed on"} cell ${cell.x + 1}, ${cell.y + 1}`,
+    );
 
     setValues((current) => ({
       ...current,
@@ -281,16 +312,38 @@ export default function MinesweeperDemo({
 
     if (nextBoard[key].isMine) {
       nextStatus = "lost";
-      nextValues = revealAllMines(nextBoard, { ...values, [key]: "revealed" });
+      nextValues = revealAllMines(nextBoard, {
+        ...values,
+        [key]: "revealed",
+      });
+
+      announce(
+        `Cell ${cell.x + 1}, ${cell.y + 1}: mine hit. Game lost.`,
+      );
     } else {
       nextValues = cascadeReveal(nextBoard, values, cell.x, cell.y);
+
+      const revealedCount = Object.keys(nextValues).filter(
+        (cellKey) =>
+          nextValues[cellKey] === "revealed" &&
+          values[cellKey] !== "revealed",
+      ).length;
 
       if (checkWin(nextBoard, nextValues)) {
         nextStatus = "won";
         nextValues = revealAllMines(nextBoard, nextValues);
+
+        announce(
+          `Cell ${cell.x + 1}, ${cell.y + 1}: revealed ${revealedCount} ${revealedCount === 1 ? "cell" : "cells"
+          }. Game won.`,
+        );
+      } else {
+        announce(
+          `Cell ${cell.x + 1}, ${cell.y + 1}: revealed ${revealedCount} ${revealedCount === 1 ? "cell" : "cells"
+          }.`,
+        );
       }
     }
-
     setBoard(nextBoard);
     setValues(nextValues);
     setConditions((current) => ({
@@ -308,6 +361,40 @@ export default function MinesweeperDemo({
     revealCell(cell);
   }
 
+  function handleCellKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
+    const directionMap: Record<string, FocusDirection> = {
+      ArrowUp: "up",
+      ArrowDown: "down",
+      ArrowLeft: "left",
+      ArrowRight: "right",
+      Home: "home",
+      End: "end",
+    };
+
+    const direction = directionMap[event.key];
+
+    if (!direction) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const nextCell = moveFocus(
+      direction,
+      activeCell.x,
+      activeCell.y,
+      BOARD_WIDTH,
+      BOARD_HEIGHT,
+    );
+
+    setActiveCell(nextCell);
+
+    const nextKey = cellKey(nextCell.x, nextCell.y);
+    const nextButton = cellRefs.current[nextKey];
+
+    nextButton?.focus();
+  }
+
   return (
     <div
       className={cls(
@@ -316,6 +403,13 @@ export default function MinesweeperDemo({
         compact && "c-minesweeper-demo--compact",
       )}
     >
+      <div
+        className="c-minesweeper-demo__sr-only"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {announcement}
+      </div>
       <div className={cls("c-minesweeper-demo__layout")}>
         <section
           className={cls(
@@ -337,6 +431,7 @@ export default function MinesweeperDemo({
           <div className="c-umpire-demo__panel-body c-minesweeper-demo__panel-body">
             <div className="c-minesweeper-demo__controls">
               <div
+                role="group"
                 className="c-minesweeper-demo__mode-toggle"
                 aria-label="Interaction mode"
               >
@@ -346,7 +441,7 @@ export default function MinesweeperDemo({
                   className={cls(
                     "c-minesweeper-demo__mode-button",
                     !conditions.flagMode &&
-                      "c-minesweeper-demo__mode-button is-active",
+                    "c-minesweeper-demo__mode-button is-active",
                   )}
                   onClick={() =>
                     setConditions((current) => ({
@@ -363,7 +458,7 @@ export default function MinesweeperDemo({
                   className={cls(
                     "c-minesweeper-demo__mode-button",
                     conditions.flagMode &&
-                      "c-minesweeper-demo__mode-button is-active",
+                    "c-minesweeper-demo__mode-button is-active",
                   )}
                   onClick={() =>
                     setConditions((current) => ({ ...current, flagMode: true }))
@@ -373,7 +468,11 @@ export default function MinesweeperDemo({
                 </button>
               </div>
 
-              <div className="c-minesweeper-demo__status">
+              <div
+                className="c-minesweeper-demo__status"
+                role="group"
+                aria-label="Game status"
+              >
                 <span className="c-minesweeper-demo__status-label c-umpire-demo__eyebrow">
                   {STATUS_LABEL[conditions.gameStatus]}
                 </span>
@@ -409,70 +508,99 @@ export default function MinesweeperDemo({
             <section className="c-minesweeper-demo-board">
               <div className="c-minesweeper-demo-board__shell">
                 <div
+                  role="grid"
+                  aria-label="Minesweeper board"
                   className="c-minesweeper-demo__grid"
-                  style={{
-                    gridTemplateColumns: `repeat(${BOARD_WIDTH}, minmax(44px, 1fr))`,
-                  }}
                 >
-                  {CELL_ORDER.map((cell) => {
-                    const key = cellKey(cell.x, cell.y);
-                    const cellAvailability = availability[key];
-                    const value = values[key];
-                    const display = boardReads[displayReadKey(key)];
-                    const isRevealed =
-                      display.kind === "mine" ||
-                      display.kind === "empty" ||
-                      display.kind === "number";
-                    const isMine = display.kind === "mine";
+                  {Array.from({ length: BOARD_HEIGHT }, (_, rowIndex) => {
+                    const rowCells = CELL_ORDER.slice(
+                      rowIndex * BOARD_WIDTH,
+                      (rowIndex + 1) * BOARD_WIDTH,
+                    );
 
                     return (
-                      <button
-                        key={key}
-                        type="button"
-                        aria-disabled={!cellAvailability.enabled}
-                        aria-label={`Cell ${cell.x + 1}, ${cell.y + 1}: ${describeCellValue(value)}`}
-                        className={cls(
-                          "c-minesweeper-demo__cell",
-                          !isRevealed && "c-minesweeper-demo__cell is-hidden",
-                          isRevealed && "c-minesweeper-demo__cell is-revealed",
-                          value === "flagged" &&
-                            "c-minesweeper-demo__cell is-flagged",
-                          isMine && "c-minesweeper-demo__cell--mine",
-                          !cellAvailability.enabled &&
-                            "c-minesweeper-demo__cell is-disabled",
-                        )}
-                        onClick={() => handleCellClick(cell)}
-                        onContextMenu={(event) => {
-                          event.preventDefault();
-                          // Touch devices use the explicit mode toggle instead of long-press hacks.
-                          toggleFlag(cell);
-                        }}
-                        onMouseEnter={() => inspect(cell)}
-                        onFocus={() => inspect(cell)}
+                      <div
+                        role="row"
+                        key={rowIndex}
+                        className="c-minesweeper-demo__row"
                       >
-                        {display.kind === "flagged" && (
-                          <span className="c-minesweeper-demo__flag">⚑</span>
-                        )}
-                        {isMine && (
-                          <span className="c-minesweeper-demo__mine">✺</span>
-                        )}
-                        {display.kind === "number" && (
-                          <span
-                            className={cls(
-                              "c-minesweeper-demo__number",
-                              numberClass(display.count),
-                            )}
-                          >
-                            {display.count}
-                          </span>
-                        )}
-                      </button>
+                        {rowCells.map((cell) => {
+                          const key = cellKey(cell.x, cell.y);
+                          const cellAvailability = availability[key];
+                          const value = values[key];
+                          const display = boardReads[displayReadKey(key)];
+                          const isRevealed =
+                            display.kind === "mine" ||
+                            display.kind === "empty" ||
+                            display.kind === "number";
+                          const isMine = display.kind === "mine";
+
+                          return (
+                            <button
+                              key={key}
+                              ref={(element) => {
+                                cellRefs.current[key] = element;
+                              }}
+                              type="button"
+                              role="gridcell"
+                              tabIndex={
+                                cell.x === activeCell.x && cell.y === activeCell.y ? 0 : -1
+                              }
+                              aria-rowindex={cell.y + 1}
+                              aria-colindex={cell.x + 1}
+                              aria-disabled={!cellAvailability.enabled}
+                              aria-label={`Cell ${cell.x + 1}, ${cell.y + 1}: ${describeCellValue(value)}`}
+                              className={cls(
+                                "c-minesweeper-demo__cell",
+                                !isRevealed && "c-minesweeper-demo__cell is-hidden",
+                                isRevealed && "c-minesweeper-demo__cell is-revealed",
+                                value === "flagged" &&
+                                "c-minesweeper-demo__cell is-flagged",
+                                isMine && "c-minesweeper-demo__cell--mine",
+                                !cellAvailability.enabled &&
+                                "c-minesweeper-demo__cell is-disabled",
+                              )}
+                              onClick={() => handleCellClick(cell)}
+                              onKeyDown={handleCellKeyDown}
+                              onContextMenu={(event) => {
+                                event.preventDefault();
+                                toggleFlag(cell);
+                              }}
+                              onMouseEnter={() => inspect(cell)}
+                              onFocus={() => {
+                                inspect(cell);
+                                setActiveCell({ x: cell.x, y: cell.y });
+                              }}
+                            >
+                              {display.kind === "flagged" && (
+                                <span className="c-minesweeper-demo__flag">⚑</span>
+                              )}
+
+                              {isMine && (
+                                <span className="c-minesweeper-demo__mine">✺</span>
+                              )}
+
+                              {display.kind === "number" && (
+                                <span
+                                  className={cls(
+                                    "c-minesweeper-demo__number",
+                                    numberClass(display.count),
+                                  )}
+                                >
+                                  {display.count}
+                                </span>
+                              )}
+                            </button>
+                          );
+                        })}
+                      </div>
                     );
                   })}
                 </div>
               </div>
               {!compact && (
                 <section
+                  aria-label="Cell inspector"
                   className={cls(
                     "c-minesweeper-demo-board__panel",
                     "c-minesweeper-demo__panel",
@@ -506,7 +634,7 @@ export default function MinesweeperDemo({
                             ? boardReads.probeWouldExplode
                               ? "mine"
                               : inspectedAdjacent === null ||
-                                  inspectedAdjacent === 0
+                                inspectedAdjacent === 0
                                 ? "clear"
                                 : `${inspectedAdjacent} adjacent`
                             : "unseeded"}

--- a/docs/src/components/MinesweeperDemo.tsx
+++ b/docs/src/components/MinesweeperDemo.tsx
@@ -548,7 +548,10 @@ export default function MinesweeperDemo({
                               }
                               aria-rowindex={cell.y + 1}
                               aria-colindex={cell.x + 1}
-                              aria-disabled={!cellAvailability.enabled}
+                              aria-disabled={
+                                !cellAvailability.enabled &&
+                                !(conditions.flagMode && value === "flagged")
+                              }
                               aria-label={`Cell ${cell.x + 1}, ${cell.y + 1}: ${describeCellValue(value)}`}
                               className={cls(
                                 "c-minesweeper-demo__cell",

--- a/docs/src/components/MinesweeperDemo.tsx
+++ b/docs/src/components/MinesweeperDemo.tsx
@@ -31,6 +31,12 @@ const MINE_COUNT = 10;
 
 const EMPTY_BOARD = createBoard(BOARD_WIDTH, BOARD_HEIGHT);
 const CELL_ORDER = Object.values(EMPTY_BOARD);
+const CELL_ROWS = Array.from({ length: BOARD_HEIGHT }, (_, rowIndex) =>
+  CELL_ORDER.slice(
+    rowIndex * BOARD_WIDTH,
+    (rowIndex + 1) * BOARD_WIDTH,
+  ),
+);
 const MINESWEEPER_READS = createMinesweeperReads(BOARD_WIDTH, BOARD_HEIGHT);
 
 const STATUS_FACE: Record<GameConditions["gameStatus"], string> = {
@@ -440,8 +446,7 @@ export default function MinesweeperDemo({
                   aria-pressed={!conditions.flagMode}
                   className={cls(
                     "c-minesweeper-demo__mode-button",
-                    !conditions.flagMode &&
-                    "c-minesweeper-demo__mode-button is-active",
+                    !conditions.flagMode && "is-active",
                   )}
                   onClick={() =>
                     setConditions((current) => ({
@@ -457,8 +462,7 @@ export default function MinesweeperDemo({
                   aria-pressed={conditions.flagMode}
                   className={cls(
                     "c-minesweeper-demo__mode-button",
-                    conditions.flagMode &&
-                    "c-minesweeper-demo__mode-button is-active",
+                    conditions.flagMode && "is-active",
                   )}
                   onClick={() =>
                     setConditions((current) => ({ ...current, flagMode: true }))
@@ -512,11 +516,7 @@ export default function MinesweeperDemo({
                   aria-label="Minesweeper board"
                   className="c-minesweeper-demo__grid"
                 >
-                  {Array.from({ length: BOARD_HEIGHT }, (_, rowIndex) => {
-                    const rowCells = CELL_ORDER.slice(
-                      rowIndex * BOARD_WIDTH,
-                      (rowIndex + 1) * BOARD_WIDTH,
-                    );
+                  {CELL_ROWS.map((rowCells, rowIndex) => {
 
                     return (
                       <div
@@ -555,13 +555,11 @@ export default function MinesweeperDemo({
                               aria-label={`Cell ${cell.x + 1}, ${cell.y + 1}: ${describeCellValue(value)}`}
                               className={cls(
                                 "c-minesweeper-demo__cell",
-                                !isRevealed && "c-minesweeper-demo__cell is-hidden",
-                                isRevealed && "c-minesweeper-demo__cell is-revealed",
-                                value === "flagged" &&
-                                "c-minesweeper-demo__cell is-flagged",
+                                !isRevealed && "is-hidden",
+                                isRevealed && "is-revealed",
+                                value === "flagged" && "is-flagged",
                                 isMine && "c-minesweeper-demo__cell--mine",
-                                !cellAvailability.enabled &&
-                                "c-minesweeper-demo__cell is-disabled",
+                                !cellAvailability.enabled && "is-disabled",
                               )}
                               onClick={() => handleCellClick(cell)}
                               onKeyDown={handleCellKeyDown}

--- a/docs/src/lib/minesweeper-focus.test.ts
+++ b/docs/src/lib/minesweeper-focus.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "bun:test";
 import { moveFocus } from "./minesweeper-focus.js";
 
 describe("moveFocus", () => {
+  it("moves one cell in each direction", () => {
+    expect(moveFocus("right", 3, 3, 8, 8)).toEqual({ x: 4, y: 3 });
+    expect(moveFocus("left", 3, 3, 8, 8)).toEqual({ x: 2, y: 3 });
+    expect(moveFocus("down", 3, 3, 8, 8)).toEqual({ x: 3, y: 4 });
+    expect(moveFocus("up", 3, 3, 8, 8)).toEqual({ x: 3, y: 2 });
+  });
   it("moves horizontally and wraps within the row", () => {
     expect(moveFocus("right", 7, 3, 8, 8)).toEqual({ x: 0, y: 3 });
     expect(moveFocus("left", 0, 3, 8, 8)).toEqual({ x: 7, y: 3 });

--- a/docs/src/lib/minesweeper-focus.test.ts
+++ b/docs/src/lib/minesweeper-focus.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { moveFocus } from "./minesweeper-focus.js";
+
+describe("moveFocus", () => {
+  it("moves horizontally and wraps within the row", () => {
+    expect(moveFocus("right", 7, 3, 8, 8)).toEqual({ x: 0, y: 3 });
+    expect(moveFocus("left", 0, 3, 8, 8)).toEqual({ x: 7, y: 3 });
+  });
+
+  it("moves vertically and wraps within the column", () => {
+    expect(moveFocus("down", 4, 7, 8, 8)).toEqual({ x: 4, y: 0 });
+    expect(moveFocus("up", 4, 0, 8, 8)).toEqual({ x: 4, y: 7 });
+  });
+
+  it("moves to the start or end of the current row", () => {
+    expect(moveFocus("home", 4, 3, 8, 8)).toEqual({ x: 0, y: 3 });
+    expect(moveFocus("end", 4, 3, 8, 8)).toEqual({ x: 7, y: 3 });
+  });
+});

--- a/docs/src/lib/minesweeper-focus.ts
+++ b/docs/src/lib/minesweeper-focus.ts
@@ -1,0 +1,41 @@
+export type FocusDirection =
+  | "up"
+  | "down"
+  | "left"
+  | "right"
+  | "home"
+  | "end";
+
+export function moveFocus(
+  direction: FocusDirection,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) {
+  if (direction === "right") {
+    return { x: x === width - 1 ? 0 : x + 1, y };
+  }
+
+  if (direction === "left") {
+    return { x: x === 0 ? width - 1 : x - 1, y };
+  }
+
+  if (direction === "up") {
+    return { x, y: y === 0 ? height - 1 : y - 1 };
+  }
+
+  if (direction === "down") {
+    return { x, y: y === height - 1 ? 0 : y + 1 };
+  }
+
+  if (direction === "home") {
+    return { x: 0, y };
+  }
+
+  if (direction === "end") {
+    return { x: width - 1, y };
+  }
+
+  return { x, y };
+}

--- a/docs/src/styles/components/_components.minesweeper-demo.css
+++ b/docs/src/styles/components/_components.minesweeper-demo.css
@@ -172,7 +172,7 @@
 
 .c-minesweeper-demo-board {
   display: flex;
-  flex-direction: 'row';
+  flex-direction: row;
 }
 
 .c-minesweeper-demo-board__panel {
@@ -203,10 +203,21 @@
 .c-minesweeper-demo__grid {
   display: grid;
   gap: 1px;
-  width: max-content;
+  width: 100%;
   padding: 1px;
   background: var(--minesweeper-demo-grid-line);
   touch-action: manipulation;
+}
+
+.c-minesweeper-demo__row {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+}
+
+.sl-markdown-content .c-minesweeper-demo__row + .c-minesweeper-demo__row {
+  margin-top: 0;
 }
 
 .c-minesweeper-demo__cell {
@@ -311,6 +322,20 @@
   text-align: right;
 }
 
+.c-minesweeper-demo__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+
+
 @media (hover: hover) and (pointer: fine) {
   .c-minesweeper-demo__cell.is-hidden:not(.c-minesweeper-demo__cell.is-disabled):hover {
     transform: translate(-1px, -1px);
@@ -329,6 +354,27 @@
 }
 
 @media (max-width: 640px) {
+  .c-minesweeper-demo-board {
+    flex-direction: column;
+  }
+
+  .c-minesweeper-demo-board__shell {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 0.5rem;
+  }
+
+  .c-minesweeper-demo__cell {
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .c-minesweeper-demo__inspector-body {
+    padding-top: 1rem;
+    padding-left: 0;
+  }
+
   .c-minesweeper-demo__status-bar {
     grid-template-columns: minmax(0, 1fr);
   }


### PR DESCRIPTION
Closes #146.

## Problem

The Minesweeper board exposed all 64 cells in the normal Tab sequence and did
not announce game events to screen-reader users. The supporting controls and
inspector also lacked accessible structure, and the board overflowed on narrow
viewports around 360px.

## Approach

- Added ARIA grid, row, and gridcell semantics.
- Added roving tabindex so the board occupies one place in the Tab sequence.
- Added wrapping arrow-key navigation and row-based Home/End behavior.
- Extracted the focus calculation into a pure helper with focused Bun tests.
- Added a polite live region for game start, dig, flag, win, and loss events.
- Added accessible labels for the interaction mode, status, board, and inspector.
- Allowed the board cells to shrink and stacked the inspector below the board on
  narrow viewports.

I used roving tabindex instead of 64 individual tab stops because the board is
one composite grid widget. Tab enters and leaves the grid, while the arrow keys
handle directional navigation within it.

## Tradeoffs

Cells shrink below their desktop size on narrow screens so all eight columns
remain visible without horizontal overflow. The board remains functional at the
approximately 360px target from the issue.

## Verification

- `yarn --cwd docs test` — 3 tests passed
- `yarn docs:build` — passed
- Keyboard-tested Tab entry/exit, four-direction wrapping, Home/End, Enter,
  Space, and Flag mode
- Tested at 360px with no horizontal overflow
- Tested with Windows Narrator
- Disabled Narrator Scan Mode while interacting with the ARIA grid
- Confirmed cell coordinates and states were announced
- Confirmed game start, dig, flag, win, and loss announcements